### PR TITLE
Fixed the ambiguous constructor issue in RemoteClassLoader.PSEUDO_BOOTSTRAP

### DIFF
--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -923,7 +923,7 @@ final class RemoteClassLoader extends URLClassLoader {
          * any new classpath. In this way, we can effectively use this classloader as a representation
          * of the bootstrap classloader.
          */
-        private static final ClassLoader PSEUDO_BOOTSTRAP = new URLClassLoader(new URL[0],null) {
+        private static final ClassLoader PSEUDO_BOOTSTRAP = new URLClassLoader(new URL[0],(ClassLoader)null) {
             @Override
             public String toString() {
                 return "PSEUDO_BOOTSTRAP";


### PR DESCRIPTION
The fix forces the usage of <ClassLoader> class in the second null argument.

Possible options:
- URLClassLoader(URL[] urls, ClassLoader parent)
- URLClassLoader(URL[] urls, AccessControlContext acc)

The fix significantly improves the code coverage in static analysis tools like Coverity (compilation units: 27% -> 100%). Coverity Scan project: https://scan.coverity.com/projects/2060?tab=Overview (not ready)

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
