### PR TITLE
[JENKINS-6167] Support JNLP slave connection via HTTP proxy

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -253,7 +253,7 @@ public class Launcher {
         }
         while (true) {
             try {
-                URLConnection con = slaveJnlpURL.openConnection();
+                URLConnection con = Util.openURLConnection(slaveJnlpURL);
                 if (con instanceof HttpURLConnection) {
                     HttpURLConnection http = (HttpURLConnection) con;
                     if  (slaveJnlpCredentials != null) {


### PR DESCRIPTION
We get proxy setting from http_proxy environment variable.
https://issues.jenkins-ci.org/browse/JENKINS-6167