### PR TITLE
Fix system property name for pipe window size

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1107,7 +1107,7 @@ public class Channel implements VirtualChannel, IChannel {
 
     private static final Logger logger = Logger.getLogger(Channel.class.getName());
 
-    public static final int PIPE_WINDOW_SIZE = Integer.getInteger(Channel.class+".pipeWindowSize",128*1024);
+    public static final int PIPE_WINDOW_SIZE = Integer.getInteger(Channel.class.getName()+".pipeWindowSize",128*1024);
 
 //    static {
 //        ConsoleHandler h = new ConsoleHandler();


### PR DESCRIPTION
Previously, the system property name was
"class hudson.remoting.Channel.pipeWindowSize", which is very confusing
and difficult to set from the command-line.

Use Class.getName() instead of Class.toString(), so the new property
name will be "hudson.remoting.Channel.pipeWindowSize".
