### PR TITLE
Catalina ClientAbortException being serialized to remote node

### DIFF
--- a/src/main/java/hudson/remoting/ProxyOutputStream.java
+++ b/src/main/java/hudson/remoting/ProxyOutputStream.java
@@ -215,6 +215,9 @@ final class ProxyOutputStream extends OutputStream {
                     try {
                         os.write(buf);
                     } catch (IOException e) {
+                        if ("org.apache.catalina.connector.ClientAbortException".equals(e.getClass().getName())){
+                            e = new IOException("org.apache.catalina.connector.ClientAbortException:" + e.getMessage());
+                        }
                         try {
                             channel.send(new NotifyDeadWriter(e,oid));
                         } catch (ChannelClosedException x) {


### PR DESCRIPTION
We are investigating an issue on the ASF jenkins instance where ClientAbortException
is being serialized over to the node

This pull request is for @olamy to try; he can merge it if it fixes the problem

48 PM <olamy> java.lang.ClassNotFoundException: org.apache.catalina.connector.ClientAbortException
3:48 PM <olamy> at java.net.URLClassLoader$1.run(URLClassLoader.java:217)
3:48 PM <olamy> at java.security.AccessController.doPrivileged(Native Method)
3:48 PM <olamy> at java.net.URLClassLoader.findClass(URLClassLoader.java:205)
3:48 PM <olamy> at java.lang.ClassLoader.loadClass(ClassLoader.java:321)
3:48 PM <olamy> at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:294)
3:48 PM <olamy> at java.lang.ClassLoader.loadClass(ClassLoader.java:266)
3:48 PM <olamy> at java.lang.Class.forName0(Native Method)
3:48 PM <olamy> at java.lang.Class.forName(Class.java:264)
3:48 PM <olamy> at java.io.ObjectInputStream.resolveClass(ObjectInputStream.java:621)
3:48 PM <olamy> at hudson.remoting.ObjectInputStreamEx.resolveClass(ObjectInputStreamEx.java:50)
3:48 PM <olamy> at java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:1592)
3:48 PM <olamy> at java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1513)
3:48 PM <olamy> at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:1749)
3:48 PM <olamy> at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1346)
3:48 PM <olamy> at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:1963)
3:48 PM <olamy> at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:1887)
3:48 PM <olamy> at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:1770)
3:48 PM <olamy> at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1346)
3:48 PM <olamy> at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:1963)
3:48 PM <olamy> at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:1887)
3:48 PM <olamy> at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:1770)
3:48 PM <olamy> at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1346)
3:48 PM <olamy> at java.io.ObjectInputStream.readObject(ObjectInputStream.java:368)
3:48 PM <olamy> at hudson.remoting.Command.readFrom(Command.java:90)
3:48 PM <olamy> at hudson.remoting.ClassicCommandTransport.read(ClassicCommandTransport.java:59)
3:48 PM <olamy> at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:48)
3:48 PM <olamy> Oct 17, 2012 10:55:44 AM hudson.remoting.SynchronousCommandTransport$ReaderThread run
