### PR TITLE
Swap PingThread#dead* abstraction

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -525,9 +525,6 @@ public class Launcher {
         if (performPing && timeout > 0 && interval > 0) {
             new PingThread(channel, timeout, interval) {
                 @Override
-                protected void onDead() {
-                    onDead(null);
-                }
                 protected void onDead(Throwable diagnosis) {
                     System.err.println("Ping failed. Terminating. Cause: " + diagnosis);
                     if (diagnosis != null) {

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -526,7 +526,13 @@ public class Launcher {
             new PingThread(channel, timeout, interval) {
                 @Override
                 protected void onDead() {
-                    System.err.println("Ping failed. Terminating");
+                    onDead(null);
+                }
+                protected void onDead(Throwable diagnosis) {
+                    System.err.println("Ping failed. Terminating. Cause: " + diagnosis);
+                    if (diagnosis != null) {
+                        diagnosis.printStackTrace(System.err);
+                    }
                     System.exit(-1);
                 }
             }.start();

--- a/src/main/java/hudson/remoting/PingThread.java
+++ b/src/main/java/hudson/remoting/PingThread.java
@@ -41,7 +41,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * or when the disconnection is not properly detected.
  *
  * <p>
- * {@link #onDead()} method needs to be overridden to define
+ * {@link #onDead(Throwable)} method needs to be overridden to define
  * what to do when a connection appears to be dead.
  *
  * @author Kohsuke Kawaguchi
@@ -141,9 +141,7 @@ public abstract class PingThread extends Thread {
      *
      * @since 2.9
      */
-    protected void onDead(Throwable diagnosis) {
-        onDead();   // fall back
-    }
+    protected abstract void onDead(Throwable diagnosis);
 
     private static final class Ping implements Callable<Void, IOException> {
         private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/remoting/PingThread.java
+++ b/src/main/java/hudson/remoting/PingThread.java
@@ -134,7 +134,9 @@ public abstract class PingThread extends Thread {
      *      and provide a fallback behaviour to be backward compatible with earlier version of remoting library.
      */
     @Deprecated
-    protected abstract void onDead();
+    protected void onDead() {
+        onDead(new RuntimeException("No cause"));
+    }
 
     /**
      * Called when ping failed.


### PR DESCRIPTION
I noticed that the way PingThread#onDead(*) methods are deprecated/implemented could cause clients to not implement the method that gives the most feedback.

So here's a new implementation that
1. force subclasses to implement the most meaningful method
2. in a separate commit, get rid of the old method altogether

Existing clients should have to implement the new method anyway. The old one isn't used (except maybe by implementing clients?) and the proposed default implementation might give more feedback if ever called.

I am unable to run full tests due to a PipeTest hang when running mvn test. 
