### PR TITLE
[FIXED JENKINS-31718] Preserve the BufferedInputStream when building the transport

### DIFF
--- a/src/main/java/hudson/remoting/Capability.java
+++ b/src/main/java/hudson/remoting/Capability.java
@@ -1,15 +1,14 @@
 package hudson.remoting;
 
 import hudson.remoting.Channel.Mode;
-
-import java.io.ObjectStreamClass;
-import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
-import java.io.ObjectOutputStream;
-import java.io.OutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
 
 /**
  * Represents additional features implemented on {@link Channel}.
@@ -213,6 +212,69 @@ public final class Capability implements Serializable {
     static final byte[] PREAMBLE;
 
     public static final Capability NONE = new Capability(0);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("Capability{");
+        boolean first = true;
+        if ((mask & MASK_MULTI_CLASSLOADER) != 0) {
+            first = false;
+            sb.append("Multi-ClassLoader RPC");
+        }
+        if ((mask & MASK_PIPE_THROTTLING) != 0) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append("Pipe throttling");
+        }
+        if ((mask & MASK_MIMIC_EXCEPTION) != 0) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append("Mimic Exception");
+        }
+        if ((mask & MASK_PREFETCH) != 0) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append("Prefetch");
+        }
+        if ((mask & GREEDY_REMOTE_INPUTSTREAM) != 0) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append("Greedy RemoteInputStream");
+        }
+        if ((mask & MASK_PROXY_WRITER_2_35) != 0) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append("Proxy writer 2.35");
+        }
+        if ((mask & MASK_CHUNKED_ENCODING) != 0) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append("Chunked encoding");
+        }
+        sb.append('}');
+        return sb.toString();
+    }
 
     static {
         try {

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol.java
@@ -26,12 +26,13 @@ package org.jenkinsci.remoting.engine;
 import hudson.remoting.Channel;
 import hudson.remoting.ChannelBuilder;
 import hudson.remoting.EngineListener;
-
-import javax.annotation.Nullable;
 import java.io.BufferedInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.Socket;
+import javax.annotation.Nullable;
 
 /**
  * Handshake protocol used by JNLP slave when initiating a connection to
@@ -74,7 +75,7 @@ public abstract class JnlpProtocol {
         DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream());
         BufferedInputStream inputStream = new BufferedInputStream(socket.getInputStream());
         if(performHandshake(outputStream, inputStream)) {
-            return buildChannel(socket, channelBuilder);
+            return buildChannel(socket, channelBuilder, inputStream);
         }
 
         return null;
@@ -96,9 +97,12 @@ public abstract class JnlpProtocol {
      *
      * @param socket The established {@link Socket} connection to the master.
      * @param channelBuilder The {@link ChannelBuilder} to use.
+     * @param inputStream The {@link BufferedInputStream} of {@link Socket#getInputStream()} or {@code null} if there
+     *                    is none (TODO remove the null possibility).
      * @return The constructed channel
      */
-    abstract Channel buildChannel(Socket socket, ChannelBuilder channelBuilder) throws IOException;
+    abstract Channel buildChannel(Socket socket, ChannelBuilder channelBuilder,
+                                  BufferedInputStream inputStream) throws IOException;
 
     // The expected response from the master on successful completion of the
     // handshake.

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol1.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol1.java
@@ -75,9 +75,9 @@ class JnlpProtocol1 extends JnlpProtocol {
     }
 
     @Override
