### PR TITLE
[FIXED JENKINS-36991] Do not give up on classloading if loading is interrupted

### DIFF
--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -234,6 +234,7 @@ final class RemoteClassLoader extends URLClassLoader {
                                         interrupted = true;
                                         continue;   // JENKINS-19453: retry
                                     }
+                                    throw x;
                                 }
 
                                 // no code is allowed to reach here
@@ -343,7 +344,7 @@ final class RemoteClassLoader extends URLClassLoader {
         return rcl;
     }
     /**
-     * Induce a large delay in {@link RemoteClassLoader#findClass(String)} to allow unittests to be written.
+     * Intercept {@link RemoteClassLoader#findClass(String)} to allow unittests to be written.
      *
      * See JENKINS-6604 and similar issues
      */

--- a/src/test/java/hudson/remoting/ClassRemotingTest.java
+++ b/src/test/java/hudson/remoting/ClassRemotingTest.java
@@ -132,7 +132,7 @@ public class ClassRemotingTest extends RmiTestBase {
         final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
         final Callable<Object, Exception> c = (Callable) child2.load(TestLinkage.class);
         assertEquals(child2, c.getClass().getClassLoader());
-        RemoteClassLoader.TESTING_CLASS_LOAD = new Interrupt3thInvocation();
+        RemoteClassLoader.TESTING_CLASS_LOAD = new InterruptThirdInvocation();
         try {
             java.util.concurrent.Future<Object> f1 = scheduleCallableLoad(c);
 
@@ -156,7 +156,7 @@ public class ClassRemotingTest extends RmiTestBase {
         final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
         final Callable<Object, Exception> c = (Callable) child2.load(TestLinkage.class);
         assertEquals(child2, c.getClass().getClassLoader());
-        RemoteClassLoader.TESTING_CLASS_REFERENCE_LOAD = new Interrupt3thInvocation();
+        RemoteClassLoader.TESTING_CLASS_REFERENCE_LOAD = new InterruptThirdInvocation();
 
         try {
             Future<Object> f1 = scheduleCallableLoad(c);
@@ -187,7 +187,7 @@ public class ClassRemotingTest extends RmiTestBase {
         });
     }
 
-    private static class Interrupt3thInvocation implements Runnable {
+    private static class InterruptThirdInvocation implements Runnable {
         private int invocationCount = 0;
         @Override
         public void run() {


### PR DESCRIPTION
… while fetching ClassRefference

Fixing [JENKINS-36991](https://issues.jenkins-ci.org/browse/JENKINS-36991), a variant of [JENKINS-19453](https://issues.jenkins-ci.org/browse/JENKINS-19453).

@jenkinsci/code-reviewers (esp. @jglick and @kohsuke)