### PR TITLE
Do not attempt to retry a channel get after an ExecutionException.

### DIFF
--- a/src/main/java/hudson/remoting/PingThread.java
+++ b/src/main/java/hudson/remoting/PingThread.java
@@ -110,6 +110,7 @@ public abstract class PingThread extends Thread {
                 if (e.getCause() instanceof RequestAbortedException)
                     return; // connection has shut down orderly.
                 onDead(e);
+                return;
             } catch (TimeoutException e) {
                 onDead(new TimeoutException("Ping started on "+start+" hasn't completed at "+System.currentTimeMillis()).initCause(e));
             }


### PR DESCRIPTION
Without this the pinger busy waits retrying the same operation for the
timeout period. The timeout/retry mechanism was only intended to retry
pings that were interrupted.

This is part of the failure seen in JENKINS-12037 where the PingThread
busy waits for 4 minutes when the Ping class fails to execute on a restricted
channel.

I would appreciate it if someone with more remoting experience than me
could confirm that this is a safe behaviour. I have demonstrated this
experimentally with JENKINS-12037 but would like a 2nd opinion.