-    Channel buildChannel(Socket socket, ChannelBuilder channelBuilder) throws IOException {
+    Channel buildChannel(Socket socket, ChannelBuilder channelBuilder, BufferedInputStream inputStream) throws IOException {
         return channelBuilder.build(
-                new BufferedInputStream(socket.getInputStream()),
+                inputStream == null ? new BufferedInputStream(socket.getInputStream()) : inputStream, // TODO drop null
                 new BufferedOutputStream(socket.getOutputStream()));
     }
 

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol1.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol1.java
@@ -76,9 +76,7 @@ class JnlpProtocol1 extends JnlpProtocol {
 
     @Override
     Channel buildChannel(Socket socket, ChannelBuilder channelBuilder, BufferedInputStream inputStream) throws IOException {
-        return channelBuilder.build(
-                inputStream == null ? new BufferedInputStream(socket.getInputStream()) : inputStream, // TODO drop null
-                new BufferedOutputStream(socket.getOutputStream()));
+        return channelBuilder.build(inputStream, new BufferedOutputStream(socket.getOutputStream()));
     }
 
     static final String NAME = "JNLP-connect";

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol2.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol2.java
@@ -90,9 +90,7 @@ class JnlpProtocol2 extends JnlpProtocol {
 
     @Override
     Channel buildChannel(Socket socket, ChannelBuilder channelBuilder, BufferedInputStream inputStream) throws IOException {
-        return channelBuilder.build(
-                inputStream == null ? new BufferedInputStream(socket.getInputStream()) : inputStream, // TODO drop null
-                new BufferedOutputStream(socket.getOutputStream()));
+        return channelBuilder.build(inputStream, new BufferedOutputStream(socket.getOutputStream()));
     }
 
     private void initiateHandshake(DataOutputStream outputStream) throws IOException {

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol2.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol2.java
@@ -89,9 +89,9 @@ class JnlpProtocol2 extends JnlpProtocol {
     }
 
     @Override
-    Channel buildChannel(Socket socket, ChannelBuilder channelBuilder) throws IOException {
+    Channel buildChannel(Socket socket, ChannelBuilder channelBuilder, BufferedInputStream inputStream) throws IOException {
         return channelBuilder.build(
-                new BufferedInputStream(socket.getInputStream()),
+                inputStream == null ? new BufferedInputStream(socket.getInputStream()) : inputStream, // TODO drop null
                 new BufferedOutputStream(socket.getOutputStream()));
     }
 

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol3.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol3.java
@@ -159,9 +159,7 @@ class JnlpProtocol3 extends JnlpProtocol {
     @Override
     Channel buildChannel(Socket socket, ChannelBuilder channelBuilder, BufferedInputStream inputStream) throws IOException {
         return channelBuilder.build(
-                new CipherInputStream(
-                        inputStream == null ? socket.getInputStream() : inputStream, // TODO drop null
-                        channelCiphers.getDecryptCipher()),
+                new CipherInputStream(inputStream, channelCiphers.getDecryptCipher()),
                 new CipherOutputStream(socket.getOutputStream(), channelCiphers.getEncryptCipher())
         );
     }

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol3.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol3.java
@@ -157,9 +157,11 @@ class JnlpProtocol3 extends JnlpProtocol {
     }
 
     @Override
-    Channel buildChannel(Socket socket, ChannelBuilder channelBuilder) throws IOException {
+    Channel buildChannel(Socket socket, ChannelBuilder channelBuilder, BufferedInputStream inputStream) throws IOException {
         return channelBuilder.build(
-                new CipherInputStream(socket.getInputStream(), channelCiphers.getDecryptCipher()),
+                new CipherInputStream(
+                        inputStream == null ? socket.getInputStream() : inputStream, // TODO drop null
+                        channelCiphers.getDecryptCipher()),
                 new CipherOutputStream(socket.getOutputStream(), channelCiphers.getEncryptCipher())
         );
     }

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol1Test.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol1Test.java
@@ -114,9 +114,8 @@ public class JnlpProtocol1Test {
         when(mockSocket.getOutputStream()).thenReturn(mockOutputStream);
         when(mockSocket.getInputStream()).thenReturn(mockInputStream);
         whenNew(BufferedOutputStream.class).withArguments(mockOutputStream).thenReturn(mockBufferedOutputStream);
-        whenNew(BufferedInputStream.class).withArguments(mockInputStream).thenReturn(mockBufferedInputStream);
         when(mockChannelBuilder.build(mockBufferedInputStream, mockBufferedOutputStream)).thenReturn(mockChannel);
 
-        assertSame(mockChannel, protocol.buildChannel(mockSocket, mockChannelBuilder, null));
+        assertSame(mockChannel, protocol.buildChannel(mockSocket, mockChannelBuilder, mockBufferedInputStream));
     }
 }

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol1Test.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol1Test.java
@@ -117,6 +117,6 @@ public class JnlpProtocol1Test {
         whenNew(BufferedInputStream.class).withArguments(mockInputStream).thenReturn(mockBufferedInputStream);
         when(mockChannelBuilder.build(mockBufferedInputStream, mockBufferedOutputStream)).thenReturn(mockChannel);
 
-        assertSame(mockChannel, protocol.buildChannel(mockSocket, mockChannelBuilder));
+        assertSame(mockChannel, protocol.buildChannel(mockSocket, mockChannelBuilder, null));
     }
 }

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol2Test.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol2Test.java
@@ -181,6 +181,6 @@ public class JnlpProtocol2Test {
         whenNew(BufferedInputStream.class).withArguments(mockInputStream).thenReturn(mockBufferedInputStream);
         when(mockChannelBuilder.build(mockBufferedInputStream, mockBufferedOutputStream)).thenReturn(mockChannel);
 
-        assertSame(mockChannel, protocol.buildChannel(mockSocket, mockChannelBuilder));
+        assertSame(mockChannel, protocol.buildChannel(mockSocket, mockChannelBuilder, null));
     }
 }

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol2Test.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol2Test.java
@@ -178,9 +178,8 @@ public class JnlpProtocol2Test {
         when(mockSocket.getOutputStream()).thenReturn(mockOutputStream);
         when(mockSocket.getInputStream()).thenReturn(mockInputStream);
         whenNew(BufferedOutputStream.class).withArguments(mockOutputStream).thenReturn(mockBufferedOutputStream);
-        whenNew(BufferedInputStream.class).withArguments(mockInputStream).thenReturn(mockBufferedInputStream);
         when(mockChannelBuilder.build(mockBufferedInputStream, mockBufferedOutputStream)).thenReturn(mockChannel);
 
-        assertSame(mockChannel, protocol.buildChannel(mockSocket, mockChannelBuilder, null));
+        assertSame(mockChannel, protocol.buildChannel(mockSocket, mockChannelBuilder, mockBufferedInputStream));
     }
 }

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol3Test.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol3Test.java
@@ -287,6 +287,6 @@ public class JnlpProtocol3Test {
         when(mockChannelBuilder.build(mockCipherInputStream, mockCipherOutputStream))
                 .thenReturn(mockChannel);
 
-        assertSame(mockChannel, protocol.buildChannel(mockSocket, mockChannelBuilder));
+        assertSame(mockChannel, protocol.buildChannel(mockSocket, mockChannelBuilder, null));
     }
 }

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol3Test.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol3Test.java
@@ -282,11 +282,11 @@ public class JnlpProtocol3Test {
                 .withArguments(mockOutputStream, protocol.getChannelCiphers().getEncryptCipher())
                 .thenReturn(mockCipherOutputStream);
         whenNew(CipherInputStream.class)
-                .withArguments(mockInputStream, protocol.getChannelCiphers().getDecryptCipher())
+                .withArguments(mockBufferedInputStream, protocol.getChannelCiphers().getDecryptCipher())
                 .thenReturn(mockCipherInputStream);
         when(mockChannelBuilder.build(mockCipherInputStream, mockCipherOutputStream))
                 .thenReturn(mockChannel);
 
-        assertSame(mockChannel, protocol.buildChannel(mockSocket, mockChannelBuilder, null));
+        assertSame(mockChannel, protocol.buildChannel(mockSocket, mockChannelBuilder, mockBufferedInputStream));
     }
 }

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocolTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocolTest.java
@@ -80,7 +80,7 @@ public class JnlpProtocolTest {
     @Test
     public void testHandshakeSucceeds() throws Exception {
         when(mockProtocol.performHandshake(mockDataOutputStream, mockBufferedInputStream)).thenReturn(true);
-        when(mockProtocol.buildChannel(mockSocket, mockChannelBuilder, null)).thenReturn(mockChannel);
+        when(mockProtocol.buildChannel(mockSocket, mockChannelBuilder, mockBufferedInputStream)).thenReturn(mockChannel);
 
         assertSame(mockChannel, mockProtocol.establishChannel(mockSocket, mockChannelBuilder));
     }

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocolTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocolTest.java
@@ -80,7 +80,7 @@ public class JnlpProtocolTest {
     @Test
     public void testHandshakeSucceeds() throws Exception {
         when(mockProtocol.performHandshake(mockDataOutputStream, mockBufferedInputStream)).thenReturn(true);
-        when(mockProtocol.buildChannel(mockSocket, mockChannelBuilder)).thenReturn(mockChannel);
+        when(mockProtocol.buildChannel(mockSocket, mockChannelBuilder, null)).thenReturn(mockChannel);
 
         assertSame(mockChannel, mockProtocol.establishChannel(mockSocket, mockChannelBuilder));
     }


### PR DESCRIPTION
- Most likely some non-mock based tests would be better and likely would have caught this regression sooner.

See [JENKINS-31718](https://issues.jenkins-ci.org/browse/JENKINS-31718)

@reviewbybees @oleg-nenashev 