### PR TITLE
Unflake the JnlpProtocol2 tests

### DIFF
--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol2Test.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol2Test.java
@@ -84,7 +84,8 @@ public class JnlpProtocol2Test {
         mockStatic(EngineUtil.class);
         when(EngineUtil.readLine(mockBufferedInputStream)).thenReturn("error");
 
-        assertEquals("error", protocol.performHandshake(mockDataOutputStream, mockBufferedInputStream));
+        assertEquals("error",
+                protocol.performHandshake(mockDataOutputStream, mockBufferedInputStream));
 
         inOrder.verify(mockDataOutputStream).writeUTF("Protocol:JNLP2-connect");
         inOrder.verify(mockDataOutputStream).writeUTF(argThat(
@@ -104,10 +105,13 @@ public class JnlpProtocol2Test {
         responseProperties.put(JnlpProtocol2.COOKIE_KEY, COOKIE);
 
         mockStatic(EngineUtil.class);
-        when(EngineUtil.readLine(mockBufferedInputStream)).thenReturn(JnlpProtocol.GREETING_SUCCESS);
-        when(EngineUtil.readResponseHeaders(mockBufferedInputStream)).thenReturn(responseProperties);
+        when(EngineUtil.readLine(mockBufferedInputStream))
+                .thenReturn(JnlpProtocol.GREETING_SUCCESS);
+        when(EngineUtil.readResponseHeaders(mockBufferedInputStream))
+                .thenReturn(responseProperties);
 
-        assertEquals(JnlpProtocol.GREETING_SUCCESS, protocol.performHandshake(mockDataOutputStream, mockBufferedInputStream));
+        assertEquals(JnlpProtocol.GREETING_SUCCESS,
+                protocol.performHandshake(mockDataOutputStream, mockBufferedInputStream));
         assertEquals(COOKIE, protocol.getCookie());
 
         inOrder.verify(mockDataOutputStream).writeUTF("Protocol:JNLP2-connect");
@@ -141,13 +145,16 @@ public class JnlpProtocol2Test {
         responseProperties2.put(JnlpProtocol2.COOKIE_KEY, COOKIE2);
 
         mockStatic(EngineUtil.class);
-        when(EngineUtil.readLine(mockBufferedInputStream)).thenReturn(JnlpProtocol.GREETING_SUCCESS);
+        when(EngineUtil.readLine(mockBufferedInputStream))
+                .thenReturn(JnlpProtocol.GREETING_SUCCESS);
         when(EngineUtil.readResponseHeaders(mockBufferedInputStream)).thenReturn(responseProperties)
                 .thenReturn(responseProperties2);
 
-        assertEquals(JnlpProtocol.GREETING_SUCCESS, protocol.performHandshake(mockDataOutputStream, mockBufferedInputStream));
+        assertEquals(JnlpProtocol.GREETING_SUCCESS,
+                protocol.performHandshake(mockDataOutputStream, mockBufferedInputStream));
         assertEquals(COOKIE, protocol.getCookie());
-        assertEquals(JnlpProtocol.GREETING_SUCCESS, protocol.performHandshake(mockDataOutputStream, mockBufferedInputStream));
+        assertEquals(JnlpProtocol.GREETING_SUCCESS,
+                protocol.performHandshake(mockDataOutputStream, mockBufferedInputStream));
         assertEquals(COOKIE2, protocol.getCookie());
 
         inOrder.verify(mockDataOutputStream).writeUTF("Protocol:JNLP2-connect");

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol2Test.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol2Test.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -81,7 +81,6 @@ public class JnlpProtocol2Test {
         ByteArrayOutputStream expectedPropertiesStream = new ByteArrayOutputStream();
         expectedProperties.store(expectedPropertiesStream, null);
 
-        mockStatic(EngineUtil.class);
         when(EngineUtil.readLine(mockBufferedInputStream)).thenReturn("error");
 
         assertEquals("error",
@@ -104,7 +103,6 @@ public class JnlpProtocol2Test {
         Properties responseProperties = new Properties();
         responseProperties.put(JnlpProtocol2.COOKIE_KEY, COOKIE);
 
-        mockStatic(EngineUtil.class);
         when(EngineUtil.readLine(mockBufferedInputStream))
                 .thenReturn(JnlpProtocol.GREETING_SUCCESS);
         when(EngineUtil.readResponseHeaders(mockBufferedInputStream))
@@ -144,7 +142,6 @@ public class JnlpProtocol2Test {
         Properties responseProperties2 = new Properties();
         responseProperties2.put(JnlpProtocol2.COOKIE_KEY, COOKIE2);
 
-        mockStatic(EngineUtil.class);
         when(EngineUtil.readLine(mockBufferedInputStream))
                 .thenReturn(JnlpProtocol.GREETING_SUCCESS);
         when(EngineUtil.readResponseHeaders(mockBufferedInputStream)).thenReturn(responseProperties)

--- a/src/test/java/org/jenkinsci/remoting/engine/PropertiesStringMatcher.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/PropertiesStringMatcher.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2015, Sun Microsystems, Inc., Kohsuke Kawaguchi, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.remoting.engine;
+
+import org.mockito.ArgumentMatcher;
+
+/**
+ * Matcher that allows comparing Properties.store() results that may differ
+ * only in the date comment line.
+ *
+ * @author Akshay Dayal
+ */
+public class PropertiesStringMatcher extends ArgumentMatcher<String> {
+    private String expected;
+
+    public PropertiesStringMatcher(String expected) {
+        this.expected = expected.substring(
+                expected.indexOf(System.getProperty("line.separator")));
+    }
+
+    @Override
+    public boolean matches(Object value) {
+        String other = (String) value;
+        return other.endsWith(expected);
+    }
+}


### PR DESCRIPTION
Originally part of https://github.com/jenkinsci/remoting/pull/41. I'm breaking it out into its own pull request so it can get reviewed & merged in sooner.

The current JnlpProtocol2 tests incorrectly try to mock out Properties call to new Date(). This results in the tests sometimes failing. I could not get Powermock to correctly mock out the call and instead chose to write an ArgumentMatcher that would compare string-ified properties as needed.