### PR TITLE
Don't try to close a socket that is already closed

### DIFF
--- a/src/main/java/hudson/remoting/SocketInputStream.java
+++ b/src/main/java/hudson/remoting/SocketInputStream.java
@@ -53,8 +53,14 @@ public class SocketInputStream extends FilterInputStream {
 
     @Override
     public void close() throws IOException {
-        socket.shutdownInput();
-        if (socket.isOutputShutdown())
+        if (socket.isClosed()) {
+            return;
+        }
+        if (!socket.isInputShutdown()) {
+            socket.shutdownInput();
+        }
+        if (socket.isOutputShutdown()) {
             socket.close();
+        }
     }
 }

--- a/src/main/java/hudson/remoting/SocketOutputStream.java
+++ b/src/main/java/hudson/remoting/SocketOutputStream.java
@@ -65,8 +65,14 @@ public class SocketOutputStream extends FilterOutputStream {
 
     @Override
     public void close() throws IOException {
-        socket.shutdownOutput();
-        if (socket.isInputShutdown())
+        if (socket.isClosed()) {
+            return;
+        }
+        if (!socket.isOutputShutdown()) {
+            socket.shutdownOutput();
+        }
+        if (socket.isInputShutdown()) {
             socket.close();
+        }
     }
 }


### PR DESCRIPTION
@reviewbybees

Spotted this one while doing some testing. Getting exceptions like

```
Mar 03, 2016 5:22:19 PM hudson.remoting.Channel terminate
WARNING: Failed to close down the reader side of the transport
java.net.SocketException: Socket is closed
	at java.net.Socket.shutdownInput(Socket.java:1514)
	at hudson.remoting.SocketInputStream.close(SocketInputStream.java:56)
	at java.io.BufferedInputStream.close(BufferedInputStream.java:483)
	at hudson.remoting.FlightRecorderInputStream.close(FlightRecorderInputStream.java:112)
	at hudson.remoting.ChunkedInputStream.close(ChunkedInputStream.java:113)
	at hudson.remoting.ChunkedCommandTransport.closeRead(ChunkedCommandTransport.java:56)
	at hudson.remoting.Channel.terminate(Channel.java:837)
	at hudson.remoting.Channel$CloseCommand.execute(Channel.java:1077)
	at hudson.remoting.Channel$1.handle(Channel.java:498)
	at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:60)
```

reported in the logs for cases where both sides of the channel are closed normally