### PR TITLE
[JENKINS-33999] Do not blacklist Spring’s Exceptions

### DIFF
--- a/src/main/java/hudson/remoting/ClassFilter.java
+++ b/src/main/java/hudson/remoting/ClassFilter.java
@@ -60,7 +60,7 @@ public abstract class ClassFilter {
         ".*org[.]apache[.]xalan.*",
         "^org[.]codehaus[.]groovy[.]runtime[.].*",
         "^org[.]hibernate[.].*",
-        "^org[.]springframework[.].*",
+        "^org[.]springframework[.](?!core[.]NestedRuntimeException$).*",
         "^sun[.]rmi[.].*",
     };
 

--- a/src/main/java/hudson/remoting/ClassFilter.java
+++ b/src/main/java/hudson/remoting/ClassFilter.java
@@ -60,7 +60,7 @@ public abstract class ClassFilter {
         ".*org[.]apache[.]xalan.*",
         "^org[.]codehaus[.]groovy[.]runtime[.].*",
         "^org[.]hibernate[.].*",
-        "^org[.]springframework[.](?!core[.]NestedRuntimeException$).*",
+        "^org[.]springframework[.](?!(\\p{Alnum}+[.])*\\p{Alnum}*Exception$).*",
         "^sun[.]rmi[.].*",
     };
 

--- a/src/test/java/hudson/remoting/DefaultClassFilterTest.java
+++ b/src/test/java/hudson/remoting/DefaultClassFilterTest.java
@@ -49,10 +49,11 @@ public class DefaultClassFilterTest {
     private static final List<String> defaultBadClasses = Arrays.asList("org.codehaus.groovy.runtime.Bob",
                                     "org.apache.commons.collections.functors.Wibble", "org.apache.xalan.Bogus",
                                     "com.sun.org.apache.xalan.bogus", "org.springframework.core.SomeClass", 
-                                    "org.springframework.SomeClass");
+                                    "org.springframework.wibble.ExceptionHandler");
     /** Some classes that should not be matched by the default class filter */
     private static final List<String> defaultOKClasses = Arrays.asList("java.lang.String", "java.lang.Object",
-                                    "java.util.ArrayList", "org.springframework.core.NestedRuntimeException");
+                                    "java.util.ArrayList", "org.springframework.core.NestedRuntimeException",
+                                    "org.springframework.a.b.c.yada.SomeSuperException");
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();

--- a/src/test/java/hudson/remoting/DefaultClassFilterTest.java
+++ b/src/test/java/hudson/remoting/DefaultClassFilterTest.java
@@ -48,10 +48,11 @@ public class DefaultClassFilterTest {
     /** Some classes that should be matched by the default class filter */
     private static final List<String> defaultBadClasses = Arrays.asList("org.codehaus.groovy.runtime.Bob",
                                     "org.apache.commons.collections.functors.Wibble", "org.apache.xalan.Bogus",
-                                    "com.sun.org.apache.xalan.bogus");
+                                    "com.sun.org.apache.xalan.bogus", "org.springframework.core.SomeClass", 
+                                    "org.springframework.SomeClass");
     /** Some classes that should not be matched by the default class filter */
     private static final List<String> defaultOKClasses = Arrays.asList("java.lang.String", "java.lang.Object",
-                                    "java.util.ArrayList");
+                                    "java.util.ArrayList", "org.springframework.core.NestedRuntimeException");
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();


### PR DESCRIPTION
`NestedRuntimeException` and others needs to be propagated across remoting for things
like remote authentication schemes.

@reviewbybees
[JENKINS-33999](https://issues.jenkins-ci.org/browse/JENKINS-33999)