### PR TITLE
Local slave log

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -48,6 +48,7 @@ import java.io.File;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.FileWriter;
+import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -88,6 +89,9 @@ public class Launcher {
     // no-op, but left for backward compatibility
     @Option(name="-ping")
     public boolean ping = true;
+
+    @Option(name="-slaveLog", usage="create local slave error log")
+    public boolean slaveLog = false;
 
     @Option(name="-text",usage="encode communication with the master with base64. " +
             "Useful for running slave over 8-bit unsafe protocol like telnet")
@@ -175,6 +179,13 @@ public class Launcher {
     }
 
     public void run() throws Exception {
+         if(slaveLog){
+            OutputStream str= System.err;
+            File file = new File(System.getenv("WORKSPACE"), "slave-log.log");
+            PrintStream stream = new PrintStream(file);
+            OutputListener listenerOut = new OutputListener(stream);
+            System.setErr(new PrintStream(listenerOut.createListenableOutputStream(str))); //set listenable error stream
+        }
         if(auth!=null) {
             final int idx = auth.indexOf(':');
             if(idx<0)   throw new CmdLineException(null, "No ':' in the -auth option");

--- a/src/main/java/hudson/remoting/OutputListener.java
+++ b/src/main/java/hudson/remoting/OutputListener.java
@@ -1,0 +1,64 @@
+package hudson.remoting;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Represents a listener which listens write event, created by listenable output stream (@link OuputStreamImpl), and writes into its output streams (@link OutputStream). 
+ * 
+ * @author Lucie Votypkova
+ */
+public class OutputListener {
+
+    private List<OutputStream> outputStreams = new ArrayList<OutputStream>();
+
+    public OutputListener(List<OutputStream> streams) throws java.io.IOException {
+        this.outputStreams = streams;
+    }
+
+    public OutputListener(OutputStream stream) throws java.io.IOException {
+        this.outputStreams.add(stream);
+    }
+
+    public OutputStream createListenableOutputStream(OutputStream stream) {
+        outputStreams.add(0,stream);
+        return new OutputStreamImpl(this);
+    }
+
+    public void writeEvent(int b) {
+        for (OutputStream stream : outputStreams) {
+            try {
+                stream.write(b);
+            } catch (IOException ex) {
+                Logger.getLogger(OutputListener.class.getName()).log(Level.SEVERE, null, ex);
+            }
+
+        }
+    }
+
+    public void addOutputStream(OutputStream out) {
+        outputStreams.add(out);
+    }
+
+    /**
+     * Represents listenable output stream, which creates write event for its listener if the write method is called/
+     * 
+     */
+    private class OutputStreamImpl extends OutputStream {
+
+        private OutputListener listener;
+
+        public OutputStreamImpl(OutputListener listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        public void write(int b) {
+            listener.writeEvent(b);
+        }
+    }
+}


### PR DESCRIPTION
Adds the local slave log.
If the slave.jar is started with option -slaveLog, error log of this process is saved also locally in slave-log.log file (in workspace directory of slave).
