### PR TITLE
[NO_MERGE] [JENKINS-22193] - Added an option to disable the Jar caching

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -54,6 +54,7 @@ import java.net.URL;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import javax.annotation.CheckForNull;
 
 /**
  * Represents a communication channel to the remote peer.
@@ -672,8 +673,10 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 
     /**
      * If this channel is built with jar file caching, return the object that manages this cache.
+     * @return JarCache or null if it is disabled
      * @since 2.24
      */
+    @CheckForNull
     public JarCache getJarCache() {
         return jarCache;
     }
@@ -684,6 +687,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *
      * So to best avoid performance loss due to race condition, please set a JarCache in the constructor,
      * unless your call sequence guarantees that you call this method before remote classes are loaded.
+     * @param jarCache The Jar cache to be set. The null value disables the caching
      * @since 2.24
      */
     public void setJarCache(JarCache jarCache) {

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -680,6 +680,17 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     public JarCache getJarCache() {
         return jarCache;
     }
+    
+    /**
+     * Checks that Jar cache is available.
+     * The remoting library should work well even with disabled caches.
+     * @return True if the cache is available
+     * @since TODO
+     */
+    @CheckForNull
+    public  boolean hasJarCache() {
+        return jarCache != null;
+    }
 
     /**
      * You can change the {@link JarCache} while the channel is in operation,

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -148,7 +148,13 @@ public class Launcher {
      */
     @Option(name="-jar-cache",metaVar="DIR",usage="Cache directory that stores jar files sent from the master")
     public File jarCache = new File(System.getProperty("user.home"),".jenkins/cache/jars");
-
+    
+    /**
+     * @since TODO: define a version
+     */
+    @Option(name="-jar-cache-disabled",usage="Disables the jar caching")
+    public boolean jarCacheDisabled = false;
+    
     public InetSocketAddress connectionTarget = null;
 
     @Option(name="-connectTo",usage="make a TCP connection to the given host and port, then start communication.",metaVar="HOST:PORT")
@@ -216,9 +222,11 @@ public class Launcher {
         } else
         if(slaveJnlpURL!=null) {
             List<String> jnlpArgs = parseJnlpArguments();
-            if (jarCache != null) {
+            if (jarCache != null && !jarCacheDisabled) {
               jnlpArgs.add("-jar-cache");
               jnlpArgs.add(jarCache.getPath());
+            } else {
+              jnlpArgs.add("-jar-cache-disabled");
             }
             if (this.noReconnect) {
                 jnlpArgs.add("-noreconnect");
@@ -400,7 +408,7 @@ public class Launcher {
         s.setTcpNoDelay(true);
         main(new BufferedInputStream(new SocketInputStream(s)),
              new BufferedOutputStream(new SocketOutputStream(s)), mode,ping,
-             new FileSystemJarCache(jarCache,true));
+             jarCacheDisabled ? null : new FileSystemJarCache(jarCache,true));
     }
 
     /**

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -114,7 +114,7 @@ final class RemoteClassLoader extends URLClassLoader {
         super(new URL[0],parent);
         this.channel = RemoteInvocationHandler.unwrap(proxy);
         this.underlyingProxy = proxy;
-        if (!channel.remoteCapability.supportsPrefetch() || channel.getJarCache()==null)
+        if (!channel.remoteCapability.supportsPrefetch() && channel.getJarCache()!=null)
             proxy = new DumbClassLoaderBridge(proxy);
         this.proxy = proxy;
     }

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -114,7 +114,7 @@ final class RemoteClassLoader extends URLClassLoader {
         super(new URL[0],parent);
         this.channel = RemoteInvocationHandler.unwrap(proxy);
         this.underlyingProxy = proxy;
-        if (!channel.remoteCapability.supportsPrefetch() && channel.getJarCache()!=null)
+        if (!channel.remoteCapability.supportsPrefetch())
             proxy = new DumbClassLoaderBridge(proxy);
         this.proxy = proxy;
     }

--- a/src/main/java/hudson/remoting/ResourceImageInJar.java
+++ b/src/main/java/hudson/remoting/ResourceImageInJar.java
@@ -11,7 +11,8 @@ import java.util.concurrent.ExecutionException;
  * <p>
  * The jar file is identified by its checksum, and the receiver can use {@link JarLoader}
  * to retrieve the jar file if necessary.
- *
+ * </p>
+ * This method requires {@link JarCache} to be present.
  * @author Kohsuke Kawaguchi
  */
 class ResourceImageInJar extends ResourceImageRef {
@@ -73,8 +74,11 @@ class ResourceImageInJar extends ResourceImageRef {
 
     Future<URL> _resolveJarURL(Channel channel) throws IOException, InterruptedException {
         JarCache c = channel.getJarCache();
-        assert c !=null : "we don't advertise jar caching to the other side unless we have a cache with us";
-
+        //assert c !=null : "we don't advertise jar caching to the other side unless we have a cache with us";
+        if (c == null) {
+            throw (IOException)new IOException(String.format("Failed to resolve a jar %016x%016x. JAR caching is disabled",sum1,sum2));
+        }
+        
         return c.resolve(channel, sum1, sum2);
 //            throw (IOException)new IOException(String.format("Failed to resolve a jar %016x%016x",sum1,sum2)).initCause(e);
     }

--- a/src/main/java/hudson/remoting/StubJarCache.java
+++ b/src/main/java/hudson/remoting/StubJarCache.java
@@ -1,0 +1,59 @@
+package hudson.remoting;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A JAR cache stub, which actually does not implement any caching.
+ * This cache is intended to be used with the -jar-cache-disabled option.
+ * @author Oleg Nenashev, Synopsys Inc.
+ * @since TODO
+ */
+public class StubJarCache extends JarCacheSupport {
+   
+    public StubJarCache() {
+    }
+
+    @Override
+    protected final URL lookInCache(Channel channel, long sum1, long sum2) throws IOException, InterruptedException {
+        return null;
+    }
+
+    @Override
+    protected URL retrieve(Channel channel, long sum1, long sum2) throws IOException, InterruptedException {
+        final String target = map(sum1, sum2);
+        try {
+            File tmp = File.createTempFile(target,"tmp");
+            try {
+                RemoteOutputStream o = new RemoteOutputStream(new FileOutputStream(tmp));
+                try {
+                    LOGGER.log(Level.FINE, String.format("Retrieving jar file %16X%16X",sum1,sum2));
+                    getJarLoader(channel).writeJarTo(sum1, sum2, o);
+                } finally {
+                    o.close();
+                }
+
+                return tmp.toURI().toURL();             
+            } finally {
+                tmp.delete();
+            }
+        } catch (IOException e) {
+            throw (IOException)new IOException("Failed to write to "+target).initCause(e);
+        }
+    }
+
+    /**
+     * Map to the cache jar file name.
+     */
+    String map(long sum1, long sum2) {
+        return String.format("jar_%02X/%014X%016X.jar",
+                (int)(sum1>>>(64-8)),
+                sum1&0x00FFFFFFFFFFFFFFL, sum2);
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(FileSystemJarCache.class.getName());
+}

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -83,7 +83,12 @@ public class Main {
     @Option(name="-jar-cache",metaVar="DIR",usage="Cache directory that stores jar files sent from the master")
     public File jarCache = null;
 
-
+    /**
+     * @since TODO: define a version
+     */
+    @Option(name="-jar-cache-disabled",usage="Disables the jar caching")
+    public boolean jarCacheDisabled = false;
+    
     /**
      * 4 mandatory parameters.
      * Host name (deprecated), Jenkins URL, secret key, and slave name.
@@ -154,8 +159,11 @@ public class Main {
             engine.setCredentials(credentials);
         if(proxyCredentials!=null)
         	engine.setProxyCredentials(proxyCredentials);
-        if(jarCache!=null)
+        if(jarCache!=null && !jarCacheDisabled) {
             engine.setJarCache(new FileSystemJarCache(jarCache,true));
+        } else {
+            engine.setJarCache(null);
+        }
         engine.setNoReconnect(noReconnect);
         return engine;
     }

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 
 import hudson.remoting.Engine;
 import hudson.remoting.EngineListener;
+import hudson.remoting.StubJarCache;
 
 /**
  * Entry point to JNLP slave agent.
@@ -162,7 +163,7 @@ public class Main {
         if(jarCache!=null && !jarCacheDisabled) {
             engine.setJarCache(new FileSystemJarCache(jarCache,true));
         } else {
-            engine.setJarCache(null);
+            engine.setJarCache(new StubJarCache());
         }
         engine.setNoReconnect(noReconnect);
         return engine;

--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -210,7 +210,11 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
         public Void call() throws IOException {
             try {
                 Channel ch = Channel.current();
-                ch.getJarCache().resolve(ch,sum1,sum2).get();
+                
+                //TODO: Add support of caches for unit tests
+                JarCache jarCache =  ch.getJarCache();
+                assert jarCache !=null : "we don't advertise jar caching to the other side unless we have a cache with us";              
+                jarCache.resolve(ch,sum1,sum2).get();            
                 return null;
             } catch (InterruptedException e) {
                 throw new IOException(e);


### PR DESCRIPTION
The change adds a "-jar-cache-disabled", which disables the jar caching
It may be helpful to workaround issues like https://issues.jenkins-ci.org/browse/JENKINS-20913