### PR TITLE
[FIXED JENKINS-39290] A debug flag to disable NIO

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,14 @@ These properties require independent configuration on both sides of the channel.
       Property example: <code>org.jenkinsci.remoting.engine.JnlpProtocol3.disabled</code>
       </td>
     </tr>
+    <tr>
+      <td>org.jenkinsci.remoting.nio.NioChannelHub.disabled</td>
+      <td>false</td>
+      <td>2.62.3</td>
+      <td>?</td>
+      <td><a href="https://issues.jenkins-ci.org/browse/JENKINS-39290">JENKINS-39290</a></td>
+      <td>Boolean flag to disable NIO-based socket connection handling, and switch back to classic IO. Used to isolate the problem.</td>
+    </tr>-
     <!--Template
     <tr>
       <td></td>

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,12 @@ THE SOFTWARE.
       <version>3.0.1</version>
       <type>jar</type>
     </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>access-modifier-annotation</artifactId>
+      <version>1.4</version>
+      <optional>true</optional><!-- no need to have this at runtime -->
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
@@ -11,6 +11,9 @@ import hudson.remoting.ChunkHeader;
 import hudson.remoting.CommandTransport;
 import hudson.remoting.SingleLaneExecutorService;
 import org.jenkinsci.remoting.RoleChecker;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.Closeable;
 import java.io.EOFException;
@@ -702,12 +705,13 @@ public class NioChannelHub implements Runnable, Closeable {
 
     /**
      * Escape hatch to disable NIO-based remoting.
+     * <p>
+     * This field is a debug switch and not a part of the committed interface of this library,
+     * but needs to be public and mutable for example so that it can be set from script console.
+     * Subject to change without notice. Do not rely on this from application code.
      *
      * @since 2.26.3
-     * @deprecated
-     *      This field is a debug switch and not a part of the committed interface of this library,
-     *      but needs to be public and mutable for example so that it can be set from script console.
-     *      Subject to change without notice. Do not rely on this from application code.
      */
+    @Restricted(NoExternalUse.class)
     public static boolean DISABLE_NIO = Boolean.getBoolean(NioChannelHub.class.getName()+".disabled");
 }

--- a/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
@@ -12,7 +12,6 @@ import hudson.remoting.CommandTransport;
 import hudson.remoting.SingleLaneExecutorService;
 import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.Closeable;
@@ -475,7 +474,8 @@ public class NioChannelHub implements Runnable, Closeable {
             protected CommandTransport makeTransport(InputStream is, OutputStream os, Mode mode, Capability cap) throws IOException {
                 if (r==null)    r = factory.create(is);
                 if (w==null)    w = factory.create(os);
-                if (r!=null && w!=null && mode==Mode.BINARY && cap.supportsChunking() && !DISABLE_NIO) {
+                boolean disableNio = Boolean.getBoolean(NioChannelHub.class.getName()+".disabled");
+                if (r!=null && w!=null && mode==Mode.BINARY && cap.supportsChunking() && !disableNio) {
                     try {
                         // run() might be called asynchronously from another thread, so wait until that gets going
                         // if you see the execution hanging here forever, that means you forgot to call run()
@@ -702,16 +702,4 @@ public class NioChannelHub implements Runnable, Closeable {
     }
 
     private static final Logger LOGGER = Logger.getLogger(NioChannelHub.class.getName());
-
-    /**
-     * Escape hatch to disable NIO-based remoting.
-     * <p>
-     * This field is a debug switch and not a part of the committed interface of this library,
-     * but needs to be public and mutable for example so that it can be set from script console.
-     * Subject to change without notice. Do not rely on this from application code.
-     *
-     * @since 2.26.3
-     */
-    @Restricted(NoExternalUse.class)
-    public static boolean DISABLE_NIO = Boolean.getBoolean(NioChannelHub.class.getName()+".disabled");
 }

--- a/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
@@ -472,7 +472,7 @@ public class NioChannelHub implements Runnable, Closeable {
             protected CommandTransport makeTransport(InputStream is, OutputStream os, Mode mode, Capability cap) throws IOException {
                 if (r==null)    r = factory.create(is);
                 if (w==null)    w = factory.create(os);
-                if (r!=null && w!=null && mode==Mode.BINARY && cap.supportsChunking()) {
+                if (r!=null && w!=null && mode==Mode.BINARY && cap.supportsChunking() && !DISABLE_NIO) {
                     try {
                         // run() might be called asynchronously from another thread, so wait until that gets going
                         // if you see the execution hanging here forever, that means you forgot to call run()
@@ -492,9 +492,9 @@ public class NioChannelHub implements Runnable, Closeable {
                     else            t = new DualNioTransport(getName(),r,w,cap);
                     t.scheduleReregister();
                     return t;
-                }
-                else
+                } else {
                     return super.makeTransport(is, os, mode, cap);
+                }
             }
         };
     }
@@ -699,4 +699,15 @@ public class NioChannelHub implements Runnable, Closeable {
     }
 
     private static final Logger LOGGER = Logger.getLogger(NioChannelHub.class.getName());
+
+    /**
+     * Escape hatch to disable NIO-based remoting.
+     *
+     * @since 2.26.3
+     * @deprecated
+     *      This field is a debug switch and not a part of the committed interface of this library,
+     *      but needs to be public and mutable for example so that it can be set from script console.
+     *      Subject to change without notice. Do not rely on this from application code.
+     */
+    public static boolean DISABLE_NIO = Boolean.getBoolean(NioChannelHub.class.getName()+".disabled");
 }


### PR DESCRIPTION
To further isolate problems during remote trouble-shooting of remoting, define a switch to bypass NIO and use classic blocking I/O transport.

Ample warning to prevent accidental dependencies from other Java code.