### PR TITLE
[JENKINS-21251] Slave channel timeout seemingly caused by usage of System.currentTimeMillis()

### DIFF
--- a/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
+++ b/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
@@ -71,10 +71,11 @@ public class AtmostOneThreadExecutor extends AbstractExecutorService {
 
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         synchronized (q) {
-            long start = System.currentTimeMillis();
-            long end = start+unit.toMillis(timeout);
-            while (isAlive() && System.currentTimeMillis()<end) {
-                q.wait(end-System.currentTimeMillis());
+            long now = System.nanoTime();
+            long end = now + unit.toNanos(timeout);
+            while (isAlive() && (end - now > 0L)) {
+                q.wait(TimeUnit.NANOSECONDS.toMillis(end - now));
+                now = System.nanoTime();
             }
         }
         return isTerminated();

--- a/src/main/java/hudson/remoting/PingThread.java
+++ b/src/main/java/hudson/remoting/PingThread.java
@@ -109,7 +109,7 @@ public abstract class PingThread extends Thread {
 
         do {
             try {
-                f.get(Math.max(TimeUnit.MILLISECONDS.toNanos(10),remaining),TimeUnit.NANOSECONDS);
+                f.get(Math.max(1,remaining),TimeUnit.NANOSECONDS);
                 return;
             } catch (ExecutionException e) {
                 if (e.getCause() instanceof RequestAbortedException)

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -256,21 +256,22 @@ abstract class Request<RSP extends Serializable,EXC extends Throwable> extends C
             }
 
             public RSP get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-                synchronized(Request.this) {
+                synchronized (Request.this) {
                     // wait until the response arrives
                     // Note that the wait method can wake up for no reasons at all (AKA spurious wakeup),
-                    long end = System.currentTimeMillis() + unit.toMillis(timeout);
-                    long now;
-                    while(response==null && (now=System.currentTimeMillis())<end) {
+                    long now = System.nanoTime();
+                    long end = now + unit.toNanos(timeout);
+                    while (response == null && (end - now > 0L)) {
                         if (isCancelled()) {
                             throw new CancellationException();
                         }
-                        Request.this.wait(Math.max(1,end-now));
+                        Request.this.wait(Math.max(1, TimeUnit.NANOSECONDS.toMillis(end - now)));
+                        now = System.nanoTime();
                     }
-                    if(response==null)
+                    if (response == null)
                         throw new TimeoutException();
 
-                    if(response.exception!=null)
+                    if (response.exception != null)
                         throw new ExecutionException(response.exception);
 
                     return response.returnValue;

--- a/src/main/java/hudson/remoting/SingleLaneExecutorService.java
+++ b/src/main/java/hudson/remoting/SingleLaneExecutorService.java
@@ -86,10 +86,11 @@ public class SingleLaneExecutorService extends AbstractExecutorService {
     }
 
     public synchronized boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        long start = System.currentTimeMillis();
-        long end = start+unit.toMillis(timeout);
-        while (!isTerminated() && System.currentTimeMillis()<end) {
-            wait(end - System.currentTimeMillis());
+        long now = System.nanoTime();
+        long end = now + unit.toNanos(timeout);
+        while (!isTerminated() && (end - now) > 0L) {
+            wait(TimeUnit.NANOSECONDS.toMillis(end - now));
+            now = System.nanoTime();
         }
         return isTerminated();
     }

--- a/src/main/java/hudson/remoting/SynchronousExecutorService.java
+++ b/src/main/java/hudson/remoting/SynchronousExecutorService.java
@@ -38,7 +38,7 @@ class SynchronousExecutorService extends AbstractExecutorService {
 
         while (count!=0) {
             long d = end - now;
-            if (d<0) {
+            if (d<=0) {
                 return false;
             }
             wait(TimeUnit.NANOSECONDS.toMillis(d));

--- a/src/main/java/hudson/remoting/SynchronousExecutorService.java
+++ b/src/main/java/hudson/remoting/SynchronousExecutorService.java
@@ -33,12 +33,16 @@ class SynchronousExecutorService extends AbstractExecutorService {
     }
 
     public synchronized boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        long end = System.currentTimeMillis() + unit.toMillis(timeout);
+        long now = System.nanoTime();
+        long end = now + unit.toNanos(timeout);
 
         while (count!=0) {
-            long d = end - System.currentTimeMillis();
-            if (d<0)    return false;
-            wait(d);
+            long d = end - now;
+            if (d<0) {
+                return false;
+            }
+            wait(TimeUnit.NANOSECONDS.toMillis(d));
+            now = System.nanoTime();
         }
         return true;
     }


### PR DESCRIPTION
Initial calculation of wait time was susceptible to clock drift.

The calculation on how long to wait in various places on the code was
susceptible to the clock changing as multiple calls where made to
System.currentTimeMillis() for the initial calculation.

Changed this so that we use a single call to System.nanoTime and made just
a single call for the initial calculation.

There is still a potential issue for any callers of Channel.getLastHeard()
this will be addressed in a future change and has only been noted in this
commit.

Replaces Pull #29 which was getting multiple different fixes intertwined.

@reviewbybees