### PR TITLE
Fix unit test issue on windows.

### DIFF
--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -2,9 +2,15 @@
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+
 import junit.framework.AssertionFailedError;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.ant.AntClassLoader;
+import org.hamcrest.core.StringContains;
+import org.hamcrest.core.StringEndsWith;
+import org.hamcrest.core.StringStartsWith;
+import org.junit.Assert;
 
 import java.io.File;
 import java.io.IOException;
@@ -131,9 +137,10 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
      * Validates that the resource is coming from a jar.
      */
     private void verifyResource(String v) throws IOException, InterruptedException {
-        assertTrue(v, v.startsWith("jar:file:"));
-        assertTrue(v, v.contains(dir.getPath()));
-        assertTrue(v, v.endsWith("::hello"));
+        Assert.assertThat(v, StringStartsWith.startsWith("jar:file:"));
+        // need to convert to a URI otherwise this fails on windows or if you have special chars in the path
+        Assert.assertThat(v, StringContains.containsString(dir.toURI().getPath()));
+        Assert.assertThat(v, StringEndsWith.endsWith("::hello"));
     }
 
     /**
@@ -160,7 +167,8 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
         verifyResource(lines[0]);
 
         assertTrue(lines[1].startsWith("jar:file:"));
-        assertTrue(lines[1].contains(dir.getPath()));
+        // need to convert to a URI otherwise this fails on windows or if you have special chars in the path
+        Assert.assertThat(lines[1], StringContains.containsString(dir.toURI().getPath()));
         assertTrue(lines[1].endsWith("::hello2"));
     }
 

--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -3,13 +3,8 @@
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 
-import junit.framework.AssertionFailedError;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.ant.AntClassLoader;
-import org.hamcrest.core.StringContains;
-import org.hamcrest.core.StringEndsWith;
-import org.hamcrest.core.StringStartsWith;
 import org.junit.Assert;
 
 import java.io.File;
@@ -17,8 +12,12 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.core.AllOf.allOf;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.hamcrest.core.StringEndsWith.endsWith;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -137,10 +136,9 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
      * Validates that the resource is coming from a jar.
      */
     private void verifyResource(String v) throws IOException, InterruptedException {
-        Assert.assertThat(v, StringStartsWith.startsWith("jar:file:"));
-        // need to convert to a URI otherwise this fails on windows or if you have special chars in the path
-        Assert.assertThat(v, StringContains.containsString(dir.toURI().getPath()));
-        Assert.assertThat(v, StringEndsWith.endsWith("::hello"));
+        Assert.assertThat(v, allOf(startsWith("jar:file:"), 
+                                   containsString(dir.toURI().getPath()), 
+                                   endsWith("::hello")));
     }
 
     /**
@@ -166,10 +164,9 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
 
         verifyResource(lines[0]);
 
-        assertTrue(lines[1].startsWith("jar:file:"));
-        // need to convert to a URI otherwise this fails on windows or if you have special chars in the path
-        Assert.assertThat(lines[1], StringContains.containsString(dir.toURI().getPath()));
-        assertTrue(lines[1].endsWith("::hello2"));
+        Assert.assertThat(lines[1], allOf(startsWith("jar:file:"), 
+                                          containsString(dir.toURI().getPath()), 
+                                          endsWith("::hello2")));
     }
 
     /**


### PR DESCRIPTION
do not compare a URI path with a File Path - it is doomed to fail on Windows.

The unit tests in question still have some issues on windows as they fail to clean up resources that are locked - however at least you see the asserts passing.

@reviewbybees