### PR TITLE
[JENKINS-31256] Use credentials in waitForServerToBack

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -182,7 +182,7 @@ public class Engine extends Thread {
                     // find out the TCP port
                     HttpURLConnection con = (HttpURLConnection)Util.openURLConnection(salURL);
                     if (credentials != null) {
-                        // TODO /tcpSlaveAgentListener is unprotected so why do we need to pass any credentials?
+                        // Pass credentials to support running Jenkins behind a (reverse) proxy requiring authorization
                         String encoding = Base64.encode(credentials.getBytes("UTF-8"));
                         con.setRequestProperty("Authorization", "Basic " + encoding);
                     }
@@ -372,7 +372,17 @@ public class Engine extends Thread {
                     retries++;
                     t.setName(oldName+": trying "+url+" for "+retries+" times");
 
-                    HttpURLConnection con = (HttpURLConnection) url.openConnection();
+                    HttpURLConnection con = (HttpURLConnection)Util.openURLConnection(url);
+                    if (credentials != null) {
+                        // Pass credentials to support running Jenkins behind a (reverse) proxy requiring authorization
+                        String encoding = Base64.encode(credentials.getBytes("UTF-8"));
+                        con.setRequestProperty("Authorization", "Basic " + encoding);
+                    }
+
+                    if (proxyCredentials != null) {
+                        String encoding = Base64.encode(proxyCredentials.getBytes("UTF-8"));
+                        con.setRequestProperty("Proxy-Authorization", "Basic " + encoding);
+                    }
                     con.setConnectTimeout(5000);
                     con.setReadTimeout(5000);
                     con.connect();

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -180,17 +180,7 @@ public class Engine extends Thread {
                     URL salURL = new URL(s+"tcpSlaveAgentListener/");
 
                     // find out the TCP port
-                    HttpURLConnection con = (HttpURLConnection)Util.openURLConnection(salURL);
-                    if (credentials != null) {
-                        // Pass credentials to support running Jenkins behind a (reverse) proxy requiring authorization
-                        String encoding = Base64.encode(credentials.getBytes("UTF-8"));
-                        con.setRequestProperty("Authorization", "Basic " + encoding);
-                    }
-
-                    if (proxyCredentials != null) {
-                        String encoding = Base64.encode(proxyCredentials.getBytes("UTF-8"));
-                        con.setRequestProperty("Proxy-Authorization", "Basic " + encoding);
-                    }
+                    HttpURLConnection con = (HttpURLConnection)Util.openURLConnection(salURL, credentials, proxyCredentials);
                     try {
                         try {
                             con.setConnectTimeout(30000);
@@ -372,17 +362,7 @@ public class Engine extends Thread {
                     retries++;
                     t.setName(oldName+": trying "+url+" for "+retries+" times");
 
-                    HttpURLConnection con = (HttpURLConnection)Util.openURLConnection(url);
-                    if (credentials != null) {
-                        // Pass credentials to support running Jenkins behind a (reverse) proxy requiring authorization
-                        String encoding = Base64.encode(credentials.getBytes("UTF-8"));
-                        con.setRequestProperty("Authorization", "Basic " + encoding);
-                    }
-
-                    if (proxyCredentials != null) {
-                        String encoding = Base64.encode(proxyCredentials.getBytes("UTF-8"));
-                        con.setRequestProperty("Proxy-Authorization", "Basic " + encoding);
-                    }
+                    HttpURLConnection con = (HttpURLConnection)Util.openURLConnection(url, credentials, proxyCredentials);
                     con.setConnectTimeout(5000);
                     con.setReadTimeout(5000);
                     con.connect();

--- a/src/main/java/hudson/remoting/Util.java
+++ b/src/main/java/hudson/remoting/Util.java
@@ -14,6 +14,8 @@ import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.SocketAddress;
 import java.net.URL;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
 import java.util.Iterator;
 
 /**
@@ -112,7 +114,7 @@ class Util {
      * If http_proxy environment variable exists,  the connection uses the proxy.
      * Credentials can be passed e.g. to support running Jenkins behind a (reverse) proxy requiring authorization
      */
-    static URLConnection openURLConnection(URL url, String credentials, String proxyCredentials) throws IOException {
+    static URLConnection openURLConnection(URL url, String credentials, String proxyCredentials, SSLSocketFactory sslSocketFactory) throws IOException {
         String httpProxy = null;
         // If http.proxyHost property exists, openConnection() uses it.
         if (System.getProperty("http.proxyHost") == null) {
@@ -140,7 +142,19 @@ class Util {
             String encoding = Base64.encode(proxyCredentials.getBytes("UTF-8"));
             con.setRequestProperty("Proxy-Authorization", "Basic " + encoding);
         }
+        if (con instanceof HttpsURLConnection && sslSocketFactory != null) {
+            ((HttpsURLConnection) con).setSSLSocketFactory(sslSocketFactory);
+        }
         return con;
+    }
+
+    /**
+     * Gets URL connection.
+     * If http_proxy environment variable exists,  the connection uses the proxy.
+     * Credentials can be passed e.g. to support running Jenkins behind a (reverse) proxy requiring authorization
+     */
+    static URLConnection openURLConnection(URL url, String credentials, String proxyCredentials) throws IOException {
+        return openURLConnection(url, credentials, proxyCredentials, null);
     }
 
     /**
@@ -148,7 +162,7 @@ class Util {
      * If http_proxy environment variable exists,  the connection uses the proxy.
      */
     static URLConnection openURLConnection(URL url) throws IOException {
-        return openURLConnection(url, null, null);
+        return openURLConnection(url, null, null, null);
     }
 
     static InetSocketAddress getResolvedHttpProxyAddress(String host, int port) throws IOException {

--- a/src/main/java/hudson/remoting/Util.java
+++ b/src/main/java/hudson/remoting/Util.java
@@ -110,8 +110,9 @@ class Util {
     /**
      * Gets URL connection.
      * If http_proxy environment variable exists,  the connection uses the proxy.
+     * Credentials can be passed e.g. to support running Jenkins behind a (reverse) proxy requiring authorization
      */
-    static URLConnection openURLConnection(URL url) throws IOException {
+    static URLConnection openURLConnection(URL url, String credentials, String proxyCredentials) throws IOException {
         String httpProxy = null;
         // If http.proxyHost property exists, openConnection() uses it.
         if (System.getProperty("http.proxyHost") == null) {
@@ -131,7 +132,23 @@ class Util {
         } else {
             con = url.openConnection();
         }
+        if (credentials != null) {
+            String encoding = Base64.encode(credentials.getBytes("UTF-8"));
+            con.setRequestProperty("Authorization", "Basic " + encoding);
+        }
+        if (proxyCredentials != null) {
+            String encoding = Base64.encode(proxyCredentials.getBytes("UTF-8"));
+            con.setRequestProperty("Proxy-Authorization", "Basic " + encoding);
+        }
         return con;
+    }
+
+    /**
+     * Gets URL connection.
+     * If http_proxy environment variable exists,  the connection uses the proxy.
+     */
+    static URLConnection openURLConnection(URL url) throws IOException {
+        return openURLConnection(url, null, null);
     }
 
     static InetSocketAddress getResolvedHttpProxyAddress(String host, int port) throws IOException {


### PR DESCRIPTION
It's a follow-up to #67 

> This patch addresses three regressions introduced with HUDSON-4071, 662b0f and JENKINS-6167 as these only modified run() resulting in no proxy and no authorization support in waitForServerToBack()

> As a result the connection to the master could not be reestablished as connections were rejected with response code 401 as reported in JENKINS-31256.

https://issues.jenkins-ci.org/browse/JENKINS-31256

CC @wiizzard @reviewbybees