### PR TITLE
[JENKINS-32825] Deadlock in Channel Abort

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
@@ -332,8 +332,12 @@ public class FifoBuffer implements Closeable {
             int chunk;
 
             synchronized (lock) {
-                while ((chunk = Math.min(len,writable()))==0)
+                while ((chunk = Math.min(len,writable()))==0) {
+                    if (closed)
+                        throw new IOException("closed during write operation");
+
                     lock.wait(100);
+                }
 
                 w.write(buf, start, chunk);
 


### PR DESCRIPTION
See [JENKINS-32925](https://issues.jenkins-ci.org/browse/JENKINS-32825)

Additional `closed` state check introduced to break writing loop.

@reviewbybees