### PR TITLE
[JENKINS-19453] Interrupted class loading can lead to NoClassDefFoundError

### DIFF
--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -214,29 +214,45 @@ final class RemoteClassLoader extends URLClassLoader {
                     RemoteClassLoader rcl = (RemoteClassLoader) cl;
                     synchronized (_getClassLoadingLock(rcl, name)) {
                         Class<?> c = rcl.findLoadedClass(name);
-                        try {
-                            if (TESTING) {
-                                Thread.sleep(1000);
-                            }
-                            if (c!=null)    return c;
 
-                            // TODO: check inner class handling
-                            Future<byte[]> img = cr.classImage.resolve(channel, name.replace('.', '/') + ".class");
-                            if (img.isDone()) {
+                        boolean interrupted = false;
+                        try {//
+                            while (true) {
                                 try {
-                                    return rcl.loadClassFile(name, img.get());
-                                } catch (ExecutionException x) {
-                                    // failure to retrieve a jar shouldn't fail the classloading
-                                }
-                            }
+                                    if (TESTING) {
+                                        Thread.sleep(1000);
+                                    }
+                                    if (c!=null)    return c;
 
-                            // if the load activitiy is still pending, or if the load had failed,
-                            // fetch just this class file
-                            return rcl.loadClassFile(name, proxy.fetch(name));
-                        } catch (IOException x) {
-                            throw new ClassNotFoundException(name,x);
-                        } catch (InterruptedException x) {
-                            throw new ClassNotFoundException(name,x);
+                                    // TODO: check inner class handling
+                                    Future<byte[]> img = cr.classImage.resolve(channel, name.replace('.', '/') + ".class");
+                                    if (img.isDone()) {
+                                        try {
+                                            return rcl.loadClassFile(name, img.get());
+                                        } catch (ExecutionException x) {
+                                            // failure to retrieve a jar shouldn't fail the classloading
+                                        }
+                                    }
+
+                                    // if the load activity is still pending, or if the load had failed,
+                                    // fetch just this class file
+                                    return rcl.loadClassFile(name, proxy.fetch(name));
+                                } catch (IOException x) {
+                                    throw new ClassNotFoundException(name,x);
+                                } catch (InterruptedException x) {
+                                    // pretend as if this operation is not interruptible.
+                                    // but we need to remember to set the interrupt flag back on
+                                    // before we leave this call.
+                                    interrupted = true;
+                                    continue;   // JENKINS-19453: retry
+                                }
+
+                                // no code is allowed to reach here
+                            }
+                        } finally {
+                            // process the interrupt later.
+                            if (interrupted)
+                                Thread.currentThread().interrupt();
                         }
                     }
                 } else {
@@ -275,7 +291,11 @@ final class RemoteClassLoader extends URLClassLoader {
         }
         return rcl;
     }
-    /** JENKINS-6604 */
+    /**
+     * Induce a large delay in {@link RemoteClassLoader#findClass(String)} to allow
+     *
+     * See JENKINS-6604
+     */
     static boolean TESTING;
 
     private Class<?> loadClassFile(String name, byte[] bytes) {

--- a/src/test/java/hudson/remoting/ClassRemotingTest.java
+++ b/src/test/java/hudson/remoting/ClassRemotingTest.java
@@ -134,7 +134,11 @@ public class ClassRemotingTest extends RmiTestBase {
                     }
                 }
             });
+
+            // This is so that the first two class loads succeed but the third fails.
+            // A better test would use semaphores rather than timing (cf. the test before this one).
             Thread.sleep(2500);
+
             f1.cancel(true);
             try {
                 Object o = f1.get();
@@ -145,6 +149,8 @@ public class ClassRemotingTest extends RmiTestBase {
             } catch (CancellationException x) {
                 // good
             }
+
+            // verify that classes that we tried to load aren't irrevocably damaged and it's still available
             assertNotNull(channel.call(c));
         } finally {
             RemoteClassLoader.TESTING = false;

--- a/src/test/java/hudson/remoting/DummyClassLoader.java
+++ b/src/test/java/hudson/remoting/DummyClassLoader.java
@@ -37,6 +37,10 @@ import org.apache.commons.io.IOUtils;
  * out of nowhere, to test {@link RemoteClassLoader} by creating a class
  * that only exists on one side of the channel but not the other.
  *
+ * <p>
+ * Given a class in a "remoting" package, this classloader is capable of loading the same version of the class
+ * in the "rem0ting" package.
+ *
  * @author Kohsuke Kawaguchi
  */
 class DummyClassLoader extends ClassLoader {

--- a/src/test/java/hudson/remoting/TestLinkage.java
+++ b/src/test/java/hudson/remoting/TestLinkage.java
@@ -27,6 +27,9 @@ package hudson.remoting;
 public class TestLinkage implements Callable {
 
     public Object call() throws Throwable {
+        // force classloading of several classes
+        // when we run this test, we insert an artificial delay to each  classloading
+        // so that we can intercept the classloading.
         return A.field;
     }
 


### PR DESCRIPTION
[JENKINS-19453](https://issues.jenkins-ci.org/browse/JENKINS-19453): interrupting class loading irrecoverably breaks the class being loaded. Filing for evaluation; so far just have a failing test.
