### PR TITLE
Ensure a message is logged if we can not create an override

### DIFF
--- a/src/main/java/hudson/remoting/ClassFilter.java
+++ b/src/main/java/hudson/remoting/ClassFilter.java
@@ -81,8 +81,8 @@ public abstract class ClassFilter {
      * values provide for user specified overrides - see {@link #FILE_OVERRIDE_LOCATION_PROPERTY}.
      */
     /*package*/ static ClassFilter createDefaultInstance() {
-        List<Pattern> patternOverride = loadPatternOverride();
         try {
+            List<Pattern> patternOverride = loadPatternOverride();
             if (patternOverride != null) {
                 LOGGER.log(Level.FINE, "Using user specified overrides for class blacklisting");
                 return new RegExpClassFilter(patternOverride);

--- a/src/main/java/hudson/remoting/ClassFilter.java
+++ b/src/main/java/hudson/remoting/ClassFilter.java
@@ -82,12 +82,19 @@ public abstract class ClassFilter {
      */
     /*package*/ static ClassFilter createDefaultInstance() {
         List<Pattern> patternOverride = loadPatternOverride();
-        if (patternOverride != null) {
-            LOGGER.log(Level.FINE, "Using user specified overrides for class blacklisting");
-            return new RegExpClassFilter(patternOverride);
-        } else {
-            LOGGER.log(Level.FINE, "Using default in built class blacklisting");
-            return new RegExpClassFilter(DEFAULT_PATTERNS);
+        try {
+            if (patternOverride != null) {
+                LOGGER.log(Level.FINE, "Using user specified overrides for class blacklisting");
+                return new RegExpClassFilter(patternOverride);
+            } else {
+                LOGGER.log(Level.FINE, "Using default in built class blacklisting");
+                return new RegExpClassFilter(DEFAULT_PATTERNS);
+            }
+        }
+        catch (Error e) {
+            // when being used by something like XStream the actual cause gets swallowed
+            LOGGER.log(Level.SEVERE, "Failed to initialize the default class filter", e);
+            throw e;
         }
     }
 


### PR DESCRIPTION
If the first access of the ClassFilter is from a class being auto wired
then the root cause of the Issue can get swallowed and it is not clear in
the logs what is wrong.  So if something goes wrong always log the error
at the expense that it gets logged twice (which is not a bad thing as it
is fatal anyway and will cause Jenkins to pretty much not work at all)

@reviewbybees