### PR TITLE
[JENKINS-21251] Slave channel timeout seemingly caused by usage of System.currentTimeMillis()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 /.classpath
 /.project
 /.settings
+.fbExcludeFilterFile

--- a/pom.xml
+++ b/pom.xml
@@ -161,14 +161,6 @@ THE SOFTWARE.
     </resources>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <!-- version specified in grandparent pom -->
-        <configuration>
-          <threshold>High</threshold>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
         <!-- version specified in grandparent pom -->

--- a/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
+++ b/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
@@ -74,7 +74,7 @@ public class AtmostOneThreadExecutor extends AbstractExecutorService {
             long now = System.nanoTime();
             long end = now + unit.toNanos(timeout);
             while (isAlive() && (end - now > 0L)) {
-                q.wait((end - now) / 1000L);
+                q.wait(TimeUnit.NANOSECONDS.toMillis(end - now));
                 now = System.nanoTime();
             }
         }

--- a/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
+++ b/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
@@ -71,10 +71,12 @@ public class AtmostOneThreadExecutor extends AbstractExecutorService {
 
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         synchronized (q) {
-            long start = System.currentTimeMillis();
-            long end = start+unit.toMillis(timeout);
-            while (isAlive() && System.currentTimeMillis()<end) {
-                q.wait(end-System.currentTimeMillis());
+            long now = System.currentTimeMillis();
+            long end = now + unit.toMillis(timeout);
+            while (isAlive() && now < end) {
+                q.wait(end - now);
+                // XXX this is not safe against Clock skew - but System.nanoTime() has performance implications.
+                now = System.currentTimeMillis();
             }
         }
         return isTerminated();

--- a/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
+++ b/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
@@ -71,12 +71,11 @@ public class AtmostOneThreadExecutor extends AbstractExecutorService {
 
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         synchronized (q) {
-            long now = System.currentTimeMillis();
-            long end = now + unit.toMillis(timeout);
-            while (isAlive() && now < end) {
-                q.wait(end - now);
-                // XXX this is not safe against Clock skew - but System.nanoTime() has performance implications.
-                now = System.currentTimeMillis();
+            long now = System.nanoTime();
+            long end = now + unit.toNanos(timeout);
+            while (isAlive() && (end - now > 0)) {
+                q.wait((end - now) / 1000L);
+                now = System.nanoTime();
             }
         }
         return isTerminated();

--- a/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
+++ b/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
@@ -73,7 +73,7 @@ public class AtmostOneThreadExecutor extends AbstractExecutorService {
         synchronized (q) {
             long now = System.nanoTime();
             long end = now + unit.toNanos(timeout);
-            while (isAlive() && (end - now > 0)) {
+            while (isAlive() && (end - now > 0L)) {
                 q.wait((end - now) / 1000L);
                 now = System.nanoTime();
             }

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -55,6 +55,7 @@ import java.util.Vector;
 import java.util.WeakHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -1015,9 +1016,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      */
     public synchronized void join(long timeout) throws InterruptedException {
         long now = System.nanoTime();
-        long end = now + (timeout * 1000L);
+        long end = now + TimeUnit.MILLISECONDS.toNanos(timeout);
         while ((end - now > 0L) && (inClosed == null || outClosed == null)) {
-            wait((end - now) / 1000L);
+            wait(TimeUnit.NANOSECONDS.toMillis(end - now));
             now = System.nanoTime();
         }
     }

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1016,7 +1016,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     public synchronized void join(long timeout) throws InterruptedException {
         long now = System.nanoTime();
         long end = now + (timeout * 1000L);
-        while ((end - now > 0) && (inClosed == null || outClosed == null)) {
+        while ((end - now > 0L) && (inClosed == null || outClosed == null)) {
             wait((end - now) / 1000L);
             now = System.nanoTime();
         }

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1015,7 +1015,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         long now = System.currentTimeMillis();
         long end = now + timeout;
         while (now < end && (inClosed == null || outClosed == null)) {
-            wait(now - end);
+            wait(end - now);
             // XXX this is not safe against Clock skew - but System.nanoTime()
             // has performance implications.
             now = System.currentTimeMillis();

--- a/src/main/java/hudson/remoting/ClassicCommandTransport.java
+++ b/src/main/java/hudson/remoting/ClassicCommandTransport.java
@@ -89,7 +89,6 @@ import java.io.StreamCorruptedException;
             else
                 return (StreamCorruptedException)new StreamCorruptedException().initCause(e);
         }
-
         return rawIn.analyzeCrash(e,(channel!=null ? channel : this).toString());
     }
 

--- a/src/main/java/hudson/remoting/PingThread.java
+++ b/src/main/java/hudson/remoting/PingThread.java
@@ -80,14 +80,14 @@ public abstract class PingThread extends Thread {
     public void run() {
         try {
             while(true) {
-                long nextCheck = System.nanoTime() + (interval * 1000L);
+                long nextCheck = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(interval);
 
                 ping();
 
                 // wait until the next check
                 long diff;
                 while((diff = nextCheck - System.nanoTime()) > 0) {
-                    Thread.sleep(diff / 1000L);
+                    Thread.sleep(TimeUnit.NANOSECONDS.toMillis(diff));
                 }
             }
         } catch (ChannelClosedException e) {
@@ -104,12 +104,12 @@ public abstract class PingThread extends Thread {
         Future<?> f = channel.callAsync(new Ping());
         long start = System.currentTimeMillis();
 
-        long end = System.nanoTime() + (timeout * 1000L);
+        long end = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeout);
         long remaining = end - System.nanoTime();
 
         do {
             try {
-                f.get(Math.max(10000,remaining),TimeUnit.NANOSECONDS);
+                f.get(Math.max(TimeUnit.MILLISECONDS.toNanos(10),remaining),TimeUnit.NANOSECONDS);
                 return;
             } catch (ExecutionException e) {
                 if (e.getCause() instanceof RequestAbortedException)

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -259,13 +259,15 @@ abstract class Request<RSP extends Serializable,EXC extends Throwable> extends C
                 synchronized(Request.this) {
                     // wait until the response arrives
                     // Note that the wait method can wake up for no reasons at all (AKA spurious wakeup),
-                    long end = System.currentTimeMillis() + unit.toMillis(timeout);
-                    long now;
-                    while(response==null && (now=System.currentTimeMillis())<end) {
+                    long now = System.currentTimeMillis();
+                    long end = now + unit.toMillis(timeout);
+                    while (response==null && (now < end)) {
                         if (isCancelled()) {
                             throw new CancellationException();
                         }
                         Request.this.wait(Math.max(1,end-now));
+                        // XXX this is not safe against Clock skew - but System.nanoTime() has performance implications.
+                        now = System.currentTimeMillis();
                     }
                     if(response==null)
                         throw new TimeoutException();

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -265,7 +265,7 @@ abstract class Request<RSP extends Serializable,EXC extends Throwable> extends C
                         if (isCancelled()) {
                             throw new CancellationException();
                         }
-                        Request.this.wait(Math.max(1, (end - now) / 1000L));
+                        Request.this.wait(Math.max(1, TimeUnit.NANOSECONDS.toMillis(end - now)));
                         now = System.nanoTime();
                     }
                     if (response == null)

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -261,7 +261,7 @@ abstract class Request<RSP extends Serializable,EXC extends Throwable> extends C
                     // Note that the wait method can wake up for no reasons at all (AKA spurious wakeup),
                     long now = System.nanoTime();
                     long end = now + unit.toNanos(timeout);
-                    while (response == null && (end - now > 0)) {
+                    while (response == null && (end - now > 0L)) {
                         if (isCancelled()) {
                             throw new CancellationException();
                         }

--- a/src/main/java/hudson/remoting/SingleLaneExecutorService.java
+++ b/src/main/java/hudson/remoting/SingleLaneExecutorService.java
@@ -86,10 +86,12 @@ public class SingleLaneExecutorService extends AbstractExecutorService {
     }
 
     public synchronized boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        long start = System.currentTimeMillis();
-        long end = start+unit.toMillis(timeout);
-        while (!isTerminated() && System.currentTimeMillis()<end) {
-            wait(end - System.currentTimeMillis());
+        long now = System.currentTimeMillis();
+        long end = now+unit.toMillis(timeout);
+        while (!isTerminated() && now < end) {
+            wait(end - now);
+            // XXX this is not safe against Clock skew - but System.nanoTime() has performance implications.
+            now = System.currentTimeMillis();
         }
         return isTerminated();
     }

--- a/src/main/java/hudson/remoting/SingleLaneExecutorService.java
+++ b/src/main/java/hudson/remoting/SingleLaneExecutorService.java
@@ -88,7 +88,7 @@ public class SingleLaneExecutorService extends AbstractExecutorService {
     public synchronized boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         long now = System.nanoTime();
         long end = now + unit.toNanos(timeout);
-        while (!isTerminated() && end - now < 0L) {
+        while (!isTerminated() && (end - now) > 0L) {
             wait((end - now) /  1000L);
             now = System.nanoTime();
         }

--- a/src/main/java/hudson/remoting/SingleLaneExecutorService.java
+++ b/src/main/java/hudson/remoting/SingleLaneExecutorService.java
@@ -86,12 +86,11 @@ public class SingleLaneExecutorService extends AbstractExecutorService {
     }
 
     public synchronized boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        long now = System.currentTimeMillis();
-        long end = now+unit.toMillis(timeout);
-        while (!isTerminated() && now < end) {
-            wait(end - now);
-            // XXX this is not safe against Clock skew - but System.nanoTime() has performance implications.
-            now = System.currentTimeMillis();
+        long now = System.nanoTime();
+        long end = now + unit.toNanos(timeout);
+        while (!isTerminated() && end - now < 0L) {
+            wait((end - now) /  1000L);
+            now = System.nanoTime();
         }
         return isTerminated();
     }

--- a/src/main/java/hudson/remoting/SingleLaneExecutorService.java
+++ b/src/main/java/hudson/remoting/SingleLaneExecutorService.java
@@ -89,7 +89,7 @@ public class SingleLaneExecutorService extends AbstractExecutorService {
         long now = System.nanoTime();
         long end = now + unit.toNanos(timeout);
         while (!isTerminated() && (end - now) > 0L) {
-            wait((end - now) /  1000L);
+            wait(TimeUnit.NANOSECONDS.toMillis(end - now));
             now = System.nanoTime();
         }
         return isTerminated();

--- a/src/main/java/hudson/remoting/SynchronousExecutorService.java
+++ b/src/main/java/hudson/remoting/SynchronousExecutorService.java
@@ -33,17 +33,16 @@ class SynchronousExecutorService extends AbstractExecutorService {
     }
 
     public synchronized boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        long now = System.currentTimeMillis();
-        long end = now + unit.toMillis(timeout);
+        long now = System.nanoTime();
+        long end = now + unit.toNanos(timeout);
 
         while (count!=0) {
             long d = end - now;
             if (d<0) {
                 return false;
             }
-            wait(d);
-            // XXX this is not safe against Clock skew - but System.nanoTime() has performance implications.
-            now = System.currentTimeMillis();
+            wait(d / 1000L);
+            now = System.nanoTime();
         }
         return true;
     }

--- a/src/main/java/hudson/remoting/SynchronousExecutorService.java
+++ b/src/main/java/hudson/remoting/SynchronousExecutorService.java
@@ -33,12 +33,17 @@ class SynchronousExecutorService extends AbstractExecutorService {
     }
 
     public synchronized boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        long end = System.currentTimeMillis() + unit.toMillis(timeout);
+        long now = System.currentTimeMillis();
+        long end = now + unit.toMillis(timeout);
 
         while (count!=0) {
-            long d = end - System.currentTimeMillis();
-            if (d<0)    return false;
+            long d = end - now;
+            if (d<0) {
+                return false;
+            }
             wait(d);
+            // XXX this is not safe against Clock skew - but System.nanoTime() has performance implications.
+            now = System.currentTimeMillis();
         }
         return true;
     }

--- a/src/main/java/hudson/remoting/SynchronousExecutorService.java
+++ b/src/main/java/hudson/remoting/SynchronousExecutorService.java
@@ -41,7 +41,7 @@ class SynchronousExecutorService extends AbstractExecutorService {
             if (d<0) {
                 return false;
             }
-            wait(d / 1000L);
+            wait(TimeUnit.NANOSECONDS.toMillis(d));
             now = System.nanoTime();
         }
         return true;


### PR DESCRIPTION
[JENKINS-21251](https://issues.jenkins-ci.org/browse/JENKINS-21251)

Initial calculation of duration to wait is susceptible to the clock changing (e.g. NTP).

Changed the code so that the initial calculation is performed with a single call to System.currentTimeMillis().
At this point I do not believe the overhead of using System.nanoTime() is worth the overhead.

