### PR TITLE
[JENKINS-39370,JENKINS-39369] - Support of work directories in Remoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ User documentation:
 * [Remoting 3 Compatibility Notes](docs/remoting-3-compatibility.md)
 * [Remoting Protocols](docs/protocols.md) - Overview of protocols integrated with Jenkins
 * [Remoting Configuration](docs/configuration.md) - Configuring remoting agents
+* [Logging](docs/logging.md) - Logging
+* [Work Directory](docs/workDir.md) - Remoting work directory (new in Remoting `TODO`)
 * [Jenkins Specifics](docs/jenkins-specifics.md) - Notes on using remoting in Jenkins
 * [Troubleshooting](docs/troubleshooting.md) - Investigating and solving common remoting issues
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,9 +1,21 @@
 Logging
 ===
 
-In Remoting logging system behavior depends on the [Work Directory](workDir.md) mode.
+In Remoting logging is powered by the standard `java.util.logging` engine. 
+The default behavior depends on the [Work Directory](workDir.md) mode.
 
-### With work directory
+### Configuration
+
+In order to configure logging it is possible to use an external property file, path to which can be defined using the `-loggingConfig` CLI option or the `java.util.logging.config.file` system property. 
+
+If logging is configured via `-loggingConfig`, some messages printed before the logging system initialization may be missing in startup logs configured by this option.
+
+See details about the property file format
+in [Oracle documentation](https://docs.oracle.com/cd/E19717-01/819-7753/6n9m71435/index.html)
+and [this guide](http://tutorials.jenkov.com/java-logging/configuration.html).
+Note that `ConsoleHandler` won't be enabled by default if this option is specified.
+
+### Default behavior with work directory
 
 With work directory Remoting automatically writes logs to the disk.
 This is a main difference from the legacy mode without workDir.
@@ -19,14 +31,11 @@ Logging destinations:
   * Default logging level - `INFO`
   * If the legacy `-agentLog` or `-slaveLog` option is enabled, this file logging will be disabled.
 
-In order to configure logging it is possible to use an external property file, path to which can be defined using the `-loggingConfig` CLI option. 
-If this option is defined, an empty `${workDir}/${internalDir}/logs` will be created if it does not exist.
-See details about the file format
-in [Oracle documentation](https://docs.oracle.com/cd/E19717-01/819-7753/6n9m71435/index.html)
-and [this guide](http://tutorials.jenkov.com/java-logging/configuration.html).
-Note that `ConsoleHandler` won't be enabled by default if this option is specified.
+If `-agentLog` or `-slaveLog` are not specified, `${workDir}/${internalDir}/logs` directory will be created during the work directory initialization (if required).
 
-### Without work directory (legacy mode)
+<!--TODO: Mention conflict with early initialization by java.util.logging.config.file?-->
+
+### Default behavior without work directory (legacy mode)
 
 * By default, all logs within the system are being sent to _STDOUT/STDERR_ using `java.util.logging`.
 * If `-agentLog` or `-slaveLog` option is specified, the log will be also forwarded to the specified file

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -20,8 +20,10 @@ Logging destinations:
   * If the legacy `-agentLog` or `-slaveLog` option is enabled, this file logging will be disabled.
 
 In order to configure logging it is possible to use an external property file, path to which can be defined using the `-loggingConfig` CLI option. 
+If this option is defined, an empty `${workDir}/${internalDir}/logs` will be created if it does not exist.
 See details about the file format
-[in this guide](http://tutorials.jenkov.com/java-logging/configuration.html).
+in [Oracle documentation](https://docs.oracle.com/cd/E19717-01/819-7753/6n9m71435/index.html)
+and [this guide](http://tutorials.jenkov.com/java-logging/configuration.html).
 Note that `ConsoleHandler` won't be enabled by default if this option is specified.
 
 ### Without work directory (legacy mode)

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -19,12 +19,10 @@ Logging destinations:
   * Default logging level - `INFO`
   * If the legacy `-agentLog` or `-slaveLog` option is enabled, this file logging will be disabled.
 
-<!--TODO: Document the configuration file support-->
-<!--
 In order to configure logging it is possible to use an external property file, path to which can be defined using the `-loggingConfig` CLI option. 
 See details about the file format
 [in this guide](http://tutorials.jenkov.com/java-logging/configuration.html).
--->
+Note that `ConsoleHandler` won't be enabled by default if this option is specified.
 
 ### Without work directory (legacy mode)
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,37 @@
+Logging
+===
+
+In Remoting logging system behavior depends on the [Work Directory](workDir.md) mode.
+
+### With work directory
+
+With work directory Remoting automatically writes logs to the disk.
+This is a main difference from the legacy mode without workDir.
+
+Logging destinations:
+
+* STDOUT and STDERR
+  * Logs include `java.util.logging` and messages printed to _STDOUT/STDERR_ directly.
+* Files - `${workDir}/${internalDir}/logs` directory
+  * File base name - `remoting.log`
+  * Logs are being automatically rotated.
+    By default, Remoting keeps 5 10MB files
+  * Default logging level - `INFO`
+  * If the legacy `-agentLog` or `-slaveLog` option is enabled, this file logging will be disabled.
+
+<!--TODO: Document the configuration file support-->
+<!--
+In order to configure logging it is possible to use an external property file, path to which can be defined using the `-loggingConfig` CLI option. 
+See details about the file format
+[in this guide](http://tutorials.jenkov.com/java-logging/configuration.html).
+-->
+
+### Without work directory (legacy mode)
+
+* By default, all logs within the system are being sent to _STDOUT/STDERR_ using `java.util.logging`.
+* If `-agentLog` or `-slaveLog` option is specified, the log will be also forwarded to the specified file
+  * The existing file will be overridden on startup
+  * Remoting does not perform automatic log rotation of this log file
+  
+Particular Jenkins components use external features to provide better logging in the legacy mode.
+E.g. Windows agent services generate logs using features provided by [Windows Service Wrapper (WinSW)](https://github.com/kohsuke/winsw/).

--- a/docs/workDir.md
+++ b/docs/workDir.md
@@ -1,0 +1,45 @@
+Remoting Work directory
+===
+
+In Remoting work directory is a storage 
+
+Remoting work directory is available starting from Remoting `TODO`.
+Before this version there was no working directory concept in the library itself;
+all operations were managed by library users (e.g. Jenkins agent workspaces).
+
+### Before Remoting TODO
+
+* There is no work directory management in Remoting itself
+* Logs are not being persisted to the disk unless `-slaveLog` option is specified
+* JAR Cache is being stored in `${user.home}/.jenkins` unless `-jarCache` option is specified
+
+### After Remoting TODO
+
+Due to compatibility reasons, Remoting retains the legacy behavior by default.
+Work directory can be enabled using the `-workDir` option in CLI or via the `TODO` [system property](configuration.md).
+
+Once the option is enabled, Remoting starts using the following structure:
+
+```
+${WORKDIR}
+  |_ ${INTERNAL_DIR} - defined by '-internalDir', 'remoting' by default
+    |_ jarCache - JAR Cache
+    |_ logs     - Remoting logs
+    |_ ...      - Other directories contributed by library users
+```
+
+Structure of the `logs` directory depends on the logging settings.
+See [this page](logging.md) for more information.
+
+### Migrating to work directories in Jenkins
+
+:exclamation: Remoting does not perform migration from the previous structure, 
+because it cannot identify potential external users of the data.
+
+Once the `-workDir` flag is enabled in Remoting, admins are expected to do the following:
+
+1. Remove the `${user.home}/.jenkins` directory if there is no other Remoting instances running under the same user.
+2. Consider upgrading configurations of agents in order to enable Work Directories
+  * SSH agents can be configured in agent settings.
+  * JNLP agents should be started with the `-workDir` parameter.
+  * See [JENKINS-TODO](TODO) for more information about changes in Jenkins plugins, which enable work directories by default.

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -156,6 +156,15 @@ public class Engine extends Thread {
     private JarCache jarCache = new FileSystemJarCache(new File(System.getProperty("user.home"),".jenkins/cache/jars"),true);
 
     /**
+     * Specifies a destination for the agent log.
+     * If specified, this option overrides the default destination within {@link #workDir}.
+     * If both this options and {@link #workDir} is not set, the log will not be generated.
+     * @since TODO
+     */
+    @CheckForNull
+    private Path agentLog;
+    
+    /**
      * Specifies a default working directory of the remoting instance.
      * If specified, this directory will be used to store logs, JAR cache, etc.
      * <p>
@@ -209,7 +218,7 @@ public class Engine extends Thread {
         if (workDir != null) {
             final WorkDirManager workDirManager = WorkDirManager.getInstance();
             final Path path = workDirManager.initializeWorkDir(workDir.toFile(), internalDir, failIfWorkDirIsMissing);
-            workDirManager.setupLogging(path, null);
+            workDirManager.setupLogging(path, agentLog);
         }
 
         // Start the engine thread
@@ -242,6 +251,16 @@ public class Engine extends Thread {
 
     public void setNoReconnect(boolean noReconnect) {
         this.noReconnect = noReconnect;
+    }
+
+    /**
+     * Sets the destination for agent logs.
+     * @param agentLog Path to the agent log.
+     *      If {@code null}, the engine will pick the default behavior depending on the {@link #workDir} value
+     * @since TODO
+     */
+    public void setAgentLog(@CheckForNull Path agentLog) {
+        this.agentLog = agentLog;
     }
 
     /**

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -175,7 +175,16 @@ public class Engine extends Thread {
      * @since TODO
      */
     @Nonnull
-    public String internalDir = WorkDirManager.DEFAULT_INTERNAL_DIRECTORY;
+    public String internalDir = WorkDirManager.DirType.INTERNAL_DIR.getDefaultLocation();
+
+    /**
+     * Fail the initialization if the workDir or internalDir are missing.
+     * This option presumes that the workspace structure gets initialized previously in order to ensure that we do not start up with a borked instance
+     * (e.g. if a filesystem mount gets disconnected).
+     * @since TODO
+     */
+    @Nonnull
+    public boolean failIfWorkDirIsMissing = WorkDirManager.DEFAULT_FAIL_IF_WORKDIR_IS_MISSING;
 
     private DelegatingX509ExtendedTrustManager agentTrustManager = new DelegatingX509ExtendedTrustManager(new BlindTrustX509ExtendedTrustManager());
 
@@ -197,7 +206,7 @@ public class Engine extends Thread {
      */
     public synchronized void startEngine() throws IOException {
         // Prepare the working directory if required
-        final Path path = WorkDirManager.getInstance().initializeWorkDir(workDir.toFile(), internalDir);
+        final Path path = WorkDirManager.getInstance().initializeWorkDir(workDir.toFile(), internalDir, failIfWorkDirIsMissing);
         if (path != null) {
             System.out.println("Both error and output logs will be printed to " + path);
             System.out.flush();
@@ -260,6 +269,15 @@ public class Engine extends Thread {
     public void setInternalDir(@Nonnull String internalDir) {
         this.internalDir = internalDir;
     }
+
+    /**
+     * Sets up behavior if the workDir or internalDir are missing during the startup.
+     * This option presumes that the workspace structure gets initialized previously in order to ensure that we do not start up with a borked instance
+     * (e.g. if a filesystem mount gets disconnected).
+     * @param failIfWorkDirIsMissing Flag
+     * @since TODO
+     */
+    public void setFailIfWorkDirIsMissing(boolean failIfWorkDirIsMissing) { this.failIfWorkDirIsMissing = failIfWorkDirIsMissing; }
 
     /**
      * Returns {@code true} if and only if the socket to the master will have {@link Socket#setKeepAlive(boolean)} set.

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -174,6 +174,13 @@ public class Engine extends Thread {
     private Path agentLog;
     
     /**
+     * Specified location of the property file with JUL settings.
+     * @since TODO
+     */
+    @CheckForNull
+    private Path loggingConfigFilePath = null;
+    
+    /**
      * Specifies a default working directory of the remoting instance.
      * If specified, this directory will be used to store logs, JAR cache, etc.
      * <p>
@@ -234,6 +241,10 @@ public class Engine extends Thread {
                 workDirManager.disable(WorkDirManager.DirType.JAR_CACHE_DIR);
             }
             
+            if (loggingConfigFilePath != null) {
+                workDirManager.setLoggingConfig(loggingConfigFilePath.toFile());
+            }
+            
             final Path path = workDirManager.initializeWorkDir(workDir.toFile(), internalDir, failIfWorkDirIsMissing);
             jarCacheDirectory = workDirManager.getLocation(WorkDirManager.DirType.JAR_CACHE_DIR);
             workDirManager.setupLogging(path, agentLog);
@@ -265,6 +276,15 @@ public class Engine extends Thread {
      */
     public void setJarCache(@Nonnull JarCache jarCache) {
         this.jarCache = jarCache;
+    }
+    
+    /**
+     * Sets path to the property file with JUL settings.
+     * @param filePath JAR Cache to be used
+     * @since TODO
+     */
+    public void setLoggingConfigFile(@Nonnull Path filePath) {
+        this.loggingConfigFilePath = filePath;
     }
 
     /**

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -206,17 +206,19 @@ public class Engine extends Thread {
      */
     public synchronized void startEngine() throws IOException {
         // Prepare the working directory if required
-        final Path path = WorkDirManager.getInstance().initializeWorkDir(workDir.toFile(), internalDir, failIfWorkDirIsMissing);
-        if (path != null) {
-            System.out.println("Both error and output logs will be printed to " + path);
-            System.out.flush();
-            System.err.flush();
+        if (workDir != null) {
+            final Path path = WorkDirManager.getInstance().initializeWorkDir(workDir.toFile(), internalDir, failIfWorkDirIsMissing);
+            if (path != null) {
+                System.out.println("Both error and output logs will be printed to " + path);
+                System.out.flush();
+                System.err.flush();
 
-            // TODO: Log rotation by default?
-            System.setErr(new PrintStream(new TeeOutputStream(System.err,
-                    new FileOutputStream(new File(path.toFile(), "remoting.err.log")))));
-            System.setOut(new PrintStream(new TeeOutputStream(System.out,
-                    new FileOutputStream(new File(path.toFile(), "remoting.out.log")))));
+                // TODO: Log rotation by default?
+                System.setErr(new PrintStream(new TeeOutputStream(System.err,
+                        new FileOutputStream(new File(path.toFile(), "remoting.err.log")))));
+                System.setOut(new PrintStream(new TeeOutputStream(System.out,
+                        new FileOutputStream(new File(path.toFile(), "remoting.out.log")))));
+            }
         }
 
         // Start the engine thread

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -207,18 +207,9 @@ public class Engine extends Thread {
     public synchronized void startEngine() throws IOException {
         // Prepare the working directory if required
         if (workDir != null) {
-            final Path path = WorkDirManager.getInstance().initializeWorkDir(workDir.toFile(), internalDir, failIfWorkDirIsMissing);
-            if (path != null) {
-                System.out.println("Both error and output logs will be printed to " + path);
-                System.out.flush();
-                System.err.flush();
-
-                // TODO: Log rotation by default?
-                System.setErr(new PrintStream(new TeeOutputStream(System.err,
-                        new FileOutputStream(new File(path.toFile(), "remoting.err.log")))));
-                System.setOut(new PrintStream(new TeeOutputStream(System.out,
-                        new FileOutputStream(new File(path.toFile(), "remoting.out.log")))));
-            }
+            final WorkDirManager workDirManager = WorkDirManager.getInstance();
+            final Path path = workDirManager.initializeWorkDir(workDir.toFile(), internalDir, failIfWorkDirIsMissing);
+            workDirManager.setupLogging(path, null);
         }
 
         // Start the engine thread

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -392,8 +392,6 @@ public class Engine extends Thread {
 
     @Override
     public void run() {
-        //
-
         // Create the engine
         try {
             IOHub hub = IOHub.create(executor);

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -32,6 +32,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.Socket;
 import java.net.URL;
+import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
@@ -151,6 +152,28 @@ public class Engine extends Thread {
 
     private JarCache jarCache = new FileSystemJarCache(new File(System.getProperty("user.home"),".jenkins/cache/jars"),true);
 
+    /**
+     * Specifies a default working directory of the remoting instance.
+     * If specified, this directory will be used to store logs, JAR cache, etc.
+     * <p>
+     * In order to retain compatibility, the option is disabled by default.
+     * <p>
+     * Jenkins specifics: This working directory is expected to be equal to the agent root specified in Jenkins configuration.
+     * @since TODO
+     */
+    @CheckForNull
+    public Path workDir = null;
+
+    /**
+     * Specifies a directory within {@link #workDir}, which stores all the remoting-internal files.
+     * <p>
+     * This option is not expected to be used frequently, but it allows remoting users to specify a custom
+     * storage directory if the default {@code remoting} directory is consumed by other stuff.
+     * @since TODO
+     */
+    @Nonnull
+    public String internalDir = "remoting";
+
     private DelegatingX509ExtendedTrustManager agentTrustManager = new DelegatingX509ExtendedTrustManager(new BlindTrustX509ExtendedTrustManager());
 
     public Engine(EngineListener listener, List<URL> hudsonUrls, String secretKey, String slaveName) {
@@ -189,6 +212,25 @@ public class Engine extends Thread {
 
     public void setNoReconnect(boolean noReconnect) {
         this.noReconnect = noReconnect;
+    }
+
+    /**
+     * Specified a path to the work directory.
+     * @param workDir Path to the working directory of the remoting instance.
+     *                {@code null} Disables the working directory.
+     * @since TODO
+     */
+    public void setWorkDir(@CheckForNull Path workDir) {
+        this.workDir = workDir;
+    }
+
+    /**
+     * Specifies name of the internal data directory within {@link #workDir}.
+     * @param internalDir Directory name
+     * @since TODO
+     */
+    public void setInternalDir(@Nonnull String internalDir) {
+        this.internalDir = internalDir;
     }
 
     /**
@@ -232,6 +274,9 @@ public class Engine extends Thread {
 
     @Override
     public void run() {
+        //
+
+        // Create the engine
         try {
             IOHub hub = IOHub.create(executor);
             try {

--- a/src/main/java/hudson/remoting/FileSystemJarCache.java
+++ b/src/main/java/hudson/remoting/FileSystemJarCache.java
@@ -37,11 +37,15 @@ public class FileSystemJarCache extends JarCacheSupport {
     private final Map<String, Checksum> checksumsByPath = new HashMap<>();
 
     /**
+     * @param rootDir  
+     *      Root directory.
      * @param touch
      *      True to touch the cached jar file that's used. This enables external LRU based cache
      *      eviction at the expense of increased I/O.
+     * @throws IllegalArgumentException
+     *      Root directory is {@code null} or not writable.
      */
-    public FileSystemJarCache(File rootDir, boolean touch) {
+    public FileSystemJarCache(@Nonnull File rootDir, boolean touch) {
         this.rootDir = rootDir;
         this.touch = touch;
         if (rootDir==null)
@@ -54,6 +58,11 @@ public class FileSystemJarCache extends JarCacheSupport {
         }
     }
 
+    @Override
+    public String toString() {
+        return String.format("FileSystem JAR Cache: path=%s, touch=%s", rootDir, Boolean.toString(touch));
+    }
+    
     @Override
     protected URL lookInCache(Channel channel, long sum1, long sum2) throws IOException, InterruptedException {
         File jar = map(sum1, sum2);

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -278,28 +278,10 @@ public class Launcher {
     @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_DEFAULT_ENCODING")    // log file, just like console output, should be in platform default encoding
     public void run() throws Exception {
 
-        // Create and verify working directory if required
-        final Path internalDirPath = WorkDirManager.getInstance().initializeWorkDir(workDir, internalDir, failIfWorkDirIsMissing);
-
-        if (slaveLog != null) { // Legacy behavior
-            System.out.println("Using " + slaveLog + " as an agent Error log destination. 'Out' log won't be generated");
-            System.out.flush(); // Just in case the channel
-            System.err.flush();
-            System.setErr(new PrintStream(new TeeOutputStream(System.err,new FileOutputStream(slaveLog))));
-        } else if (internalDirPath != null) { // New behavior
-            System.out.println("Both error and output logs will be printed to " + internalDirPath);
-            System.out.flush();
-            System.err.flush();
-
-            // TODO: Log rotation by default?
-            System.setErr(new PrintStream(new TeeOutputStream(System.err,
-                    new FileOutputStream(new File(internalDirPath.toFile(), "remoting.err.log")))));
-            System.setOut(new PrintStream(new TeeOutputStream(System.out,
-                    new FileOutputStream(new File(internalDirPath.toFile(), "remoting.out.log")))));
-        } else {
-            // TODO: This message is suspected to break the CI
-            // System.err.println("WARNING: Log location is not specified (neither -workDir nor -slaveLog set)");
-        }
+        // Create and verify working directory and logging
+        final WorkDirManager workDirManager = WorkDirManager.getInstance();
+        final Path internalDirPath = workDirManager.initializeWorkDir(workDir, internalDir, failIfWorkDirIsMissing);
+        workDirManager.setupLogging(internalDirPath, slaveLog);
 
         if(auth!=null) {
             final int idx = auth.indexOf(':');

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -291,6 +291,9 @@ public class Launcher {
         // On the other hand, in such case there is no need to invoke WorkDirManager and handle the double initialization logic
         final WorkDirManager workDirManager = WorkDirManager.getInstance();
         final Path internalDirPath = workDirManager.initializeWorkDir(workDir, internalDir, failIfWorkDirIsMissing);
+        if (slaveLog != null) {
+            workDirManager.disable(WorkDirManager.DirType.LOGS_DIR);
+        }
         workDirManager.setupLogging(internalDirPath, slaveLog != null ? slaveLog.toPath() : null);
 
         if(auth!=null) {
@@ -326,15 +329,16 @@ public class Launcher {
             }
             if (loggingConfigFilePath != null) {
                 jnlpArgs.add("-loggingConfig");
-                jnlpArgs.add(loggingConfigFilePath.getPath());
+                jnlpArgs.add(loggingConfigFilePath.getAbsolutePath());
             }
             if (this.workDir != null) {
                 jnlpArgs.add("-workDir");
-                jnlpArgs.add(workDir.getPath());
+                jnlpArgs.add(workDir.getAbsolutePath());
                 jnlpArgs.add("-internalDir");
                 jnlpArgs.add(internalDir);
-                jnlpArgs.add("-failIfWorkDirIsMissing");
-                jnlpArgs.add(Boolean.toString(failIfWorkDirIsMissing));
+                if (failIfWorkDirIsMissing) {
+                    jnlpArgs.add("-failIfWorkDirIsMissing");
+                }
             }
             if (candidateCertificates != null && !candidateCertificates.isEmpty()) {
                 for (String c: candidateCertificates) {

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -283,7 +283,7 @@ public class Launcher {
         // On the other hand, in such case there is no need to invoke WorkDirManager and handle the double initialization logic
         final WorkDirManager workDirManager = WorkDirManager.getInstance();
         final Path internalDirPath = workDirManager.initializeWorkDir(workDir, internalDir, failIfWorkDirIsMissing);
-        workDirManager.setupLogging(internalDirPath, slaveLog.toPath());
+        workDirManager.setupLogging(internalDirPath, slaveLog != null ? slaveLog.toPath() : null);
 
         if(auth!=null) {
             final int idx = auth.indexOf(':');

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -176,6 +176,14 @@ public class Launcher {
     @Option(name="-jar-cache",metaVar="DIR",usage="Cache directory that stores jar files sent from the master")
     public File jarCache = new File(System.getProperty("user.home"),".jenkins/cache/jars");
 
+    /**
+     * Specified location of the property file with JUL settings.
+     * @since TODO
+     */
+    @CheckForNull
+    @Option(name="-loggingConfig",usage="Path to the property file with java.util.logging settings")
+    public File loggingConfigFilePath = null;
+    
     @Option(name = "-cert",
             usage = "Specify additional X.509 encoded PEM certificates to trust when connecting to Jenkins " +
                     "root URLs. If starting with @ then the remainder is assumed to be the name of the " +
@@ -315,6 +323,10 @@ public class Launcher {
             if (slaveLog != null) {
                 jnlpArgs.add("-agentLog");
                 jnlpArgs.add(slaveLog.getPath());
+            }
+            if (loggingConfigFilePath != null) {
+                jnlpArgs.add("-loggingConfig");
+                jnlpArgs.add(loggingConfigFilePath.getPath());
             }
             if (this.workDir != null) {
                 jnlpArgs.add("-workDir");

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -247,7 +247,19 @@ public class Launcher {
             usage = "Specifies a name of the internal files within a working directory ('remoting' by default)",
             depends = "-workDir")
     @Nonnull
-    public String internalDir = WorkDirManager.DEFAULT_INTERNAL_DIRECTORY;
+    public String internalDir = WorkDirManager.DirType.INTERNAL_DIR.getDefaultLocation();
+
+    /**
+     * Fail the initialization if the workDir or internalDir are missing.
+     * This option presumes that the workspace structure gets initialized previously in order to ensure that we do not start up with a borked instance
+     * (e.g. if a filesystem mount gets disconnected).
+     * @since TODO
+     */
+    @Option(name = "-failIfWorkDirIsMissing",
+            usage = "Fails the initialization if the requested workDir or internalDir are missing ('false' by default)",
+            depends = "-workDir")
+    @Nonnull
+    public boolean failIfWorkDirIsMissing = WorkDirManager.DEFAULT_FAIL_IF_WORKDIR_IS_MISSING;
 
     public static void main(String... args) throws Exception {
         Launcher launcher = new Launcher();
@@ -267,7 +279,7 @@ public class Launcher {
     public void run() throws Exception {
 
         // Create and verify working directory if required
-        final Path internalDirPath = WorkDirManager.getInstance().initializeWorkDir(workDir, internalDir);
+        final Path internalDirPath = WorkDirManager.getInstance().initializeWorkDir(workDir, internalDir, failIfWorkDirIsMissing);
 
         if (slaveLog != null) { // Legacy behavior
             System.out.println("Using " + slaveLog + " as an agent Error log destination. 'Out' log won't be generated");
@@ -318,6 +330,10 @@ public class Launcher {
             if (this.workDir != null) {
                 jnlpArgs.add("-workDir");
                 jnlpArgs.add(workDir.getPath());
+                jnlpArgs.add("-internalDir");
+                jnlpArgs.add(internalDir);
+                jnlpArgs.add("-failIfWorkDirIsMissing");
+                jnlpArgs.add(Boolean.toString(failIfWorkDirIsMissing));
             }
             if (candidateCertificates != null && !candidateCertificates.isEmpty()) {
                 for (String c: candidateCertificates) {

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -297,7 +297,8 @@ public class Launcher {
             System.setOut(new PrintStream(new TeeOutputStream(System.out,
                     new FileOutputStream(new File(internalDirPath.toFile(), "remoting.out.log")))));
         } else {
-            System.err.println("WARNING: Log location is not specified (neither -workDir nor -slaveLog set)");
+            // TODO: This message is suspected to break the CI
+            // System.err.println("WARNING: Log location is not specified (neither -workDir nor -slaveLog set)");
         }
 
         if(auth!=null) {

--- a/src/main/java/hudson/remoting/TeeOutputStream.java
+++ b/src/main/java/hudson/remoting/TeeOutputStream.java
@@ -16,6 +16,9 @@
  */
 package hudson.remoting;
 
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -27,7 +30,8 @@ import java.io.OutputStream;
  *
  * @version $Id: TeeOutputStream.java 610010 2008-01-08 14:50:59Z niallp $
  */
-class TeeOutputStream extends FilterOutputStream {
+@Restricted(NoExternalUse.class)
+public class TeeOutputStream extends FilterOutputStream {
 
     /** the second OutputStream to write to */
     protected OutputStream branch;

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 
 import hudson.remoting.Engine;
 import hudson.remoting.EngineListener;
+import java.nio.file.Path;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -110,6 +111,14 @@ public class Main {
     @Option(name="-agentLog", usage="Local agent error log destination (overrides workDir)")
     @CheckForNull
     public File agentLog = null;
+    
+    /**
+     * Specified location of the property file with JUL settings.
+     * @since TODO
+     */
+    @CheckForNull
+    @Option(name="-loggingConfig",usage="Path to the property file with java.util.logging settings")
+    public File loggingConfigFile = null;
     
     /**
      * Specifies a default working directory of the remoting instance.
@@ -237,6 +246,9 @@ public class Main {
         // TODO: ideally logging should be initialized before the "Setting up slave" entry
         if (agentLog != null) {
             engine.setAgentLog(agentLog.toPath());
+        }
+        if (loggingConfigFile != null) {
+            engine.setLoggingConfigFile(loggingConfigFile.toPath());
         }
         
         if (candidateCertificates != null && !candidateCertificates.isEmpty()) {

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -102,6 +102,16 @@ public class Main {
     public List<String> candidateCertificates;
 
     /**
+     * Specifies a destination for error logs.
+     * If specified, this option overrides the default destination within {@link #workDir}.
+     * If both this options and {@link #workDir} is not set, the log will not be generated.
+     * @since TODO
+     */
+    @Option(name="-agentLog", usage="Local agent error log destination (overrides workDir)")
+    @CheckForNull
+    public File agentLog = null;
+    
+    /**
      * Specifies a default working directory of the remoting instance.
      * If specified, this directory will be used to store logs, JAR cache, etc.
      * <p>
@@ -223,6 +233,12 @@ public class Main {
             engine.setJarCache(new FileSystemJarCache(jarCache,true));
         engine.setNoReconnect(noReconnect);
         engine.setKeepAlive(!noKeepAlive);
+        
+        // TODO: ideally logging should be initialized before the "Setting up slave" entry
+        if (agentLog != null) {
+            engine.setAgentLog(agentLog.toPath());
+        }
+        
         if (candidateCertificates != null && !candidateCertificates.isEmpty()) {
             CertificateFactory factory;
             try {

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -126,7 +126,19 @@ public class Main {
             usage = "Specifies a name of the internal files within a working directory ('remoting' by default)",
             depends = "-workDir")
     @Nonnull
-    public String internalDir = WorkDirManager.DEFAULT_INTERNAL_DIRECTORY;
+    public String internalDir = WorkDirManager.DirType.INTERNAL_DIR.getDefaultLocation();
+
+    /**
+     * Fail the initialization if the workDir or internalDir are missing.
+     * This option presumes that the workspace structure gets initialized previously in order to ensure that we do not start up with a borked instance
+     * (e.g. if a filesystem mount gets disconnected).
+     * @since TODO
+     */
+    @Option(name = "-failIfWorkDirIsMissing",
+            usage = "Fails the initialization if the requested workDir or internalDir are missing ('false' by default)",
+            depends = "-workDir")
+    @Nonnull
+    public boolean failIfWorkDirIsMissing = WorkDirManager.DEFAULT_FAIL_IF_WORKDIR_IS_MISSING;
 
     /**
      * @since 2.24
@@ -284,6 +296,7 @@ public class Main {
             engine.setWorkDir(workDir.toPath());
         }
         engine.setInternalDir(internalDir);
+        engine.setFailIfWorkDirIsMissing(failIfWorkDirIsMissing);
 
         return engine;
     }

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -50,6 +50,8 @@ import java.io.IOException;
 import hudson.remoting.Engine;
 import hudson.remoting.EngineListener;
 
+import javax.annotation.CheckForNull;
+
 /**
  * Entry point to JNLP slave agent.
  *
@@ -95,6 +97,20 @@ public class Main {
                     "root URLs. If starting with @ then the remainder is assumed to be the name of the " +
                     "certificate file to read.")
     public List<String> candidateCertificates;
+
+    /**
+     * Specifies a default working directory of the remoting instance.
+     * If specified, this directory will be used to store logs, JAR cache, etc.
+     * <p>
+     * In order to retain compatibility, the option is disabled by default.
+     * <p>
+     * Jenkins specifics: This working directory is expected to be equal to the agent root specified in Jenkins configuration.
+     * @since TODO
+     */
+    @Option(name = "-workDir",
+            usage = "Declares the working directory of the remoting instance (stores cache and logs by default)")
+    @CheckForNull
+    public File workDir = null;
 
     /**
      * @since 2.24

--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -52,7 +52,12 @@ public class WorkDirManager {
     /**
      * Defines a default name of the internal data directory within the Working directory.
      */
-    public  static final String DEFAULT_INTERNAL_DIRECTORY = "remoting";
+    public static final String DEFAULT_INTERNAL_DIRECTORY = "remoting";
+
+    /**
+     * Regular expression, which declares restrictions of the remoting internal directory symbols
+     */
+    public static final String SUPPORTED_INTERNAL_DIR_NAME_MASK = "[a-zA-Z0-9._-]*";
 
     private WorkDirManager() {
         // Cannot be instantinated outside
@@ -73,13 +78,19 @@ public class WorkDirManager {
      * Initializes the working directory for the agent.
      * Within the working directory the method also initializes a working directory for internal needs (like logging)
      * @param workDir Working directory
-     * @param internalDir Name of the remoting internal data directory within the working directory
+     * @param internalDir Name of the remoting internal data directory within the working directory.
+     *                    The range of the supported symbols is restricted to {@link #SUPPORTED_INTERNAL_DIR_NAME_MASK}.
      * @return Initialized directory for internal files within workDir or {@code null} if it is disabled
      * @throws IOException Workspace allocation issue (e.g. the specified directory is not writable).
      *                     In such case Remoting should not start up at all.
      */
     @CheckForNull
     public Path initializeWorkDir(final @CheckForNull File workDir, final @Nonnull String internalDir) throws IOException {
+
+        if (!internalDir.matches(SUPPORTED_INTERNAL_DIR_NAME_MASK)) {
+            throw new IOException("Remoting internal directory '" + internalDir +"' is not compliant with the required format " + SUPPORTED_INTERNAL_DIR_NAME_MASK);
+        }
+
         if (workDir == null) {
             LOGGER.log(Level.WARNING, "Agent working directory is not specified. Some functionality introduced in Remoting 3 may be disabled");
             return null;

--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -157,7 +157,7 @@ public class WorkDirManager {
      *                        If {@code null}, the behavior is defined by {@code internalDirPath}.
      * @throws IOException Initialization error
      */
-    public void setupLogging(@CheckForNull Path internalDirPath, @CheckForNull File overrideLogPath) throws IOException {
+    public void setupLogging(@CheckForNull Path internalDirPath, @CheckForNull Path overrideLogPath) throws IOException {
         if (loggingInitialized) {
             // Do nothing
             // TODO: print warning message?
@@ -168,7 +168,7 @@ public class WorkDirManager {
             System.out.println("Using " + overrideLogPath + " as an agent Error log destination. 'Out' log won't be generated");
             System.out.flush(); // Just in case the channel
             System.err.flush();
-            System.setErr(new PrintStream(new TeeOutputStream(System.err, new FileOutputStream(overrideLogPath))));
+            System.setErr(new PrintStream(new TeeOutputStream(System.err, new FileOutputStream(overrideLogPath.toFile()))));
             this.loggingInitialized = true;
         } else if (internalDirPath != null) { // New behavior
             System.out.println("Both error and output logs will be printed to " + internalDirPath);
@@ -183,7 +183,7 @@ public class WorkDirManager {
             this.loggingInitialized = true;
         } else {
             // TODO: This message is suspected to break the CI
-            // System.err.println("WARNING: Log location is not specified (neither -workDir nor -slaveLog set)");
+            // System.err.println("WARNING: Log location is not specified (neither -workDir nor -slaveLog/-agentLog set)");
         }
     }
 

--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -71,9 +71,10 @@ public class WorkDirManager {
     //TODO: New interfaces should ideally use Path instead of File
     /**
      * Initializes the working directory for the agent.
+     * Within the working directory the method also initializes a working directory for internal needs (like logging)
      * @param workDir Working directory
      * @param internalDir Name of the remoting internal data directory within the working directory
-     * @return Initialized workspace or {@code null} if it is disabled
+     * @return Initialized directory for internal files within workDir or {@code null} if it is disabled
      * @throws IOException Workspace allocation issue (e.g. the specified directory is not writable).
      *                     In such case Remoting should not start up at all.
      */

--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -37,8 +37,10 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
 
 /**
  * Performs working directory management in remoting.
@@ -148,7 +150,7 @@ public class WorkDirManager {
 
     /**
      * Sets up logging subsystem in the working directory.
-     * It the logging system is already initialized, do nothing
+     * If the logging system is already initialized, do nothing
      * @param internalDirPath Path to the internal remoting directory within the WorkDir.
      *                        If this value and {@code overrideLogPath} are null, the logging subsystem woill not
      *                        be initialized at all
@@ -180,6 +182,17 @@ public class WorkDirManager {
                     new FileOutputStream(new File(internalDirPath.toFile(), "remoting.err.log")))));
             System.setOut(new PrintStream(new TeeOutputStream(System.out,
                     new FileOutputStream(new File(internalDirPath.toFile(), "remoting.out.log")))));
+            
+            // Also redirect JUL to files
+            final Logger rootLogger = Logger.getLogger("");
+            final File julLog = new File(internalDirPath.toFile(), "remoting.log");
+            final FileHandler logHandler = new FileHandler(julLog.getAbsolutePath(), 
+                                         50*1024*1024, 5, false); 
+            logHandler.setFormatter(new SimpleFormatter()); 
+            logHandler.setLevel(Level.INFO); 
+            //TODO: remove the standard console handler 
+            rootLogger.addHandler(logHandler); 
+
             this.loggingInitialized = true;
         } else {
             // TODO: This message is suspected to break the CI

--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -39,6 +39,8 @@ import java.util.logging.Logger;
 
 /**
  * Performs working directory management in remoting.
+ * Using this manager remoting can initialize its working directory and put the data there.
+ * The structure of the directory is described in {@link DirType}.
  * @author Oleg Nenashev
  * @since TODO
  */

--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -1,0 +1,102 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright (c) 2016 CloudBees, Inc.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.remoting.engine;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Performs working directory management in remoting.
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+@Restricted(NoExternalUse.class)
+public class WorkDirManager {
+
+    private static final Logger LOGGER = Logger.getLogger(WorkDirManager.class.getName());
+
+    private static final WorkDirManager INSTANCE = new WorkDirManager();
+
+    /**
+     * Defines a default name of the internal data directory within the Working directory.
+     */
+    public  static final String DEFAULT_INTERNAL_DIRECTORY = "remoting";
+
+    private WorkDirManager() {
+        // Cannot be instantinated outside
+    }
+
+    /**
+     * Retrieves the instance of the {@link WorkDirManager}.
+     * Currently the implementation is hardcoded, but it may change in the future.
+     * @return Workspace manager
+     */
+    @Nonnull
+    public static WorkDirManager getInstance() {
+        return INSTANCE;
+    }
+
+    //TODO: New interfaces should ideally use Path instead of File
+    /**
+     * Initializes the working directory for the agent.
+     * @param workDir Working directory
+     * @param internalDir Name of the remoting internal data directory within the working directory
+     * @return Initialized workspace or {@code null} if it is disabled
+     * @throws IOException Workspace allocation issue (e.g. the specified directory is not writable).
+     *                     In such case Remoting should not start up at all.
+     */
+    @CheckForNull
+    public Path initializeWorkDir(final @CheckForNull File workDir, final @Nonnull String internalDir) throws IOException {
+        if (workDir == null) {
+            LOGGER.log(Level.WARNING, "Agent working directory is not specified. Some functionality introduced in Remoting 3 may be disabled");
+            return null;
+        } else {
+            if (workDir.exists()) {
+                if (!workDir.isDirectory()) {
+                    throw new IOException("The specified agent working directory path points to a non-directory file");
+                }
+                if (!workDir.canWrite() || !workDir.canRead() || !workDir.canExecute()) {
+                    throw new IOException("The specified agent working directory should be fully accessible to the remoting executable (RWX)");
+                }
+            }
+
+            // Now we create a subdirectory for remoting operations
+            Path internalDirPath = new File(workDir, internalDir).toPath();
+            Files.createDirectories(internalDirPath);
+            LOGGER.log(Level.INFO, "Using {0} as a remoting working files directory", internalDirPath);
+            return internalDirPath;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -99,7 +99,8 @@ public class WorkDirManager {
         }
 
         if (workDir == null) {
-            LOGGER.log(Level.WARNING, "Agent working directory is not specified. Some functionality introduced in Remoting 3 may be disabled");
+            // TODO: this message likely suppresses the connection setup on CI
+            // LOGGER.log(Level.WARNING, "Agent working directory is not specified. Some functionality introduced in Remoting 3 may be disabled");
             return null;
         } else {
             // Verify working directory

--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -62,7 +62,7 @@ public class WorkDirManager {
 
     private static final Logger LOGGER = Logger.getLogger(WorkDirManager.class.getName());
 
-    private static final WorkDirManager INSTANCE = new WorkDirManager();
+    private static WorkDirManager INSTANCE = new WorkDirManager();
 
     /**
      * Default value for the behavior when the requested working directory is missing.
@@ -104,6 +104,11 @@ public class WorkDirManager {
     @Nonnull
     public static WorkDirManager getInstance() {
         return INSTANCE;
+    }
+    
+    /*package*/ static void reset() {
+        INSTANCE = new WorkDirManager();
+        LogManager.getLogManager().reset();
     }
     
     public void disable(@Nonnull DirType dir) {

--- a/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerTest.java
@@ -26,6 +26,8 @@
 
 package org.jenkinsci.remoting.engine;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,6 +35,11 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests of {@link WorkDirManager}
@@ -45,14 +52,120 @@ public class WorkDirManagerTest {
     public TemporaryFolder tmpDir = new TemporaryFolder();
 
     @Test
+    public void shouldInitializeCorrectlyForExisitingDirectory() throws Exception {
+        final File dir = tmpDir.newFolder("foo");
+
+        // Probe files to confirm the directory does not get wiped
+        final File probeFileInWorkDir = new File(dir, "probe.txt");
+        FileUtils.write(probeFileInWorkDir, "Hello!");
+        final File remotingDir = new File(dir, WorkDirManager.DEFAULT_INTERNAL_DIRECTORY);
+        Files.createDirectory(remotingDir.toPath());
+        final File probeFileInInternalDir = new File(remotingDir, "/probe.txt");
+        FileUtils.write(probeFileInInternalDir, "Hello!");
+
+        // Initialize and check the results
+        final Path createdDir = WorkDirManager.getInstance().initializeWorkDir(dir, WorkDirManager.DEFAULT_INTERNAL_DIRECTORY);
+        assertThat("The initialized internal directory differs from the expected one", createdDir.toFile(), equalTo(remotingDir));
+
+        // Ensure that the files have not been wiped
+        Assert.assertTrue("Probe file in the workDir has been wiped", probeFileInWorkDir.exists());
+        Assert.assertTrue("Probe file in the internal directory has been wiped", probeFileInInternalDir.exists());
+    }
+
+    @Test
+    public void shouldPerformMkdirsIfRequired() throws Exception {
+        final File tmpDirFile = tmpDir.newFolder("foo");
+        final File workDir = new File(tmpDirFile, "just/a/long/non/existent/path");
+        Assert.assertFalse("The work dir should not exist in the test", workDir.exists());
+
+        // Probe files to confirm the directory does not get wiped;
+        final File remotingDir = new File(workDir, WorkDirManager.DEFAULT_INTERNAL_DIRECTORY);
+
+        // Initialize and check the results
+        final Path createdDir = WorkDirManager.getInstance().initializeWorkDir(workDir, WorkDirManager.DEFAULT_INTERNAL_DIRECTORY);
+        assertThat("The initialized internal directory differs from the expected one", createdDir.toFile(), equalTo(remotingDir));
+        Assert.assertTrue("Remoting internal directory should have been initialized", remotingDir.exists());
+    }
+
+    @Test
+    public void shouldProperlyCreateDirectoriesForCustomInternalDirs() throws Exception {
+        final String internalDirectoryName = "myRemotingLogs";
+        final File tmpDirFile = tmpDir.newFolder("foo");
+        final File workDir = new File(tmpDirFile, "just/another/path");
+        Assert.assertFalse("The work dir should not exist in the test", workDir.exists());
+
+        // Probe files to confirm the directory does not get wiped;
+        final File remotingDir = new File(workDir, internalDirectoryName);
+
+        // Initialize and check the results
+        final Path createdDir = WorkDirManager.getInstance().initializeWorkDir(workDir, internalDirectoryName);
+        assertThat("The initialized internal directory differs from the expected one", createdDir.toFile(), equalTo(remotingDir));
+        Assert.assertTrue("Remoting internal directory should have been initialized", remotingDir.exists());
+    }
+
+    @Test
     public void shouldFailIfWorkDirIsAFile() throws IOException {
         File foo = tmpDir.newFile("foo");
         try {
             WorkDirManager.getInstance().initializeWorkDir(foo, WorkDirManager.DEFAULT_INTERNAL_DIRECTORY);
         } catch (IOException ex) {
-            //TODO: Check message
+            assertThat("Wrong exception message",
+                    ex.getMessage(), containsString("The specified agent working directory path points to a non-directory file"));
             return;
         }
-        Assert.fail("");
+        Assert.fail("The directory has been initialized, but it should fail due to the conflicting file");
     }
+
+    @Test
+    public void shouldFailIfWorkDirIsNotExecutable() throws IOException {
+        verifyDirectoryFlag(DirectoryFlag.NOT_EXECUTABLE);
+    }
+
+    @Test
+    public void shouldFailIfWorkDirIsNotWritable() throws IOException {
+        verifyDirectoryFlag(DirectoryFlag.NOT_WRITABLE);
+    }
+
+
+    @Test
+    public void shouldFailIfWorkDirIsNotReadable() throws IOException {
+        verifyDirectoryFlag(DirectoryFlag.NOT_READABLE);
+    }
+
+    private void verifyDirectoryFlag(DirectoryFlag flag) throws IOException, AssertionError {
+        final File dir = tmpDir.newFolder("foo");
+        flag.modifyFile(dir);
+        try {
+            WorkDirManager.getInstance().initializeWorkDir(dir, WorkDirManager.DEFAULT_INTERNAL_DIRECTORY);
+        } catch (IOException ex) {
+            assertThat("Wrong exception message for " + flag,
+                    ex.getMessage(), containsString("The specified agent working directory should be fully accessible to the remoting executable"));
+            return;
+        }
+        Assert.fail("The directory has been initialized, but it should fail since the target dir is " + flag);
+    }
+
+
+    private enum DirectoryFlag {
+        NOT_WRITABLE,
+        NOT_READABLE,
+        NOT_EXECUTABLE;
+
+        public void modifyFile(File file) throws AssertionError {
+            switch (this) {
+                case NOT_EXECUTABLE:
+                    file.setExecutable(false);
+                    break;
+                case NOT_WRITABLE:
+                    file.setWritable(false);
+                    break;
+                case NOT_READABLE:
+                    file.setReadable(false);
+                    break;
+                default:
+                    Assert.fail("Unsupported file mode " + this);
+            }
+        }
+    }
+
 }

--- a/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerTest.java
@@ -132,6 +132,28 @@ public class WorkDirManagerTest {
         verifyDirectoryFlag(DirectoryFlag.NOT_READABLE);
     }
 
+    @Test
+    public void shouldNotSupportPathDelimitersAndSpacesInTheInternalDirName() throws IOException {
+        File foo = tmpDir.newFolder("foo");
+
+        assertAllocationFails(foo, " remoting ");
+        assertAllocationFails(foo, " remoting");
+        assertAllocationFails(foo, "directory with spaces");
+        assertAllocationFails(foo, "nested/directory");
+        assertAllocationFails(foo, "nested\\directory\\in\\Windows");
+        assertAllocationFails(foo, "just&a&symbol&I&do&not&like");
+    }
+
+    private void assertAllocationFails(File workDir, String internalDirName) throws AssertionError {
+        try {
+            WorkDirManager.getInstance().initializeWorkDir(workDir, internalDirName);
+        }  catch (IOException ex) {
+            assertThat(ex.getMessage(), containsString("Remoting internal directory '" + internalDirName +"' is not compliant with the required format"));
+            return;
+        }
+        Assert.fail("Initialization of WorkDirManager with invalid internal directory '" + internalDirName + "' should have failed");
+    }
+
     private void verifyDirectoryFlag(DirectoryFlag flag) throws IOException, AssertionError {
         final File dir = tmpDir.newFolder("foo");
         flag.modifyFile(dir);
@@ -144,7 +166,6 @@ public class WorkDirManagerTest {
         }
         Assert.fail("The directory has been initialized, but it should fail since the target dir is " + flag);
     }
-
 
     private enum DirectoryFlag {
         NOT_WRITABLE,

--- a/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerTest.java
@@ -1,0 +1,58 @@
+/*
+ *
+ *  * The MIT License
+ *  *
+ *  * Copyright (c) 2016 CloudBees, Inc.
+ *  *
+ *  * Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  * of this software and associated documentation files (the "Software"), to deal
+ *  * in the Software without restriction, including without limitation the rights
+ *  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  * copies of the Software, and to permit persons to whom the Software is
+ *  * furnished to do so, subject to the following conditions:
+ *  *
+ *  * The above copyright notice and this permission notice shall be included in
+ *  * all copies or substantial portions of the Software.
+ *  *
+ *  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.remoting.engine;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Tests of {@link WorkDirManager}
+ * @author Oleg Nenashev.
+ * @since TODO
+ */
+public class WorkDirManagerTest {
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
+    @Test
+    public void shouldFailIfWorkDirIsAFile() throws IOException {
+        File foo = tmpDir.newFile("foo");
+        try {
+            WorkDirManager.getInstance().initializeWorkDir(foo, WorkDirManager.DEFAULT_INTERNAL_DIRECTORY);
+        } catch (IOException ex) {
+            //TODO: Check message
+            return;
+        }
+        Assert.fail("");
+    }
+}


### PR DESCRIPTION
This pull requests adds a basic support of workspaces to Remoting. It offers options, which allow enabling workspaces for JNLP and SSH agents in Jenkins. 
* In the original implementation we had no way to determine working directory on startup. Remoting itself didn't know about workspaces even if it was a Jenkins agent/slave
* With previous parameters the remoting behavior does not change
* The change will require additional configuration on the Jenkins side to enable workspaces by default

Scope of changes:
- [x] Introduce concept of working directory in the remoting (should be compatible with Jenkins agents) - [JENKINS-39370](https://issues.jenkins-ci.org/browse/JENKINS-39370)
- [x] Automatically create STDERR and STDOUT outputs if the workspace is enabled - [JENKINS-39369](https://issues.jenkins-ci.org/browse/JENKINS-39369)
- [x] Use alternate JAR cache location if workspace is specified [JENKINS-18578](https://issues.jenkins-ci.org/browse/JENKINS-18578)
- [x] Add option to fail the agent startup if the workdir does not exist [JENKINS-39130](https://issues.jenkins-ci.org/browse/JENKINS-39130)
- [x] Functional tests
- [x] Automatic Logrotate for logs within workdir. Should be manageable by JUL settings 
- [x] Documentation
- [x] Adjust logging to make it compliant with docs, add support of JUL property files

Potential improvements:
- Postponed: specifying workdir after the agent startup (let Jenkins enable it?)
- TBD: other magic to automagically determine Workdir in a compatible way

