### PR TITLE
[JENKINS-38690] do not cause a IOHub Thread Storm

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/NIONetworkLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/NIONetworkLayer.java
@@ -147,12 +147,12 @@ public class NIONetworkLayer extends NetworkLayer implements IOHubReadyListener 
                             while (recv.hasRemaining()) {
                                 onRead(recv);
                             }
-                            if (in.isOpen() && recvKey.isValid()) {
-                                getIoHub().addInterestRead(recvKey);
-                            } else {
-                                recvKey.cancel();
-                                onRecvClosed();
-                            }
+                        }
+                        if (in.isOpen() && recvKey.isValid()) {
+                            getIoHub().addInterestRead(recvKey);
+                        } else {
+                            recvKey.cancel();
+                            onRecvClosed();
                         }
                     } catch (ClosedChannelException e) {
                         recvKey.cancel();


### PR DESCRIPTION
[JENKINS-38690](https://issues.jenkins-ci.org/browse/JENKINS-38690)
We should only add the READ interested OPS when we have fully drained the
read queue.

In the case we had a lot of data to read (where lots >> 8192 bytes) we
would read a buffers worth of data add READ to the interested opps then
read another buffer in the same thread.  If we where reading 81920 bytes
for example this would be 9 calls to add READ OPs - which would run on the
selctor thread and cause an immediate wakeup to be called followed by a
new onReady().
However the onReady will be added as a defered callback and the ops
removed, but the read thread is still going and as it takes time will call
back again to add interested ops... which will wake the selector see that
READ ops are valid and cause a new deffered callback...

So do not add read interested ops inside the loop, add it only when we
have drained the buffer.

@reviewbybees esp @stephenc 