### PR TITLE
Need a line with known text to find failures

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol.java
@@ -85,7 +85,11 @@ public abstract class JnlpProtocol {
      * Performs a handshake with the master.
      *
      * @param outputStream The stream to write into to initiate the handshake.
-     * @param inputStream The stream to read responses from the master.
+     * @param inputStream
+     *      The stream to read responses from the master.
+     *      If the server doesn't understand the protocol, the first line it sends to the client is
+     *      an error message in one line, so a protocol should send a known success message
+     *      (like {@link #GREETING_SUCCESS}) to help differentiate here.
      * @return true iff handshake was successful.
      * @throws IOException
      */

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol3.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol3.java
@@ -181,6 +181,12 @@ class JnlpProtocol3 extends JnlpProtocol {
         outputStream.writeUTF(PROTOCOL_PREFIX + NAME);
         outputStream.writeUTF(o.toString("UTF-8"));
 
+        String protocolUnderstoodResponse = readLine(inputStream);
+        if (!protocolUnderstoodResponse.equals(NEGOTIATE_LINE)) {
+            events.status("Server didn't accept the handshake: " + protocolUnderstoodResponse);
+            return false;   // the server didn't understand the protocol
+        }
+
         // Validate challenge response.
         Integer challengeResponseLength = Integer.parseInt(readLine(inputStream));
         String encryptedChallengeResponse = readChars(inputStream, challengeResponseLength);
@@ -218,4 +224,11 @@ class JnlpProtocol3 extends JnlpProtocol {
     public static final String COOKIE_KEY = "Cookie";
     public static final String NAME = "JNLP3-connect";
     public static final String SLAVE_NAME_KEY = "Node-Name";
+
+    /**
+     * If we talk to the server who doesn't understand this protocol, it sends out
+     * an error message line, so to distinguish those we need another line that
+     * indicates the protocol is understood by the server.
+     */
+    /*package*/ static final String NEGOTIATE_LINE = "Negotiate";
 }

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpServer3Handshake.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpServer3Handshake.java
@@ -46,6 +46,8 @@ public abstract class JnlpServer3Handshake extends JnlpServerHandshake {
      */
     public Channel connect() throws IOException, InterruptedException {
         try {
+            out.println(JnlpProtocol3.NEGOTIATE_LINE);
+
             // Get initiation information from slave.
             request.load(new ByteArrayInputStream(in.readUTF().getBytes(Charset.forName("UTF-8"))));
             nodeName = request.getProperty(JnlpProtocol3.SLAVE_NAME_KEY);

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol3Test.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocol3Test.java
@@ -133,6 +133,7 @@ public class JnlpProtocol3Test {
 
         when(Jnlp3Util.generateChallenge()).thenReturn("challenge");
         when(EngineUtil.readLine(mockBufferedInputStream))
+                .thenReturn(JnlpProtocol3.NEGOTIATE_LINE)
                 .thenReturn("10")
                 .thenReturn("15")
                 .thenReturn("error");
@@ -162,6 +163,7 @@ public class JnlpProtocol3Test {
 
         when(Jnlp3Util.generateChallenge()).thenReturn("challenge");
         when(EngineUtil.readLine(mockBufferedInputStream))
+                .thenReturn(JnlpProtocol3.NEGOTIATE_LINE)
                 .thenReturn("10")
                 .thenReturn("15")
                 .thenReturn(JnlpProtocol.GREETING_SUCCESS)
@@ -209,10 +211,12 @@ public class JnlpProtocol3Test {
                 .thenReturn("challenge1")
                 .thenReturn("challenge2");
         when(EngineUtil.readLine(mockBufferedInputStream))
+                .thenReturn(JnlpProtocol3.NEGOTIATE_LINE)
                 .thenReturn("10")
                 .thenReturn("15")
                 .thenReturn(JnlpProtocol.GREETING_SUCCESS)
                 .thenReturn(handshakeCiphers.encrypt(COOKIE))
+                .thenReturn(JnlpProtocol3.NEGOTIATE_LINE)
                 .thenReturn("20")
                 .thenReturn("25")
                 .thenReturn(JnlpProtocol.GREETING_SUCCESS)
@@ -259,6 +263,7 @@ public class JnlpProtocol3Test {
     public void testBuildChannel() throws Exception {
         when(Jnlp3Util.generateChallenge()).thenReturn("challenge");
         when(EngineUtil.readLine(mockBufferedInputStream))
+                .thenReturn(JnlpProtocol3.NEGOTIATE_LINE)
                 .thenReturn("10")
                 .thenReturn("15")
                 .thenReturn(JnlpProtocol.GREETING_SUCCESS)


### PR DESCRIPTION
Server who doesn't understand the JNLP3 protocol sends us a line like
"Unknown protocol:....", whereas the protocol expects an integer.
This results in the following exception:

    SEVERE: For input string: "Unknown protocol:Protocol:JNLP3-connect"
    java.lang.NumberFormatException: For input string: "Unknown protocol:Protocol:JNLP3-connect"
            at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
            at java.lang.Integer.parseInt(Integer.java:492)
            at java.lang.Integer.parseInt(Integer.java:527)
            at org.jenkinsci.remoting.engine.JnlpProtocol3.initiateAndValidateMaster(JnlpProtocol3.java:185)
            at org.jenkinsci.remoting.engine.JnlpProtocol3.performHandshake(JnlpProtocol3.java:141)
            at org.jenkinsci.remoting.engine.JnlpProtocol.establishChannel(JnlpProtocol.java:77)
            at hudson.remoting.Engine.run(Engine.java:308)

To gracefully handle this, we need JNLP3 protocol to send a known line
so that the client can easily distinguish a successful start of the
authentication/negotiation against a downright rejection. I'e added
the "Negotiate\n" line to do this here.

In JNLP1 and JNLP2, the first response thta the server sends is GREETING_SUCCESS,
so this problem doesn't apply. JNLP3 is the first protocol that requires
some back & forth, which revealed this hidden assumption.

Calling out @akshayabd and  @reviewbybees 