### PR TITLE
Force class load on UserRequest, see JENKINS-19445

### DIFF
--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -118,7 +118,7 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<
                 final Logger logger = Logger.getLogger(RemoteClassLoader.class.getName());
                 if( logger.isLoggable(logLevel) )
                 {
-                    logger.log(logLevel, "%s class '%s' using classloader: %s", eventMsg, clazz, cl.toString());
+                    logger.log(logLevel, "%s class '%s' using classloader: %s", new String[]{ eventMsg, clazz, cl.toString()} );
                 }
             }
 


### PR DESCRIPTION
This is a workaround to force class load of any class. This helps prevent deadlock on windows nodes when using JNA and Subversion.
Use property hudson.remoting.RemoteClassLoader.force to name the class to load. Ideally this forced load should happen earlier on the startup, however the classloader isn't available.
link: https://issues.jenkins-ci.org/browse/JENKINS-19445