### PR TITLE
[CID-48110] - Resource leak on exceptional path in Util#makeResource()

### DIFF
--- a/src/main/java/hudson/remoting/Util.java
+++ b/src/main/java/hudson/remoting/Util.java
@@ -60,8 +60,11 @@ class Util {
         resource.getParentFile().mkdirs();
 
         FileOutputStream fos = new FileOutputStream(resource);
-        fos.write(image);
-        fos.close();
+        try {
+            fos.write(image);
+        } finally {
+            fos.close();
+        }
 
         deleteDirectoryOnExit(tmpFile);
 


### PR DESCRIPTION
It may happen in the case of the remote classloader.
https://scan8.coverity.com/reports.htm#v14462/p10499/fileInstanceId=12836386&defectInstanceId=4427346&mergedDefectId=48110

@jenkinsci/code-reviewers 