### PR TITLE
[JENKINS-38690] Do not cause a Thread storm in IOHub

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/NIONetworkLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/NIONetworkLayer.java
@@ -147,12 +147,12 @@ public class NIONetworkLayer extends NetworkLayer implements IOHubReadyListener 
                             while (recv.hasRemaining()) {
                                 onRead(recv);
                             }
-                            if (in.isOpen() && recvKey.isValid()) {
-                                getIoHub().addInterestRead(recvKey);
-                            } else {
-                                recvKey.cancel();
-                                onRecvClosed();
-                            }
+                        }
+                        if (in.isOpen() && recvKey.isValid()) {
+                            getIoHub().addInterestRead(recvKey);
+                        } else {
+                            recvKey.cancel();
+                            onRecvClosed();
                         }
                     } catch (ClosedChannelException e) {
                         recvKey.cancel();


### PR DESCRIPTION
Replaces #115

@reviewbybees

All tests pass on my machine.

| "protocol"                         | "io"           | "clients" | "interval" | "payload" | "observedRate" | "expectedRate" | "vmLoad" | "expectedVmLoad" | "threads" | "avgMemory" | "stdMemory" | "dfMemory" | "maxMemory" | "gc[0].name"             | "gc[0].count" | "gc[0].time" | "gc[1].name"  | "gc[1].count" | "gc[1].time" | 
|------------------------------------|----------------|-----------|------------|-----------|----------------|----------------|----------|------------------|-----------|-------------|-------------|------------|-------------|--------------------------|---------------|--------------|---------------|---------------|--------------| 
| "JNLP4-plaintext (this change)"    | "non-blocking" | 100       | 100        | -1        | 1000.0         | 1000.0         | 1.36     | 1.36             | 46        | 191650.05   | 43763.10    | 1981       | 3728384.00  | "PS         MarkSweep"   | 2             | 0.042        | "PS Scavenge" | 935           | 1.47         | 
| "JNLP4-plaintext (from #115)"      | "non-blocking" | 100       | 100        | -1        | 1000.0         | 1000.0         | 1.48     | 1.48             | 60        | 199295.16   | 40312.72    | 1981       | 3728384.00  | "PS           MarkSweep" | 2             | 0.045        | "PS Scavenge" | 885           | 1.509        | 
| "JNLP4-plaintext (current master)" | "non-blocking" | 100       | 100        | -1        | 1000.0         | 1000.0         | 1.53     | 1.53             | 44        | 195592.79   | 43263.94    | 1981       | 3728384.00  | "PS      MarkSweep"      | 2             | 0.041        | "PS Scavenge" | 902           | 1.509        |