### PR TITLE
Dont try to handle empty packets

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
@@ -588,12 +588,13 @@ public class NioChannelHub implements Runnable, Closeable {
                                             r_ptr+=chunk;
                                         } while (!last);
                                         assert packetSize==0;
-
-                                        t.swimLane.submit(new Runnable() {
-                                            public void run() {
-                                                t.receiver.handle(packet);
-                                            }
-                                        });
+                                        if (packet.length > 0) {
+                                            t.swimLane.submit(new Runnable() {
+                                                public void run() {
+                                                    t.receiver.handle(packet);
+                                                }
+                                            });
+                                        }
                                         pos=0;
                                     }
                                 }


### PR DESCRIPTION
@reviewbybees

Caught this one while testing...

```
Mar 03, 2016 5:39:32 PM hudson.remoting.AbstractByteArrayCommandTransport$1 handle
WARNING: Failed to construct Command
java.io.EOFException
	at java.io.ObjectInputStream$PeekInputStream.readFully(ObjectInputStream.java:2328)
	at java.io.ObjectInputStream$BlockDataInputStream.readShort(ObjectInputStream.java:2797)
	at java.io.ObjectInputStream.readStreamHeader(ObjectInputStream.java:802)
	at java.io.ObjectInputStream.<init>(ObjectInputStream.java:299)
	at hudson.remoting.ObjectInputStreamEx.<init>(ObjectInputStreamEx.java:48)
	at hudson.remoting.AbstractByteArrayCommandTransport$1.handle(AbstractByteArrayCommandTransport.java:61)
	at org.jenkinsci.remoting.nio.NioChannelHub$2.run(NioChannelHub.java:594)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```