### PR TITLE
Deflake JnlpProtocol2Test

### DIFF
--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol2Test.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol2Test.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -34,10 +35,14 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
-import java.util.Date;
+import java.io.StringBufferInputStream;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -57,7 +62,6 @@ public class JnlpProtocol2Test {
     private static final String SLAVE_NAME = "slave-name";
     private static final String COOKIE = "some-cookie";
     private static final String COOKIE2 = "some-other-cookie";
-    private static final Date THE_DATE = new Date();
 
     private JnlpProtocol2 protocol;
     @Mock private DataOutputStream outputStream;
@@ -75,15 +79,9 @@ public class JnlpProtocol2Test {
 
     @Test
     public void testHandshakeError() throws Exception {
-        // The date comment when writing properties to stream should be the
-        // same in the scope of the tests.
-        whenNew(Date.class).withNoArguments().thenReturn(THE_DATE);
-
         Properties expectedProperties = new Properties();
         expectedProperties.put(JnlpProtocol2.SECRET_KEY, SECRET);
         expectedProperties.put(JnlpProtocol2.SLAVE_NAME_KEY, SLAVE_NAME);
-        ByteArrayOutputStream expectedPropertiesStream = new ByteArrayOutputStream();
-        expectedProperties.store(expectedPropertiesStream, null);
 
         mockStatic(EngineUtil.class);
         when(EngineUtil.readLine(inputStream)).thenReturn("error");
@@ -91,21 +89,15 @@ public class JnlpProtocol2Test {
         assertEquals("error", protocol.performHandshake(outputStream, inputStream));
 
         verify(outputStream).writeUTF("Protocol:JNLP2-connect");
-        verify(outputStream).writeUTF(expectedPropertiesStream.toString("UTF-8"));
+        verify(outputStream).writeUTF(argThat(matchesPropertiesOutput(expectedProperties)));
     }
 
     @Test
     public void testHandshakeSuccess() throws Exception {
-        // The date comment when writing properties to stream should be the
-        // same in the scope of the tests.
-        whenNew(Date.class).withNoArguments().thenReturn(THE_DATE);
-
         // Properties slave sends to master.
         Properties expectedProperties = new Properties();
         expectedProperties.put(JnlpProtocol2.SECRET_KEY, SECRET);
         expectedProperties.put(JnlpProtocol2.SLAVE_NAME_KEY, SLAVE_NAME);
-        ByteArrayOutputStream expectedPropertiesStream = new ByteArrayOutputStream();
-        expectedProperties.store(expectedPropertiesStream, null);
         // Properties master sends back.
         Properties responseProperties = new Properties();
         responseProperties.put(JnlpProtocol2.COOKIE_KEY, COOKIE);
@@ -118,21 +110,15 @@ public class JnlpProtocol2Test {
         assertEquals(COOKIE, protocol.getCookie());
 
         verify(outputStream).writeUTF("Protocol:JNLP2-connect");
-        verify(outputStream).writeUTF(expectedPropertiesStream.toString("UTF-8"));
+        verify(outputStream).writeUTF(argThat(matchesPropertiesOutput(expectedProperties)));
     }
 
     @Test
     public void testRepeatedHandshakeSendsCookie() throws Exception {
-        // The date comment when writing properties to stream should be the
-        // same in the scope of the tests.
-        whenNew(Date.class).withNoArguments().thenReturn(THE_DATE);
-
         // Properties slave sends to master the first time.
         Properties expectedProperties = new Properties();
         expectedProperties.put(JnlpProtocol2.SECRET_KEY, SECRET);
         expectedProperties.put(JnlpProtocol2.SLAVE_NAME_KEY, SLAVE_NAME);
-        ByteArrayOutputStream expectedPropertiesStream = new ByteArrayOutputStream();
-        expectedProperties.store(expectedPropertiesStream, null);
         // Properties master sends back first time.
         Properties responseProperties = new Properties();
         responseProperties.put(JnlpProtocol2.COOKIE_KEY, COOKIE);
@@ -141,8 +127,6 @@ public class JnlpProtocol2Test {
         expectedProperties2.put(JnlpProtocol2.SECRET_KEY, SECRET);
         expectedProperties2.put(JnlpProtocol2.SLAVE_NAME_KEY, SLAVE_NAME);
         expectedProperties2.put(JnlpProtocol2.COOKIE_KEY, COOKIE);
-        ByteArrayOutputStream expectedPropertiesStream2 = new ByteArrayOutputStream();
-        expectedProperties2.store(expectedPropertiesStream2, null);
         // Properties master sends back second time.
         Properties responseProperties2 = new Properties();
         responseProperties2.put(JnlpProtocol2.COOKIE_KEY, COOKIE2);
@@ -159,8 +143,64 @@ public class JnlpProtocol2Test {
         assertEquals(COOKIE2, protocol.getCookie());
 
         order.verify(outputStream).writeUTF("Protocol:JNLP2-connect");
-        order.verify(outputStream).writeUTF(expectedPropertiesStream.toString("UTF-8"));
+        order.verify(outputStream).writeUTF(argThat(matchesPropertiesOutput(expectedProperties)));
         order.verify(outputStream).writeUTF("Protocol:JNLP2-connect");
-        order.verify(outputStream).writeUTF(expectedPropertiesStream2.toString("UTF-8"));
+        order.verify(outputStream).writeUTF(argThat(matchesPropertiesOutput(expectedProperties2)));
+    }
+
+    @Test
+    public void testPropertiesStringMatcherSuccess() throws Exception {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        Properties properties = new Properties();
+        properties.put("foo", "bar");
+
+        properties.store(stream, null);
+        String str1 = stream.toString("UTF-8");
+
+        // Sleep for a little over a second to ensure the comments at the top
+        // of the string representation contain different timestamps
+        Thread.sleep(1250);
+
+        stream.reset();
+        properties.store(stream, null);
+        String str2 = stream.toString("UTF-8");
+
+        assertNotEquals(str1, str2);
+        assertTrue(matchesPropertiesOutput(properties).matches(str1));
+        assertTrue(matchesPropertiesOutput(properties).matches(str2));
+    }
+
+    @Test
+    public void testPropertiesStringMatcherFailure() throws Exception {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        Properties properties = new Properties();
+        properties.put("foo", "bar");
+        properties.store(stream, null);
+        String str = stream.toString("UTF-8");
+        properties.put("bar", "baz");
+
+        assertFalse(matchesPropertiesOutput(properties).matches(str));
+    }
+
+    /**
+     * Properties.store() writes a comment with a datestamp, so this creates a Matcher which will
+     * actually parse the stored value and confirm the resulting Properties objects match.
+     */
+    private static ArgumentMatcher<String> matchesPropertiesOutput(Properties properties) {
+        final Properties expected = (Properties) properties.clone();
+        return new ArgumentMatcher<String>() {
+            @Override
+            public boolean matches(Object obj) {
+                StringBufferInputStream stream = new StringBufferInputStream((String) obj);
+                Properties actual = new Properties();
+                try {
+                    actual.load(stream);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+
+                return expected.equals(actual);
+            }
+        };
     }
 }


### PR DESCRIPTION
PowerMockito wasn't being told to prep Properties.class to have its
'new Date()' call hijacked, so it wasn't actually doing it. That said,
even adding that didn't seem to help.

But instead of reaching into the implementation details, I've written a
custom Matcher to just verify that the output string representation of
the Properties parses back to the expected values. As an added benefit,
this no longer depends on two identical Properties objects writing keys
in the same order when store() is called, since the API there doesn't
actually guarantee that.