### PR TITLE
[JENKINS-28844] Fix memory leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.5.2</version>
+        <version>3.0.1</version>
         <configuration>
           <excludeFilterFile>${basedir}/src/findbugs-filter.xml</excludeFilterFile>
           <failOnError>true</failOnError>

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1425,7 +1425,11 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 
     /*package*/ static Channel setCurrent(Channel channel) {
         Channel old = CURRENT.get();
-        CURRENT.set(channel);
+        if (channel == null) {
+            CURRENT.remove();
+        } else {
+            CURRENT.set(channel);
+        }
         return old;
     }
 

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -931,7 +931,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * Returns true if this channel has any of the security restrictions enabled.
      *
      * @deprecated
-     *      Use methods like {@link #allowsRemoteClassLoading()} and {@link #allowsArbitraryCallable()}
+     *      Use methods like {@link #isRemoteClassLoadingAllowed()} and {@link #isArbitraryCallableAllowed()}
      *      to test individual features.
      */
     @Deprecated
@@ -943,7 +943,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * Activates/disables all the security restriction mode.
      *
      * @deprecated
-     *      Use methods like {@link #allowClassLoading(boolean)} and {@link #allowArbitraryCallable(boolean)}
+     *      Use methods like {@link #setRemoteClassLoadingAllowed(boolean)} and {@link #setArbitraryCallableAllowed(boolean)}
      *      to control individual features.
      */
     @Deprecated

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -153,12 +153,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * Remembers last I/O ID issued from locally to the other side, per thread.
      * int[1] is used as a holder of int.
      */
-    private final ThreadLocal<int[]> lastIoId = new ThreadLocal<int[]>() {
-        @Override
-        protected int[] initialValue() {
-            return new int[1];
-        }
-    };
+    private final ThreadLocal<int[]> lastIoId = new ThreadLastIoId();
 
     /**
      * Records the {@link Request}s being executed on this channel, sent by the remote peer.
@@ -1483,5 +1478,12 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         //
         // to avoid situations like this, create proxy classes that we need during the classloading
         jarLoaderProxy=RemoteInvocationHandler.getProxyClass(JarLoader.class);
+    }
+
+    private static class ThreadLastIoId extends ThreadLocal<int[]> {
+        @Override
+        protected int[] initialValue() {
+            return new int[1];
+        }
     }
 }

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1517,6 +1517,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         jarLoaderProxy=RemoteInvocationHandler.getProxyClass(JarLoader.class);
     }
 
+    /**
+     * Do not use an anonymous inner class as that can cause a {@code this} reference to escape.
+     */
     private static class ThreadLastIoId extends ThreadLocal<int[]> {
         @Override
         protected int[] initialValue() {

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1529,6 +1529,8 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 
     /**
      * A reference for the {@link Channel} that can be cleared out on {@link #close()}/{@link #terminate(IOException)}.
+     * Could probably be replaced with {@link AtomicReference} but then we would not retain the only change being
+     * from valid channel to {@code null} channel symmantics of this class.
      * @since FIXME after merge
      * @see #reference
      */

--- a/src/main/java/hudson/remoting/JarCacheSupport.java
+++ b/src/main/java/hudson/remoting/JarCacheSupport.java
@@ -36,7 +36,9 @@ public abstract class JarCacheSupport extends JarCache {
     /**
      * Throttle the jar downloading activity so that it won't eat up all the channel bandwidth.
      */
-    private final ExecutorService downloader = new AtmostOneThreadExecutor();
+    private final ExecutorService downloader = new AtmostOneThreadExecutor(
+            new NamingThreadFactory(new DaemonThreadFactory(), JarCacheSupport.class.getSimpleName())
+    );
 
     @Override
     public Future<URL> resolve(final Channel channel, final long sum1, final long sum2) throws IOException, InterruptedException {

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -158,7 +158,7 @@ public class Launcher {
             System.err.println("Illegal parameter: "+target);
             System.exit(1);
         }
-        connectionTarget = new InetSocketAddress(tokens[0],Integer.valueOf(tokens[1]));
+        connectionTarget = new InetSocketAddress(tokens[0],Integer.parseInt(tokens[1]));
     }
 
     /**

--- a/src/main/java/hudson/remoting/NamingThreadFactory.java
+++ b/src/main/java/hudson/remoting/NamingThreadFactory.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2013 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.remoting;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Thread factory that sets thread name so we know who is responsible for so many threads being created.
+ * @since FIXME after merge
+ */
+public class NamingThreadFactory implements ThreadFactory {
+    private final AtomicInteger threadNum = new AtomicInteger();
+    private final ThreadFactory delegate;
+    private final String name;
+
+    /**
+     * Creates a new naming factory.
+     * @param delegate a baseline factory, such as {@link Executors#defaultThreadFactory} or {@link DaemonThreadFactory}
+     * @param name an identifier to be used in thread names; might be e.g. your {@link Class#getSimpleName}
+     */
+    public NamingThreadFactory(ThreadFactory delegate, String name) {
+        this.delegate = delegate;
+        this.name = name;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread result = delegate.newThread(r);
+        result.setName(String.format("%s [#%d]", name, threadNum.incrementAndGet()));
+        return result;
+    }
+}

--- a/src/main/java/hudson/remoting/RemoteInvocationHandler.java
+++ b/src/main/java/hudson/remoting/RemoteInvocationHandler.java
@@ -23,20 +23,33 @@
  */
 package hudson.remoting;
 
-import org.jenkinsci.remoting.Role;
 import org.jenkinsci.remoting.RoleChecker;
 
+import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Sits behind a proxy object and implements the proxy logic.
@@ -44,6 +57,16 @@ import java.util.Collections;
  * @author Kohsuke Kawaguchi
  */
 final class RemoteInvocationHandler implements InvocationHandler, Serializable {
+    /**
+     * Our logger.
+     */
+    private static final Logger logger = Logger.getLogger(RemoteInvocationHandler.class.getName());
+    /**
+     * The {@link Unexporter} to track {@link RemoteInvocationHandler} instances that should be unexported when
+     * collected by the garbage collector.
+     * @since FIXME after merge
+     */
+    private static final Unexporter UNEXPORTER = new Unexporter();
     /**
      * This proxy acts as a proxy to the object of
      * Object ID on the remote {@link Channel}.
@@ -57,8 +80,10 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
      * This field is null when a {@link RemoteInvocationHandler} is just
      * created and not working as a remote proxy. Once tranferred to the
      * remote system, this field is set to non-null. 
+     * @since FIXME after merge
      */
-    private transient Channel channel;
+    @CheckForNull
+    private transient Channel.Ref channel;
 
     /**
      * True if we are proxying an user object.
@@ -93,7 +118,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
      * Creates a proxy that wraps an existing OID on the remote.
      */
     RemoteInvocationHandler(Channel channel, int id, boolean userProxy, boolean autoUnexportByCaller, Class proxyType) {
-        this.channel = channel;
+        this.channel = channel == null ? null : channel.ref();
         this.oid = id;
         this.userProxy = userProxy;
         this.origin = new Exception("Proxy "+toString()+" was created for "+proxyType);
@@ -108,14 +133,42 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         // if the type is a JDK-defined type, classloader should be for IReadResolve
         if(cl==null || cl==ClassLoader.getSystemClassLoader())
             cl = IReadResolve.class.getClassLoader();
-        return type.cast(Proxy.newProxyInstance(cl, new Class[]{type,IReadResolve.class},
-            new RemoteInvocationHandler(channel,id,userProxy,autoUnexportByCaller,type)));
+        RemoteInvocationHandler handler = new RemoteInvocationHandler(channel, id, userProxy, autoUnexportByCaller, type);
+        if (channel != null) {
+            if (!autoUnexportByCaller) {
+                UNEXPORTER.watch(handler);
+            }
+        }
+        return type.cast(Proxy.newProxyInstance(cl, new Class[]{type, IReadResolve.class}, handler));
     }
 
+    /**
+     * Called as soon as a channel is terminated, we cannot use {@link Channel.Listener} as that is called after
+     * termination has completed and we need to clean up the {@link PhantomReferenceImpl} before they try to
+     * clean themselves up by sending the {@link UnexportCommand} over the closing {@link Channel}.
+     *
+     * @param channel the {@link Channel} that is terminating/terminated.
+     * @since FIXME after merge
+     */
+    /*package*/ static void notifyChannelTermination(Channel channel) {
+        UNEXPORTER.onChannelTermination(channel);
+    }
+    
     /*package*/ static Class getProxyClass(Class type) {
         return Proxy.getProxyClass(type.getClassLoader(), new Class[]{type,IReadResolve.class});
     }
 
+    /**
+     * Returns the backing channel or {@code null} if the channel is disconnected or otherwise unavailable.
+     *
+     * @return the backing channel or {@code null}.
+     * @since FIXME after merge
+     */
+    @CheckForNull
+    private Channel channel() {
+        return this.channel == null ? null : this.channel.channel();
+    }
+    
     /**
      * If the given object is a proxy to a remote object in the specified channel,
      * return its object ID. Otherwise return -1.
@@ -127,7 +180,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         InvocationHandler h = Proxy.getInvocationHandler(proxy);
         if (h instanceof RemoteInvocationHandler) {
             RemoteInvocationHandler rih = (RemoteInvocationHandler) h;
-            if(rih.channel==src)
+            if(rih.channel()==src)
                 return rih.oid;
         }
         return -1;
@@ -141,7 +194,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         InvocationHandler h = Proxy.getInvocationHandler(proxy);
         if (h instanceof RemoteInvocationHandler) {
             RemoteInvocationHandler rih = (RemoteInvocationHandler) h;
-            return rih.channel;
+            return rih.channel();
         }
         return null;
     }
@@ -175,11 +228,11 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         RPCRequest req = new RPCRequest(oid, method, args, userProxy ? dc.getClassLoader() : null);
         try {
             if(userProxy) {
-                if (async)  channel.callAsync(req);
-                else        return channel.call(req);
+                if (async)  channel().callAsync(req);
+                else        return channel().call(req);
             } else {
-                if (async)  req.callAsync(channel);
-                else        return req.call(channel);
+                if (async)  req.callAsync(channel());
+                else        return req.call(channel());
             }
             return null;
         } catch (Throwable e) {
@@ -204,7 +257,13 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
             // (which would cause the finalize() method to try to unexport the object.)
             channel = null;
         } else {
-            channel = Channel.current();
+            Channel channel = Channel.current();
+            this.channel = channel == null ? null : channel.ref();
+            if (channel != null) {
+                if (!autoUnexportByCaller) {
+                    UNEXPORTER.watch(this);
+                }
+            }
         }
     }
 
@@ -233,16 +292,217 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         return oid;
     }
 
+    /**
+     * Finalizers are run only under extreme GC pressure whereas {@link PhantomReference} are cleared out
+     * more quickly, thus we use a {@link PhantomReference} in place of the override of {@link Object#finalize()}
+     * that was previously used in order to unexport.
+     * @since FIXME after merge
+     */
+    private static class PhantomReferenceImpl extends PhantomReference<RemoteInvocationHandler> {
 
-    protected void finalize() throws Throwable {
-        // unexport the remote object
-        if (channel!=null && !autoUnexportByCaller) {
-            channel.send(new UnexportCommand(oid,origin));
-            channel = null;
+        /**
+         * The object id to unexport.
+         */
+        private final int oid;
+        /**
+         * The origin from where the object was created.
+         */
+        private Throwable origin;
+        /**
+         * The reference to the channel on which to unexport.
+         */
+        private Channel.Ref channel;
+
+        /**
+         * Construct our reference and bind to the {@link ReferenceQueue} after capturing the required state for
+         * {@link #cleanup()}.
+         *
+         * @param referent       the {@link RemoteInvocationHandler} we will clean up.
+         * @param referenceQueue the {@link ReferenceQueue}
+         */
+        private PhantomReferenceImpl(RemoteInvocationHandler referent,
+                                    ReferenceQueue<? super RemoteInvocationHandler> referenceQueue) {
+            super(referent, referenceQueue);
+            this.oid = referent.oid;
+            this.origin = referent.origin;
+            this.channel = referent.channel;
         }
-        super.finalize();
+
+        /**
+         * Sends the {@link UnexportCommand} for the specified {@link #oid} if the {@link Channel} is still open.
+         * @throws IOException if the {@link UnexportCommand} could not be sent.
+         */
+        private void cleanup() throws IOException {
+            if (this.channel == null) {
+                return;
+            }
+            Channel channel = this.channel.channel();
+            if (channel != null && !channel.isClosingOrClosed()) {
+                try {
+                    channel.send(new UnexportCommand(oid, origin));
+                } finally {
+                    // clear out references to simplify GC
+                    this.origin = null;
+                    this.channel = null;
+                }
+            }
+        }
     }
 
+    /**
+     * Manages the cleanup of {@link RemoteInvocationHandler} instances that need to be auto unexported.
+     * @since FIXME after merge
+     */
+    private static class Unexporter implements Runnable {
+
+        /**
+         * Our executor service, we use at most one thread for all {@link Channel} instances in the current classloader.
+         */
+        private final ExecutorService svc = new AtmostOneThreadExecutor(
+                new NamingThreadFactory(new DaemonThreadFactory(), RemoteInvocationHandler.class.getSimpleName())
+        );
+        /**
+         * Flag to track that {@link #UNEXPORTER} has been queued for execution.
+         */
+        private final AtomicBoolean inQueue = new AtomicBoolean(false);
+        /**
+         * Flag to track that {@link #UNEXPORTER} is running.
+         */
+        private final AtomicBoolean isAlive = new AtomicBoolean(false);
+        /**
+         * Our {@link ReferenceQueue} for picking up references that have been collected by the garbage collector
+         * and need the corresponding {@link UnexportCommand} sent.
+         */
+        private final ReferenceQueue<? super RemoteInvocationHandler> queue = new ReferenceQueue<RemoteInvocationHandler>();
+        /**
+         * The "live" {@link PhantomReferenceImpl} instances for each active {@link Channel}.
+         */
+        private final ConcurrentMap<Channel.Ref,List<PhantomReferenceImpl>> referenceLists 
+                = new ConcurrentHashMap<Channel.Ref, List<PhantomReferenceImpl>>();
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void run() {
+            if (!isAlive.compareAndSet(false, true)) {
+                inQueue.set(false); // we have started execution so clear the flag, must happen after check of running
+                return;
+            }
+            inQueue.set(false); // we have started execution and running is true, so queued can be reset
+            try {
+                while (!referenceLists.isEmpty()) {
+                    try {
+                        Reference<?> ref = queue.remove(100);
+                        if (ref instanceof PhantomReferenceImpl) {
+                            PhantomReferenceImpl r = (PhantomReferenceImpl) ref;
+                            final Channel.Ref channelRef = r.channel;
+                            try {
+                                r.cleanup();
+                            } catch (IOException e) {
+                                logger.log(Level.WARNING,
+                                        String.format("Couldn't clean up oid=%d from %s", r.oid, r.origin), e);
+                            } catch (Error e) {
+                                logger.log(Level.SEVERE,
+                                        String.format("Couldn't clean up oid=%d from %s", r.oid, r.origin), e);
+                                throw e; // pass on as there is nothing we can do with an error
+                            } catch (Throwable e) {
+                                logger.log(Level.WARNING,
+                                        String.format("Couldn't clean up oid=%d from %s", r.oid, r.origin), e);
+                            } finally {
+                                if (channelRef != null) {
+                                    final List<PhantomReferenceImpl> referenceList = referenceLists.get(channelRef);
+                                    if (referenceList != null) {
+                                        referenceList.remove(r);
+                                        if (channelRef.channel() == null) {
+                                            cleanList(referenceList);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } catch (InterruptedException e) {
+                        logger.log(Level.FINE, "Interrupted", e);
+                    }
+                    // purge any dead channels, it does not matter if we spend a long time here as we are
+                    // removing future potential work for us from ever entering the queue and freeing garbage
+                    for (Iterator<Map.Entry<Channel.Ref, List<PhantomReferenceImpl>>>
+                         iterator = referenceLists.entrySet().iterator(); 
+                         iterator.hasNext(); ) {
+                        final Map.Entry<Channel.Ref, List<PhantomReferenceImpl>> entry = iterator.next();
+                        final Channel.Ref r = entry.getKey();
+                        if (r == null || r.channel() == null) {
+                            iterator.remove();
+                            // take them out of the queue
+                            cleanList(entry.getValue());
+                        }
+                    }
+                }
+            } finally {
+                isAlive.set(false);
+            }
+        }
+
+        /**
+         * Cleans a {@link List} of {@link PhantomReferenceImpl} as the {@link Channel} has closed.
+         *
+         * @param referenceList the {@link List}.
+         */
+        private void cleanList(@CheckForNull List<PhantomReferenceImpl> referenceList) {
+            if (referenceList == null) {
+                return;
+            }
+            for (PhantomReferenceImpl phantom: referenceList) {
+                phantom.clear();
+            }
+            // simplify life for the Garbage collector by reducing reference counts
+            referenceList.clear();
+        }
+
+        /**
+         * Watch the specified {@link RemoteInvocationHandler} for garbage collection so that it can be unexported
+         * when collected.
+         * 
+         * @param handler the {@link RemoteInvocationHandler} instance to watch.
+         */
+        private void watch(RemoteInvocationHandler handler) {
+            Channel.Ref ref = handler.channel;
+            if (ref == null || ref.channel() == null) {
+                // channel is dead anyway, so we could not send an UnexportCommand even if we wanted to
+                return;
+            }
+            List<PhantomReferenceImpl> referenceList;
+            while (null == (referenceList = referenceLists.get(ref))) {
+                referenceLists.putIfAbsent(ref, Collections.synchronizedList(new ArrayList<PhantomReferenceImpl>()));
+            }
+            referenceList.add(new PhantomReferenceImpl(handler, queue));
+            if (isAlive.get()) {
+                // if already running we are all set and can return
+                return;
+            }
+            // ok, we may need to schedule another execution
+            if (inQueue.compareAndSet(false, true)) {
+                // let's submit... if there are multiple instances in the queue, only one will run at a time
+                // and when it finishes the others will either exit due to and empty referencesList or else
+                // we wanted them running anyway
+                try {
+                    svc.submit(UNEXPORTER);
+                } catch (RejectedExecutionException e) {
+                    // we must be in the process of being shut down
+                }
+            }
+        }
+
+        /**
+         * Stop watching {@link RemoteInvocationHandler} instances for the specified {@link Channel} as it is
+         * terminating/ed.
+         * @param channel the {@link Channel}.
+         */
+        private void onChannelTermination(Channel channel) {
+            cleanList(referenceLists.remove(channel.ref()));
+        }
+    }
+    
     private static final long serialVersionUID = 1L;
 
     /**

--- a/src/main/java/hudson/remoting/RemoteInvocationHandler.java
+++ b/src/main/java/hudson/remoting/RemoteInvocationHandler.java
@@ -170,6 +170,23 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
     }
     
     /**
+     * Returns the backing channel or throws an {@link IOException} if the channel is disconnected or
+     * otherwise unavailable.
+     *
+     * @return the backing channel.
+     * @throws IOException if the channel is disconnected or otherwise unavailable.
+     * @since FIXME after merge
+     */
+    @CheckForNull
+    private Channel channelOrFail() throws IOException {
+        Channel channel = channel();
+        if (channel == null) {
+            throw new IOException("Backing channel is disconnected.");
+        }
+        return channel;
+    }
+
+    /**
      * If the given object is a proxy to a remote object in the specified channel,
      * return its object ID. Otherwise return -1.
      * <p>
@@ -228,11 +245,11 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         RPCRequest req = new RPCRequest(oid, method, args, userProxy ? dc.getClassLoader() : null);
         try {
             if(userProxy) {
-                if (async)  channel().callAsync(req);
-                else        return channel().call(req);
+                if (async)  channelOrFail().callAsync(req);
+                else        return channelOrFail().call(req);
             } else {
-                if (async)  req.callAsync(channel());
-                else        return req.call(channel());
+                if (async)  req.callAsync(channelOrFail());
+                else        return req.call(channelOrFail());
             }
             return null;
         } catch (Throwable e) {

--- a/src/test/java/hudson/remoting/ChannelTest.java
+++ b/src/test/java/hudson/remoting/ChannelTest.java
@@ -70,13 +70,15 @@ public class ChannelTest extends RmiTestBase {
                 // if so, try again. if we kept failing after a number of retries,
                 // then it's highly suspicious that the caller is doing the deallocation,
                 // which is a bug.
+                System.out.println("Bitten by over-eager GC, will retry test");
                 continue;
             }
 
             // now we verify that 'g' gets eventually unexported by remote.
             // to do so, we keep calling System.gc().
             for (int i=0; i<30 && channel.exportedObjects.isExported(g); i++) {
-                channel.call(new GCTask());
+                System.out.println("Attempting to force GC on remote end");
+                channel.call(new GCTask(true));
                 Thread.sleep(100);
             }
 

--- a/src/test/java/hudson/remoting/util/GCTask.java
+++ b/src/test/java/hudson/remoting/util/GCTask.java
@@ -3,12 +3,36 @@ package hudson.remoting.util;
 import hudson.remoting.CallableBase;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author Kohsuke Kawaguchi
  */
 public class GCTask extends CallableBase<Object, IOException> {
+    private final boolean agressive;
+
+    public GCTask() {
+        this(false);
+    }
+
+    public GCTask(boolean agressive) {
+        this.agressive = agressive;
+    }
+
     public Object call() throws IOException {
+        if (agressive) {
+            Set<Object[]> objects = new HashSet<Object[]>();
+            int size = ((int)Math.min(Runtime.getRuntime().freeMemory(), Integer.MAX_VALUE)) / 32;
+            while (true) {
+                try {
+                    objects.add(new Object[size]);
+                } catch (OutOfMemoryError ignore) {
+                    break;
+                }
+            }
+            objects = null;        
+        }
         System.gc();
         return null;
     }


### PR DESCRIPTION
See [JENKINS-28844](https://issues.jenkins-ci.org/browse/JENKINS-28844) 

* In larger installations of Jenkins the complex cycles of object references containing classloaders containing references to the channel which contains references back to the classloaders can confuse the garbage collector.
* The confusion arrises because classloaders are considered live while there are objects from the classloader live
      and the RemoteClassLoader and RemoteInvocationHandler's proxy both need a reference to the Channel
      which typically can be storing either some of the objects from the RemoteClassLoader or
      the RemoteInvocationHandler's proxy instances in the Channel properties. Thus although the entire subgraph
      is no longer live, the cycle is not detected as ClassLoaders are treated separately. The issue is worse in
      Java 7 where the ClassLoaders are on the PermGen heap though it is also present in Java 8.
* Typically multiple out of memory errors can cause the cycle to ultimately get cleaned up as one half
      gets cleared out breaking the cycle enough so that a subsequent out of memory removes the second half leaving
      a third out of memory to clear out the ClassLoaders... but after three out of memory errors in a row, Jenkins
      itself is typically well dead.
    
This PR (I believe) fixes these issues:
* We apply [Wheeler's theorem](http://en.wikipedia.org/wiki/Fundamental_theorem_of_software_engineering) to
      the Channel references. This allows us to clear out the reference instance as soon as the Channel is terminated
      thus simplifying the work of the garbage collector.
* We clear out some unnecessary Channel references that were hiding in ThreadLocals
* We move from using an Object.finalize() implementation to a PhantomReference implementation of the
      unexporting operation. In my experiments the call to Object.finalize() on a running Jenkins instance would
      very often get postponed to almost never, and more critically, the presence of a finalizer means that all
      instances of RemoteInvocationHandler were put in the finalizer queue as opposed to only those that
      need to be tracked for auto unexporting. We can (and do) proactively remove the references from the
      reference queue as soon as the channel is closed, further reducing the work that is required by the
      garbage collector.
* Some other findbugs related fixes and adding a thread name since I copied the naming thread factory to provide a name for the unexporter thread

@reviewbybees (who may want to know that this references ZD-26018)