### PR TITLE
[JENKINS-39150] expose diagnostics across all the channels

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1587,7 +1587,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * Used for diagnostics.
      */
     public static void dumpDiagnosticsForAll(PrintWriter w) throws IOException {
-        for (Ref ref : ACTIVE_CHANNELS.values()) {
+        for (Ref ref : ACTIVE_CHANNELS.values().toArray(new Ref[0])) {
             Channel ch = ref.channel();
             if (ch!=null)
                 ch.dumpDiagnostics(w);

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -232,7 +232,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * without telling us anything, the {@link SocketOutputStream#write(int)} will
      * return right away, and the socket only really times out after 10s of minutes.
      */
-    private long lastCommandSentAt, lastCommandReceivedAt;
+    private volatile long lastCommandSentAt, lastCommandReceivedAt;
 
     /**
      * Timestamp of when this channel was connected/created, in

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1225,6 +1225,8 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * The reverse of "pending outgoing calls".
      * Number of RPC calls (e.g., method call through a {@linkplain RemoteInvocationHandler proxy})
      * that the other side has made to us but not yet returned yet.
+     *
+     * @since 2.26.3
      */
     public void dumpDiagnostics(PrintWriter w) throws IOException {
         w.printf("Channel %s%n",name);
@@ -1585,6 +1587,8 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * Calls {@link #dumpDiagnostics(PrintWriter)} across all the active channels in this system.
      * Used for diagnostics.
+     *
+     * @since 2.26.3
      */
     public static void dumpDiagnosticsForAll(PrintWriter w) throws IOException {
         for (Ref ref : ACTIVE_CHANNELS.values().toArray(new Ref[0])) {

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -224,7 +224,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * Timestamp of the last {@link Command} object sent/received, in
      * {@link System#currentTimeMillis()} format.
      */
-    private long lastCommandSent, lastCommandReceived;
+    private long lastCommandSentAt, lastCommandReceivedAt;
 
     /**
      * Timestamp of when this channel was connected/created, in
@@ -521,7 +521,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         transport.setup(this, new CommandReceiver() {
             public void handle(Command cmd) {
                 commandsReceived++;
-                lastCommandReceived = System.currentTimeMillis();
+                lastCommandReceivedAt = System.currentTimeMillis();
                 updateLastHeard();
                 if (logger.isLoggable(Level.FINE))
                     logger.fine("Received " + cmd);
@@ -610,7 +610,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 
         transport.write(cmd, cmd instanceof CloseCommand);
         commandsSent++;
-        lastCommandSent = System.currentTimeMillis();
+        lastCommandSentAt = System.currentTimeMillis();
     }
 
     /**
@@ -1209,12 +1209,12 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * <dt>Last command sent
      * <dd>
      * The timestamp in which the last command was sent to the other side. The timestamp in which
-     * {@link #lastCommandSent} was updated.
+     * {@link #lastCommandSentAt} was updated.
      *
      * <dt>Last command received
      * <dd>
      * The timestamp in which the last command was sent to the other side. The timestamp in which
-     * {@link #lastCommandReceived} was updated.
+     * {@link #lastCommandReceivedAt} was updated.
      *
      * <dt>Pending outgoing calls
      * <dd>
@@ -1237,8 +1237,8 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         w.printf("  Created=%s%n", new Date(createdAt));
         w.printf("  Commands sent=%d%n", commandsSent);
         w.printf("  Commands received=%d%n", commandsReceived);
-        w.printf("  Last command sent=%s%n", new Date(lastCommandSent));
-        w.printf("  Last command received=%s%n", new Date(lastCommandReceived));
+        w.printf("  Last command sent=%s%n", new Date(lastCommandSentAt));
+        w.printf("  Last command received=%s%n", new Date(lastCommandReceivedAt));
         w.printf("  Pending outgoing calls=%d%n", pendingCalls.size());
         w.printf("  Pending incoming calls=%d%n", pendingCalls.size());
     }

--- a/src/main/java/hudson/remoting/Command.java
+++ b/src/main/java/hudson/remoting/Command.java
@@ -31,6 +31,8 @@ import java.util.concurrent.ExecutionException;
 
 /**
  * One-way command to be sent over to the remote system and executed there.
+ * This is the smallest unit of message in remoting from one side to another,
+ * such as "please execute this method" or "here's the return value from an earlier method call".
  * This is layer 0, the lower most layer.
  *
  * <p>

--- a/src/test/java/hudson/remoting/ChannelTest.java
+++ b/src/test/java/hudson/remoting/ChannelTest.java
@@ -166,6 +166,7 @@ public class ChannelTest extends RmiTestBase {
         }
     }
 
+    @Bug(39150)
     public void testDiagnostics() throws Exception {
         StringWriter sw = new StringWriter();
         Channel.dumpDiagnosticsForAll(new PrintWriter(sw));

--- a/src/test/java/hudson/remoting/ChannelTest.java
+++ b/src/test/java/hudson/remoting/ChannelTest.java
@@ -5,7 +5,9 @@ import org.jvnet.hudson.test.Bug;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.PrintWriter;
 import java.io.Serializable;
+import java.io.StringWriter;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.TimeUnit;
@@ -162,5 +164,15 @@ public class ChannelTest extends RmiTestBase {
         public T call() throws RuntimeException {
             return t;
         }
+    }
+
+    public void testDiagnostics() throws Exception {
+        StringWriter sw = new StringWriter();
+        Channel.dumpDiagnosticsForAll(new PrintWriter(sw));
+        System.out.println(sw);
+        assertTrue(sw.toString().contains("Channel north"));
+        assertTrue(sw.toString().contains("Channel south"));
+        assertTrue(sw.toString().contains("Commands sent=0"));
+        assertTrue(sw.toString().contains("Commands received=0"));
     }
 }


### PR DESCRIPTION
Continuing from https://github.com/jenkinsci/remoting/pull/120

No code change since then, just re-targeting stable-2.x