### PR TITLE
[JENKINS-24050] Fix issue where cancelled keys cause Jenkins NIO hub to die.

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
+import java.nio.channels.CancelledKeyException;
 import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SelectableChannel;
@@ -576,6 +577,8 @@ public class NioChannelHub implements Runnable, Closeable {
                                 }
                             }
                             t.reregister();
+                        } catch (CancelledKeyException e) {
+			    LOGGER.log(WARNING, "Key cancelled", e);
                         } catch (IOException e) {
                             LOGGER.log(WARNING, "Communication problem", e);
                             t.abort(e);


### PR DESCRIPTION
So I don't really have a good unittest, but I'm pretty sure the issue is fixed by checking if the key is valid even before reading, and also handling the CancelledKeyException (for good measure).  The existing tests pass: https://travis-ci.org/kbrowder/remoting/builds/31436797.
