### PR TITLE
JENKINS-13395 constructor escape of "this" from Channel

### DIFF
--- a/src/main/java/hudson/remoting/ProxyOutputStream.java
+++ b/src/main/java/hudson/remoting/ProxyOutputStream.java
@@ -215,6 +215,9 @@ final class ProxyOutputStream extends OutputStream {
                     try {
                         os.write(buf);
                     } catch (IOException e) {
+                        if ("org.apache.catalina.connector.ClientAbortException".equals(e.getClass().getName())){
+                            e = new IOException("org.apache.catalina.connector.ClientAbortException:" + e.getMessage());
+                        }
                         try {
                             channel.send(new NotifyDeadWriter(e,oid));
                         } catch (ChannelClosedException x) {


### PR DESCRIPTION
Patch is simply a repeated set of "Replace Constuctor with factory method" operations.

There are a large number of constructors that seem to be used externally, so I suspect there are some additional code changes that may be necessary in other modules (due to uinterface changes in Channel)

I am only indirectly a jenkins user and this bug has been found by code review.
