### PR TITLE
Trying to guide people away from implementing RoleSensitive manually

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/RoleChecker.java
+++ b/src/main/java/org/jenkinsci/remoting/RoleChecker.java
@@ -19,7 +19,7 @@ public abstract class RoleChecker {
     /**
      * Called from {@link RoleSensitive#checkRoles(RoleChecker)} to ensure that this side of the channel
      * is willing to execute {@link Callable}s that expects one of the given roles on their intended recipients.
-     *
+     * <p><strong>If you think you need to implement {@link RoleSensitive#checkRoles}</strong> please reread that method’s Javadoc.
      * <p>
      * Normally, each side of the channel has a fixed set of roles (say {@code actualRoles}),
      * and the implementation would be {@code actualRoles.containsAll(roles)}.

--- a/src/main/java/org/jenkinsci/remoting/RoleSensitive.java
+++ b/src/main/java/org/jenkinsci/remoting/RoleSensitive.java
@@ -23,6 +23,7 @@ public interface RoleSensitive {
      * <p><strong>Do not implement this method</strong> unless you know what you are doing.
      * If you have a Jenkins {@link Callable} or {@code FileCallable}, use the standard abstract base classes instead,
      * such as {@code MasterToSlaveCallable}, {@code MasterToSlaveFileCallable}, {@code NotReallyRoleSensitiveCallable}, etc.
+     * See <a href="https://wiki.jenkins-ci.org/display/JENKINS/Slave+To+Master+Access+Control/#SlaveToMasterAccessControl-I%27maplugindeveloper.WhatshouldIdo%3F">this document</a> for details.
      * @return
      *      If the method returns normally, the check has passed.
      *

--- a/src/main/java/org/jenkinsci/remoting/RoleSensitive.java
+++ b/src/main/java/org/jenkinsci/remoting/RoleSensitive.java
@@ -20,7 +20,9 @@ public interface RoleSensitive {
     /**
      * Verifies the roles expected by this callable by invoking {@link RoleChecker#check(RoleSensitive, Collection)}
      * method (or its variants), to provide an opportunity for {@link RoleChecker} to reject this object.
-     *
+     * <p><strong>Do not implement this method</strong> unless you know what you are doing.
+     * If you have a Jenkins {@link Callable} or {@code FileCallable}, use of the standard abstract base classes instead,
+     * such as {@code MasterToSlaveCallable}, {@code MasterToSlaveFileCallable}, {@code NotReallyRoleSensitiveCallable}, etc.
      * @return
      *      If the method returns normally, the check has passed.
      *

--- a/src/main/java/org/jenkinsci/remoting/RoleSensitive.java
+++ b/src/main/java/org/jenkinsci/remoting/RoleSensitive.java
@@ -21,7 +21,7 @@ public interface RoleSensitive {
      * Verifies the roles expected by this callable by invoking {@link RoleChecker#check(RoleSensitive, Collection)}
      * method (or its variants), to provide an opportunity for {@link RoleChecker} to reject this object.
      * <p><strong>Do not implement this method</strong> unless you know what you are doing.
-     * If you have a Jenkins {@link Callable} or {@code FileCallable}, use of the standard abstract base classes instead,
+     * If you have a Jenkins {@link Callable} or {@code FileCallable}, use the standard abstract base classes instead,
      * such as {@code MasterToSlaveCallable}, {@code MasterToSlaveFileCallable}, {@code NotReallyRoleSensitiveCallable}, etc.
      * @return
      *      If the method returns normally, the check has passed.


### PR DESCRIPTION
After about the seventeenth Jenkins plugin pull request (most recently https://github.com/jenkinsci/analysis-core-plugin/pull/31) featuring something like

```java
@Override
public void checkRoles(RoleChecker checker) throws SecurityException {
    // TODO what do we need to do here?
}
```

I am trying to guide people to the answer, in case they read Javadoc anyway.

(For SECURITY-144 we explicitly decided to introduce `RoleSensitive` despite the source incompatibility, while keeping a binary-compatible runtime behavior, since every plugin author really must decide how a given callable is _intended_ to be used.)

@reviewbybees