### PR TITLE
[JENKINS-39150] - API stabilization && compliance with the compatibility policy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,12 @@ THE SOFTWARE.
       <version>3.0.1</version>
       <type>jar</type>
     </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>access-modifier-annotation</artifactId>
+      <version>1.7</version>
+      <type>jar</type>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1615,7 +1615,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
                         throw (Error)ex;
                     }
                     logger.log(Level.WARNING, 
-                            String.format("Cannot domp diagmostics for the channel %s", ch.getName()), ex);
+                            String.format("Cannot dump diagnostics for the channel %s", ch.getName()), ex);
                 }
             }
         }

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1229,11 +1229,14 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * Number of RPC calls (e.g., method call through a {@linkplain RemoteInvocationHandler proxy})
      * that the other side has made to us but not yet returned yet.
      *
+     * @param w Output destination
+     * @throws IOException Error while creating or writing the channel information
+     * 
      * @since 2.62.3 - stable 2.x (restricted)
      * @since TODO 3.x - public version 
      */
     @Restricted(NoExternalUse.class)
-    public void dumpDiagnostics(PrintWriter w) throws IOException {
+    public void dumpDiagnostics(@Nonnull PrintWriter w) throws IOException {
         w.printf("Channel %s%n",name);
         w.printf("  Created=%s%n", new Date(createdAt));
         w.printf("  Commands sent=%d%n", commandsSent);
@@ -1595,15 +1598,25 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * Calls {@link #dumpDiagnostics(PrintWriter)} across all the active channels in this system.
      * Used for diagnostics.
      *
+     * @param w Output destination
+     * 
      * @since 2.62.3 - stable 2.x (restricted)
      * @since TODO 3.x - public version 
      */
     @Restricted(NoExternalUse.class)
-    public static void dumpDiagnosticsForAll(PrintWriter w) throws IOException {
+    public static void dumpDiagnosticsForAll(@Nonnull PrintWriter w) {
         for (Ref ref : ACTIVE_CHANNELS.values().toArray(new Ref[0])) {
             Channel ch = ref.channel();
-            if (ch!=null) {
-                ch.dumpDiagnostics(w);
+            if (ch != null) {
+                try {
+                    ch.dumpDiagnostics(w);
+                } catch (Throwable ex) {
+                    if (ex instanceof Error) {
+                        throw (Error)ex;
+                    }
+                    logger.log(Level.WARNING, 
+                            String.format("Cannot domp diagmostics for the channel %s", ch.getName()), ex);
+                }
             }
         }
     }

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1613,7 +1613,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
             // Check if we can still write the output
             if (w.checkError()) {
                 logger.log(Level.WARNING, 
-                        String.format("Cannot dump diagnostics for all channels, because output stream encontered an error. "
+                        String.format("Cannot dump diagnostics for all channels, because output stream encountered an error. "
                                 + "Processed %d of %d channels, first unprocessed channel reference is %s.",
                                 processedCount, channels.length, ref
                         )); 

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -60,6 +60,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Represents a communication channel to the remote peer.
@@ -1172,6 +1174,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         w.printf(Locale.ENGLISH, "Resource loading time=%,dms%n", resourceLoadingTime.get() / (1000 * 1000));
     }
 
+    //TODO: Make public after merge into the master branch
     /**
      * Print the diagnostic information.
      *
@@ -1226,8 +1229,10 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * Number of RPC calls (e.g., method call through a {@linkplain RemoteInvocationHandler proxy})
      * that the other side has made to us but not yet returned yet.
      *
-     * @since 2.26.3
+     * @since 2.62.3 - stable 2.x (restricted)
+     * @since TODO 3.x - public version 
      */
+    @Restricted(NoExternalUse.class)
     public void dumpDiagnostics(PrintWriter w) throws IOException {
         w.printf("Channel %s%n",name);
         w.printf("  Created=%s%n", new Date(createdAt));
@@ -1584,17 +1589,22 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         return CURRENT.get();
     }
 
+    // TODO: Unrestrict after the merge into the master.
+    // By now one may use it via the reflection logic only
     /**
      * Calls {@link #dumpDiagnostics(PrintWriter)} across all the active channels in this system.
      * Used for diagnostics.
      *
-     * @since 2.26.3
+     * @since 2.62.3 - stable 2.x (restricted)
+     * @since TODO 3.x - public version 
      */
+    @Restricted(NoExternalUse.class)
     public static void dumpDiagnosticsForAll(PrintWriter w) throws IOException {
         for (Ref ref : ACTIVE_CHANNELS.values().toArray(new Ref[0])) {
             Channel ch = ref.channel();
-            if (ch!=null)
+            if (ch!=null) {
                 ch.dumpDiagnostics(w);
+            }
         }
     }
 

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -212,7 +212,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * Number of {@link Command} objects sent to the other side.
      */
-    private int commandsSent;
+    private volatile long commandsSent;
 
     /**
      * Number of {@link Command} objects received from the other side.
@@ -220,7 +220,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * When a transport is functioning correctly, {@link #commandsSent} of one side
      * and {@link #commandsReceived} of the other side should closely match.
      */
-    private int commandsReceived;
+    private volatile long commandsReceived;
 
     /**
      * Timestamp of the last {@link Command} object sent/received, in

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1243,8 +1243,10 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         w.printf("  Commands received=%d%n", commandsReceived);
         w.printf("  Last command sent=%s%n", new Date(lastCommandSentAt));
         w.printf("  Last command received=%s%n", new Date(lastCommandReceivedAt));
-        w.printf("  Pending outgoing calls=%d%n", pendingCalls.size());
-        w.printf("  Pending incoming calls=%d%n", pendingCalls.size());
+        
+        // TODO: Update after the merge to 3.x branch, where the Hashtable is going to be replaced as a part of
+        // https://github.com/jenkinsci/remoting/pull/109
+        w.printf("  Pending calls=%d%n", pendingCalls.size());
     }
 
     /**


### PR DESCRIPTION
In https://github.com/jenkinsci/remoting/pull/122 @kohsuke merged the pull request without waiting for the feedback from reviewers. It effectively introduced new public API in the stabilization branch.

I also used my chance to review the code deeply and realised that <code>IOException</code> handling is far from ideal for the production code. Hence I propose to change it as well

@reviewbybees