### PR TITLE
Fix bad pom and ignore eclipse file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 /.classpath
 /.project
 /.settings
+.fbExcludeFilterFile

--- a/pom.xml
+++ b/pom.xml
@@ -161,14 +161,6 @@ THE SOFTWARE.
     </resources>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <!-- version specified in grandparent pom -->
-        <configuration>
-          <threshold>High</threshold>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
         <!-- version specified in grandparent pom -->


### PR DESCRIPTION
Findbugs was declared twice with different configurations so removed the one that checked for the least amount of issues.

Add eclipse findbugs config file to .gitignore

@reviewbybees