### PR TITLE
[JENKINS-9679] NoClassDefFoundError on Base64 when launching an headless...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.4</version>
+      <version>1.7</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
... slave with -jnlpCredential option

slave.jar includes commons-codec.jar.
