### PR TITLE
[JENKINS-26759] Make FileSystemJarCache more defensive

### DIFF
--- a/src/main/java/hudson/remoting/Checksum.java
+++ b/src/main/java/hudson/remoting/Checksum.java
@@ -73,7 +73,7 @@ final class Checksum {
      */
     static Checksum forURL(URL url) throws IOException {
         try {
-            MessageDigest md = MessageDigest.getInstance(DIGEST_ALGORITHM);
+            MessageDigest md = MessageDigest.getInstance(JarLoaderImpl.DIGEST_ALGORITHM);
             Util.copy(url.openStream(), new DigestOutputStream(new NullOutputStream(), md));
             return new Checksum(md.digest(), md.getDigestLength() / 8);
         } catch (NoSuchAlgorithmException e) {
@@ -94,7 +94,4 @@ final class Checksum {
         public void write(byte[] b, int off, int len) {
         }
     }
-
-    public static final String DIGEST_ALGORITHM = System.getProperty(
-            JarLoaderImpl.class.getName() + ".algorithm", "SHA-256");
 }

--- a/src/main/java/hudson/remoting/FileSystemJarCache.java
+++ b/src/main/java/hudson/remoting/FileSystemJarCache.java
@@ -71,8 +71,14 @@ public class FileSystemJarCache extends JarCacheSupport {
                 tmp.renameTo(target);
 
                 if (target.exists()) {
+                    Checksum expected = new Checksum(sum1, sum2);
+                    Checksum actual = Checksum.forFile(target);
+                    System.out.println(actual.toString());
+                    if (!expected.equals(actual)) {
+                        throw new IOException("Checksum of retrieved jar doesn't match: " + target);
+                    }
                     // even if we fail to rename, we are OK as long as the target actually exists at this point
-                    // this can happen if two FileSystejarCache instances share the same cache dir
+                    // this can happen if two FileSystemJarCache instances share the same cache dir
                     return target.toURI().toURL();
                 }
 

--- a/src/main/java/hudson/remoting/FileSystemJarCache.java
+++ b/src/main/java/hudson/remoting/FileSystemJarCache.java
@@ -73,7 +73,6 @@ public class FileSystemJarCache extends JarCacheSupport {
                 if (target.exists()) {
                     Checksum expected = new Checksum(sum1, sum2);
                     Checksum actual = Checksum.forFile(target);
-                    System.out.println(actual.toString());
                     if (!expected.equals(actual)) {
                         throw new IOException("Checksum of retrieved jar doesn't match: " + target);
                     }

--- a/src/main/java/hudson/remoting/FileSystemJarCache.java
+++ b/src/main/java/hudson/remoting/FileSystemJarCache.java
@@ -95,7 +95,6 @@ public class FileSystemJarCache extends JarCacheSupport {
                     // same cache dir.
                     //
                     // Verify the checksum to be sure the target is correct.
-                    expected = new Checksum(sum1, sum2);
                     actual = Checksum.forFile(target);
                     if (!expected.equals(actual)) {
                         throw new IOException(String.format(

--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -14,6 +14,9 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * Implements {@link JarLoader} to be called from the other side.
  *
+ * TODO: move {@link #knownJars} and {@link #checksums} to another class to share it across
+ * {@link JarLoaderImpl}s.
+ *
  * @author Kohsuke Kawaguchi
  */
 @edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_BAD_FIELD")

--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -40,8 +40,7 @@ class JarLoaderImpl implements JarLoader, Serializable {
     }
 
     public boolean isPresentOnRemote(Checksum sum) {
-        boolean ret = presentOnRemote.contains(sum);
-        return ret;
+        return presentOnRemote.contains(sum);
     }
 
     public void notifyJarPresence(long sum1, long sum2) {

--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -1,27 +1,18 @@
 package hudson.remoting;
 
-import hudson.remoting.forward.Forwarder;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.net.URL;
-import java.security.DigestOutputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentSkipListSet;
 
 /**
  * Implements {@link JarLoader} to be called from the other side.
- *
- * TODO: move {@link #knownJars} and {@link #checksums} to another class to share it across
- * {@link JarLoaderImpl}s.
  *
  * @author Kohsuke Kawaguchi
  */
@@ -49,7 +40,8 @@ class JarLoaderImpl implements JarLoader, Serializable {
     }
 
     public boolean isPresentOnRemote(Checksum sum) {
-        return presentOnRemote.contains(sum);
+        boolean ret = presentOnRemote.contains(sum);
+        return ret;
     }
 
     public void notifyJarPresence(long sum1, long sum2) {
@@ -70,31 +62,11 @@ class JarLoaderImpl implements JarLoader, Serializable {
         Checksum v = checksums.get(jar);    // cache hit
         if (v!=null)    return v;
 
-        try {
-            MessageDigest md = MessageDigest.getInstance(DIGEST_ALGORITHM);
-            Util.copy(jar.openStream(),new DigestOutputStream(new NullOutputStream(),md));
-            v = new Checksum(md.digest(),md.getDigestLength()/8);
-        } catch (NoSuchAlgorithmException e) {
-            throw new AssertionError(e);
-        }
+        v = Checksum.forURL(jar);
 
         knownJars.put(v,jar);
         checksums.put(jar,v);
         return v;
-    }
-
-    class NullOutputStream extends OutputStream {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void write(byte[] b) {
-        }
-
-        @Override
-        public void write(byte[] b, int off, int len) {
-        }
     }
 
     /**
@@ -103,8 +75,6 @@ class JarLoaderImpl implements JarLoader, Serializable {
     private Object writeReplace() {
         return Channel.current().export(JarLoader.class, this);
     }
-
-    public static final String DIGEST_ALGORITHM = System.getProperty(JarLoaderImpl.class.getName()+".algorithm","SHA-256");
 
     private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -75,5 +75,7 @@ class JarLoaderImpl implements JarLoader, Serializable {
         return Channel.current().export(JarLoader.class, this);
     }
 
+    public static final String DIGEST_ALGORITHM = System.getProperty(JarLoaderImpl.class.getName()+".algorithm","SHA-256");
+
     private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -23,34 +23,31 @@
  */
 package hudson.remoting;
 
-import org.jenkinsci.constant_pool_scanner.ConstantPoolScanner;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.MalformedURLException;
 import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Vector;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static hudson.remoting.Util.getBaseName;
-import static hudson.remoting.Util.makeResource;
-import static hudson.remoting.Util.readFully;
-import static java.util.logging.Level.FINE;
-import static java.util.logging.Level.WARNING;
+import org.jenkinsci.constant_pool_scanner.ConstantPoolScanner;
+
+import static hudson.remoting.Util.*;
+import static java.util.logging.Level.*;
 
 /**
  * Loads class files from the other peer through {@link Channel}.

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -23,31 +23,34 @@
  */
 package hudson.remoting;
 
+import org.jenkinsci.constant_pool_scanner.ConstantPoolScanner;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.reflect.Method;
-import java.net.URL;
 import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Vector;
-import java.util.List;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Set;
+import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Vector;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.jenkinsci.constant_pool_scanner.ConstantPoolScanner;
-
-import static hudson.remoting.Util.*;
-import static java.util.logging.Level.*;
+import static hudson.remoting.Util.getBaseName;
+import static hudson.remoting.Util.makeResource;
+import static hudson.remoting.Util.readFully;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
 
 /**
  * Loads class files from the other peer through {@link Channel}.

--- a/src/test/java/hudson/remoting/ChecksumTest.java
+++ b/src/test/java/hudson/remoting/ChecksumTest.java
@@ -1,0 +1,64 @@
+package hudson.remoting;
+
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import com.google.common.io.Files;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Tests for {@link Checksum}.
+ *
+ * @author Akshay Dayal
+ */
+public class ChecksumTest {
+
+    private static final String FILE_CONTENTS1 = "These are the file contents";
+    private static final String FILE_CONTENTS2 = "These are some other file contents";
+
+    @Test
+    public void testForFileAndURL() throws Exception {
+        File tmpFile1 = createTmpFile("file1", FILE_CONTENTS1);
+        File tmpFile2 = createTmpFile("file2", FILE_CONTENTS2);
+        HashCode hash1 = Files.hash(tmpFile1, Hashing.sha256());
+        HashCode hash2 = Files.hash(tmpFile2, Hashing.sha256());
+
+        assertEquals(createdExpectedChecksum(hash1), Checksum.forFile(tmpFile1));
+        assertEquals(createdExpectedChecksum(hash1), Checksum.forURL(tmpFile1.toURI().toURL()));
+
+        assertEquals(createdExpectedChecksum(hash2), Checksum.forFile(tmpFile2));
+        assertEquals(createdExpectedChecksum(hash2), Checksum.forURL(tmpFile2.toURI().toURL()));
+
+        assertNotEquals(Checksum.forFile(tmpFile1), Checksum.forFile(tmpFile2));
+    }
+
+    private File createTmpFile(String name, String contents) throws Exception {
+        File tmpFile = File.createTempFile(name, ".txt");
+        tmpFile.deleteOnExit();
+        Files.append(contents, tmpFile, Charset.forName("UTF-8"));
+        return tmpFile;
+    }
+
+    static Checksum createdExpectedChecksum(HashCode hashCode) throws Exception {
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(hashCode.asBytes()));
+        long sum1 = 0;
+        long sum2 = 0;
+        for (int i = 0; i < hashCode.asBytes().length / 8; i++) {
+            long nextLong = in.readLong();
+            if (i % 2 == 0) {
+                sum1 ^= nextLong;
+            }
+            else {
+                sum2 ^= nextLong;
+            }
+        }
+        return new Checksum(sum1, sum2);
+    }
+}

--- a/src/test/java/hudson/remoting/ChecksumTest.java
+++ b/src/test/java/hudson/remoting/ChecksumTest.java
@@ -3,7 +3,9 @@ package hudson.remoting;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -23,10 +25,12 @@ public class ChecksumTest {
     private static final String FILE_CONTENTS1 = "These are the file contents";
     private static final String FILE_CONTENTS2 = "These are some other file contents";
 
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
     @Test
     public void testForFileAndURL() throws Exception {
-        File tmpFile1 = createTmpFile("file1", FILE_CONTENTS1);
-        File tmpFile2 = createTmpFile("file2", FILE_CONTENTS2);
+        File tmpFile1 = createTmpFile("file1.txt", FILE_CONTENTS1);
+        File tmpFile2 = createTmpFile("file2.txt", FILE_CONTENTS2);
         HashCode hash1 = Files.hash(tmpFile1, Hashing.sha256());
         HashCode hash2 = Files.hash(tmpFile2, Hashing.sha256());
 
@@ -40,8 +44,7 @@ public class ChecksumTest {
     }
 
     private File createTmpFile(String name, String contents) throws Exception {
-        File tmpFile = File.createTempFile(name, ".txt");
-        tmpFile.deleteOnExit();
+        File tmpFile = tmp.newFile(name);
         Files.append(contents, tmpFile, Charset.forName("UTF-8"));
         return tmpFile;
     }

--- a/src/test/java/hudson/remoting/FileSystemJarCacheTest.java
+++ b/src/test/java/hudson/remoting/FileSystemJarCacheTest.java
@@ -46,7 +46,6 @@ public class FileSystemJarCacheTest {
 
     @Before
     public void setUp() throws Exception {
-
         fileSystemJarCache = new FileSystemJarCache(tmp.getRoot(), true);
 
         expectedChecksum = ChecksumTest.createdExpectedChecksum(

--- a/src/test/java/hudson/remoting/FileSystemJarCacheTest.java
+++ b/src/test/java/hudson/remoting/FileSystemJarCacheTest.java
@@ -1,0 +1,97 @@
+package hudson.remoting;
+
+import com.google.common.hash.Hashing;
+import com.google.common.io.Files;
+import org.hamcrest.core.StringContains;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link FileSystemJarCache}.
+ *
+ * @author Akshay Dayal
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FileSystemJarCacheTest {
+
+    private static final String CONTENTS = "These are the contents";
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Mock private Channel mockChannel;
+    @Mock private JarLoader mockJarLoader;
+    private FileSystemJarCache fileSystemJarCache;
+    private Checksum expectedChecksum;
+
+    @Before
+    public void setUp() throws Exception {
+        File rootDir = Files.createTempDir();
+        rootDir.deleteOnExit();
+        fileSystemJarCache = new FileSystemJarCache(rootDir, true);
+
+        expectedChecksum = ChecksumTest.createdExpectedChecksum(
+                Hashing.sha256().hashBytes(CONTENTS.getBytes(Charset.forName("UTF-8"))));
+    }
+
+    @Test
+    public void testSuccessfulRetrieve() throws Exception {
+        when(mockChannel.getProperty(JarLoader.THEIRS)).thenReturn(mockJarLoader);
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+                RemoteOutputStream o = (RemoteOutputStream) invocationOnMock.getArguments()[2];
+                o.write(CONTENTS.getBytes(Charset.forName("UTF-8")));
+                return null;
+            }
+        }).when(mockJarLoader).writeJarTo(
+                eq(expectedChecksum.sum1),
+                eq(expectedChecksum.sum2),
+                any(RemoteOutputStream.class));
+
+        URL url = fileSystemJarCache.retrieve(
+                mockChannel, expectedChecksum.sum1, expectedChecksum.sum2);
+        assertEquals(expectedChecksum, Checksum.forURL(url));
+    }
+
+    @Test
+    public void testRetrieveChecksumDifferent() throws Exception {
+        when(mockChannel.getProperty(JarLoader.THEIRS)).thenReturn(mockJarLoader);
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+                RemoteOutputStream o = (RemoteOutputStream) invocationOnMock.getArguments()[2];
+                o.write("Some other contents".getBytes(Charset.forName("UTF-8")));
+                return null;
+            }
+        }).when(mockJarLoader).writeJarTo(
+                eq(expectedChecksum.sum1),
+                eq(expectedChecksum.sum2),
+                any(RemoteOutputStream.class));
+
+        expectedEx.expect(IOException.class);
+        expectedEx.expectCause(hasMessage(
+                StringContains.containsString("Checksum of retrieved jar doesn't match")));
+        fileSystemJarCache.retrieve(
+                mockChannel, expectedChecksum.sum1, expectedChecksum.sum2);
+    }
+}


### PR DESCRIPTION
[JENKINS-26759](https://issues.jenkins-ci.org/browse/JENKINS-26759)

After a jar is fetched verify the checksum matches the expected value, if not throw an exception.