### PR TITLE
Maven command should use `--batch-mode`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ for (int i = 0; i < platforms.size(); ++i) {
                         'PATH+JDK=$JAVA_HOME/bin',
                     ]) {
                         timeout(30) {
-                            String command = 'mvn clean install -Dmaven.test.failure.ignore=true'
+                            String command = 'mvn --batch-mode clean install -Dmaven.test.failure.ignore=true'
                             if (isUnix()) {
                                 sh command
                             }


### PR DESCRIPTION
The maven command should use batch mode - otherwise the logs are an unintelligible mess containing output of the amount of KB downloaded when downloading dependencies.

@oleg-nenashev @rtyler 