### PR TITLE
Thread starvation on close / terminate slaves channel.

### DIFF
--- a/src/main/java/hudson/remoting/PipeWindow.java
+++ b/src/main/java/hudson/remoting/PipeWindow.java
@@ -206,7 +206,7 @@ abstract class PipeWindow {
                     return available;
 
                 while (available<min) {
-                    wait();
+                    wait(100);
                     checkDeath();
                 }
 

--- a/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
@@ -333,7 +333,7 @@ public class FifoBuffer implements Closeable {
 
             synchronized (lock) {
                 while ((chunk = Math.min(len,writable()))==0)
-                    lock.wait();
+                    lock.wait(100);
 
                 w.write(buf, start, chunk);
 


### PR DESCRIPTION
The error happens when starting approximately 100 build jobs with "once only" build executors as used with the mesos plugin. In our scenario we have approximately 20 active build executors, that are disconnected at approximately the same time. During termination of the channels we get the thread starvation described below.

In Example below Lock 0x27a7 was acquired by the thread pool (on the channel), but required by RemoteInvocationHandler and NioChannelHub. The Fifo Buffer / Pipe Window never released the lock in the wait. So i introduced a timeout and this seems to do the trick.

"Computer.threadPoolForRemoting [#1748] for build4G-6G-mesos-70dd9b11-d5f4-43eb-b914-7604285a6e7c@9817" daemon prio=5 tid=0x56ff nid=NA waiting
  java.lang.Thread.State: WAITING
blocks RemoteInvocationHandler [#6]@9927
blocks NioChannelHub keys=4 gen=1027971: Computer.threadPoolForRemoting [#114]@9708
  at java.lang.Object.wait(Object.java:-1)
  at org.jenkinsci.remoting.nio.FifoBuffer.write(FifoBuffer.java:336)
  at org.jenkinsci.remoting.nio.NioChannelHub$NioTransport.writeBlock(NioChannelHub.java:220)
  at hudson.remoting.AbstractByteArrayCommandTransport.write(AbstractByteArrayCommandTransport.java:83)
  at hudson.remoting.Channel.send(Channel.java:579)
  - locked <0x27a7> (a hudson.remoting.Channel)
  at hudson.remoting.ProxyOutputStream.write(ProxyOutputStream.java:141)
  - locked <0x27bb> (a hudson.remoting.ProxyOutputStream)
  at hudson.remoting.RemoteOutputStream.write(RemoteOutputStream.java:110)
  at hudson.remoting.Util.copy(Util.java:43)
  at hudson.remoting.JarLoaderImpl.writeJarTo(JarLoaderImpl.java:37)
  at sun.reflect.GeneratedMethodAccessor187.invoke(Unknown Source:-1)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:606)
  at hudson.remoting.RemoteInvocationHandler$RPCRequest.perform(RemoteInvocationHandler.java:608)
  at hudson.remoting.RemoteInvocationHandler$RPCRequest.call(RemoteInvocationHandler.java:583)
  at hudson.remoting.RemoteInvocationHandler$RPCRequest.call(RemoteInvocationHandler.java:542)
  at hudson.remoting.UserRequest.perform(UserRequest.java:121)
  at hudson.remoting.UserRequest.perform(UserRequest.java:49)
  at hudson.remoting.Request$2.run(Request.java:326)
  at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
  at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
  at java.util.concurrent.FutureTask.run(FutureTask.java:262)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
  at java.lang.Thread.run(Thread.java:745)