### PR TITLE
Allow user to adjust socket timeout

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -388,7 +388,7 @@ public class Engine extends Thread {
                 // to interfere with normal operation. the main purpose of this is that when the other peer dies
                 // abruptly, we shouldn't hang forever, and at some point we should notice that the connection
                 // is gone.
-                s.setSoTimeout(30*60*1000); // 30 mins. See PingThread for the ping interval
+                s.setSoTimeout(SOCKET_TIMEOUT); // default is 30 mins. See PingThread for the ping interval
 
                 if (isHttpProxy) {
                     String connectCommand = String.format("CONNECT %s:%s HTTP/1.1\r\nHost: %s\r\n\r\n", host, port, host);
@@ -561,7 +561,8 @@ public class Engine extends Thread {
             }
         });
     }
-
+    //a read() call on the SocketInputStream associated with underlying Socket will block for only this amount of time
+    static final int SOCKET_TIMEOUT = Integer.getInteger(Engine.class.getName()+".socketTimeout",30*60*1000);
     /**
      * @deprecated Use {@link JnlpProtocol#GREETING_SUCCESS}.
      */


### PR DESCRIPTION
we encounter slave offline issue when executing commands like 
`
sleep 40m
`
on jnlp agent, the socket read timeout is hard coded to 30 minutes and caused the issue
