### PR TITLE
[FIXED JENKINS-37539] - Prevent NPE in Engine#connect() when host or port are null or empty

### DIFF
--- a/src/main/java/hudson/remoting/Util.java
+++ b/src/main/java/hudson/remoting/Util.java
@@ -125,7 +125,7 @@ class Util {
      *
      * Warning: this method won't match shortened representation of IPV6 address
      */
-    static boolean inNoProxyEnvVar(String host) {
+    static boolean inNoProxyEnvVar(@Nonnull  String host) {
         String noProxy = System.getenv("no_proxy");
         if (noProxy != null) {
             noProxy = noProxy.trim()
@@ -218,7 +218,7 @@ class Util {
         return openURLConnection(url, null, null, null);
     }
 
-    static InetSocketAddress getResolvedHttpProxyAddress(String host, int port) throws IOException {
+    static InetSocketAddress getResolvedHttpProxyAddress(@Nonnull String host, int port) throws IOException {
         InetSocketAddress targetAddress = null;
         Iterator<Proxy> proxies = ProxySelector.getDefault().select(URI.create(String.format("http://%s:%d", host, port))).iterator();
         while (targetAddress == null && proxies.hasNext()) {


### PR DESCRIPTION
Bug diagnosis:
* https://scan8.coverity.com/reports.htm#v14462/p10499/fileInstanceId=12836372&defectInstanceId=4427367&mergedDefectId=152195
* https://scan8.coverity.com/reports.htm#v14462/p10499/fileInstanceId=12836372&defectInstanceId=4427365&mergedDefectId=152194

https://issues.jenkins-ci.org/browse/JENKINS-37539

@reviewbybees