### PR TITLE
Ignore InterruptedException and continue to check the channel

### DIFF
--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -140,10 +140,14 @@ abstract class Request<RSP extends Serializable,EXC extends Throwable> extends C
                     // wait until the response arrives
                     t.setName(name+" / waiting for "+channel);
                     while(response==null && !channel.isInClosed())
-                        // I don't know exactly when this can happen, as pendingCalls are cleaned up by Channel,
-                        // but in production I've observed that in rare occasion it can block forever, even after a channel
-                        // is gone. So be defensive against that.
-                        wait(30*1000);
+                        try {
+                            // I don't know exactly when this can happen, as pendingCalls are cleaned up by Channel,
+                            // but in production I've observed that in rare occasion it can block forever, even after a channel
+                            // is gone. So be defensive against that.
+                            wait(30*1000);
+                        } catch (InterruptedException ie){
+                            // ignore the interrupt exception
+                        }
 
                     if (response==null)
                         // channel is closed and we still don't have a response


### PR DESCRIPTION
On the OpenStack Jenkins install we are seeing many occasions
where the InterruptedException from the wait is causing jobs
to fail.

bug report in OpenStack-CI:
https://bugs.launchpad.net/openstack-ci/+bug/1260311

logstash query:
http://bit.ly/1eXPv67

This patch has defensive code to prevent completely giving up
when we run into this InterruptedException
