### PR TITLE
JENKINS-31510 Filter DiskFileItem with ClassFilter.DEFAULT

### DIFF
--- a/src/main/java/hudson/remoting/ClassFilter.java
+++ b/src/main/java/hudson/remoting/ClassFilter.java
@@ -40,6 +40,8 @@ public abstract class ClassFilter {
                 return true;    // ConvertedClosure is named in exploit
             if (name.startsWith("org.apache.commons.collections.functors."))
                 return true;    // InvokerTransformer, InstantiateFactory, InstantiateTransformer are particularly scary
+            if (name.startsWith("org.apache.commons.fileupload.disk."))
+                return true;    // DiskFileItem can allow arbitrary file write
 
             // this package can appear in ordinary xalan.jar or com.sun.org.apache.xalan
             // the target is trax.TemplatesImpl


### PR DESCRIPTION
With this change Jenkins now filters DiskFileItem (in the lights of JENKINS -159). Once a remoting version with this fix is released, Jenkins needs to be updated, and that will also mean that having a custom commons-fileupload release won't be necessary either.