### PR TITLE
[JENKINS-39547] - Corrupt jar cache

### DIFF
--- a/src/main/java/hudson/remoting/Checksum.java
+++ b/src/main/java/hudson/remoting/Checksum.java
@@ -5,6 +5,7 @@ import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
@@ -74,44 +75,10 @@ final class Checksum {
      * Returns the checksum for the given URL.
      */
     static Checksum forURL(URL url) throws IOException {
-        String location = url.toExternalForm();
-        if (CHECKSUMS_BY_URL.containsKey(location)) {
-            return CHECKSUMS_BY_URL.get(location);
-        }
-
-        return calculateFor(url);
-    }
-
-    /**
-     * Allow calculating checksums only one at a time.
-     *
-     * <p>This method caches calculated checksums so future calls to
-     * {@link #forURL)} should not need to re-calculate the value.
-     *
-     * <p>Even if many slaves connect at around the same time, the checksums
-     * should only be calculated once. Making this method synchronized ensures
-     * this behavior.
-     *
-     * <p>Previously when a large number of slaves connected at the same time
-     * the master would experience a spike in CPU and probably I/O. By caching
-     * the results and synchronizing the calculation of the results this issue
-     * is addressed.
-     */
-    private synchronized static Checksum calculateFor(URL url) throws IOException {
-        // When callers all request the checksum of a large jar the calls to
-        // forURL will all fall through to this method since the first caller's
-        // calculation may take a while. Hence re-check the cache at the start.
-        String location = url.toExternalForm();
-        if (CHECKSUMS_BY_URL.containsKey(location)) {
-            return CHECKSUMS_BY_URL.get(location);
-        }
-
         try {
             MessageDigest md = MessageDigest.getInstance(JarLoaderImpl.DIGEST_ALGORITHM);
             Util.copy(url.openStream(), new DigestOutputStream(new NullOutputStream(), md));
-            Checksum checksum =  new Checksum(md.digest(), md.getDigestLength() / 8);
-            CHECKSUMS_BY_URL.putIfAbsent(location, checksum);
-            return checksum;
+            return new Checksum(md.digest(), md.getDigestLength() / 8);
         } catch (NoSuchAlgorithmException e) {
             throw new AssertionError(e);
         }
@@ -130,7 +97,4 @@ final class Checksum {
         public void write(byte[] b, int off, int len) {
         }
     }
-
-    private static final ConcurrentMap<String,Checksum> CHECKSUMS_BY_URL =
-        new ConcurrentHashMap<String,Checksum>();
 }

--- a/src/main/java/hudson/remoting/Checksum.java
+++ b/src/main/java/hudson/remoting/Checksum.java
@@ -5,13 +5,10 @@ import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * Represents 128bit checksum of a jar file.

--- a/src/main/java/hudson/remoting/Checksum.java
+++ b/src/main/java/hudson/remoting/Checksum.java
@@ -74,8 +74,9 @@ final class Checksum {
      * Returns the checksum for the given URL.
      */
     static Checksum forURL(URL url) throws IOException {
-        if (CHECKSUMS_BY_URL.containsKey(url)) {
-            return CHECKSUMS_BY_URL.get(url);
+        String location = url.toExternalForm();
+        if (CHECKSUMS_BY_URL.containsKey(location)) {
+            return CHECKSUMS_BY_URL.get(location);
         }
 
         return calculateFor(url);
@@ -100,15 +101,16 @@ final class Checksum {
         // When callers all request the checksum of a large jar the calls to
         // forURL will all fall through to this method since the first caller's
         // calculation may take a while. Hence re-check the cache at the start.
-        if (CHECKSUMS_BY_URL.containsKey(url)) {
-            return CHECKSUMS_BY_URL.get(url);
+        String location = url.toExternalForm();
+        if (CHECKSUMS_BY_URL.containsKey(location)) {
+            return CHECKSUMS_BY_URL.get(location);
         }
 
         try {
             MessageDigest md = MessageDigest.getInstance(JarLoaderImpl.DIGEST_ALGORITHM);
             Util.copy(url.openStream(), new DigestOutputStream(new NullOutputStream(), md));
             Checksum checksum =  new Checksum(md.digest(), md.getDigestLength() / 8);
-            CHECKSUMS_BY_URL.putIfAbsent(url, checksum);
+            CHECKSUMS_BY_URL.putIfAbsent(location, checksum);
             return checksum;
         } catch (NoSuchAlgorithmException e) {
             throw new AssertionError(e);
@@ -129,7 +131,6 @@ final class Checksum {
         }
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DMI_COLLECTION_OF_URLS")
-    private static final ConcurrentMap<URL,Checksum> CHECKSUMS_BY_URL =
-        new ConcurrentHashMap<URL,Checksum>();
+    private static final ConcurrentMap<String,Checksum> CHECKSUMS_BY_URL =
+        new ConcurrentHashMap<String,Checksum>();
 }

--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -20,7 +20,8 @@ import java.util.concurrent.ConcurrentMap;
 class JarLoaderImpl implements JarLoader, Serializable {
     private final ConcurrentMap<Checksum,URL> knownJars = new ConcurrentHashMap<>();
 
-    private final ConcurrentMap<String, Checksum> checksums = new ConcurrentHashMap<>();
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DMI_COLLECTION_OF_URLS") // TODO: fix this
+    private final ConcurrentMap<URL,Checksum> checksums = new ConcurrentHashMap<>();
 
     private final Set<Checksum> presentOnRemote = Collections.synchronizedSet(new HashSet<Checksum>());
 
@@ -57,14 +58,13 @@ class JarLoaderImpl implements JarLoader, Serializable {
      * Obtains the checksum for the jar at the specified URL.
      */
     public Checksum calcChecksum(URL jar) throws IOException {
-        String jarPath = jar.toExternalForm();
-        Checksum v = checksums.get(jarPath);    // cache hit
+        Checksum v = checksums.get(jar);    // cache hit
         if (v!=null)    return v;
 
         v = Checksum.forURL(jar);
 
         knownJars.put(v,jar);
-        checksums.put(jarPath,v);
+        checksums.put(jar,v);
         return v;
     }
 

--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -18,10 +18,9 @@ import java.util.concurrent.ConcurrentMap;
  */
 @edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_BAD_FIELD")
 class JarLoaderImpl implements JarLoader, Serializable {
-    private final ConcurrentMap<Checksum,URL> knownJars = new ConcurrentHashMap<Checksum,URL>();
+    private final ConcurrentMap<Checksum,URL> knownJars = new ConcurrentHashMap<>();
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DMI_COLLECTION_OF_URLS") // TODO: fix this
-    private final ConcurrentMap<URL,Checksum> checksums = new ConcurrentHashMap<URL,Checksum>();
+    private final ConcurrentMap<String, Checksum> checksums = new ConcurrentHashMap<>();
 
     private final Set<Checksum> presentOnRemote = Collections.synchronizedSet(new HashSet<Checksum>());
 
@@ -58,13 +57,14 @@ class JarLoaderImpl implements JarLoader, Serializable {
      * Obtains the checksum for the jar at the specified URL.
      */
     public Checksum calcChecksum(URL jar) throws IOException {
-        Checksum v = checksums.get(jar);    // cache hit
+        String jarPath = jar.toExternalForm();
+        Checksum v = checksums.get(jarPath);    // cache hit
         if (v!=null)    return v;
 
         v = Checksum.forURL(jar);
 
         knownJars.put(v,jar);
-        checksums.put(jar,v);
+        checksums.put(jarPath,v);
         return v;
     }
 

--- a/src/test/java/hudson/remoting/ChecksumTest.java
+++ b/src/test/java/hudson/remoting/ChecksumTest.java
@@ -45,17 +45,6 @@ public class ChecksumTest {
         assertNotEquals(Checksum.forFile(tmpFile1), Checksum.forFile(tmpFile2));
     }
 
-    @Test
-    public void testCaching() throws Exception {
-        File tmpFile = createTmpFile("file.txt", FILE_CONTENTS1);
-        HashCode hash = Files.hash(tmpFile, Hashing.sha256());
-        assertEquals(createdExpectedChecksum(hash), Checksum.forFile(tmpFile));
-
-        tmpFile.delete();
-        assertFalse(tmpFile.exists());
-        assertEquals(createdExpectedChecksum(hash), Checksum.forFile(tmpFile));
-    }
-
     private File createTmpFile(String name, String contents) throws Exception {
         File tmpFile = tmp.newFile(name);
         Files.append(contents, tmpFile, Charsets.UTF_8);

--- a/src/test/java/hudson/remoting/FileSystemJarCacheTest.java
+++ b/src/test/java/hudson/remoting/FileSystemJarCacheTest.java
@@ -9,6 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Bug;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
@@ -107,6 +108,7 @@ public class FileSystemJarCacheTest {
     }
 
     @Test
+    @Bug(39547)
     public void retrieveInvalidChecksum() throws Exception {
         when(mockChannel.getProperty(JarLoader.THEIRS)).thenReturn(mockJarLoader);
 


### PR DESCRIPTION
[JENKINS-39547](https://issues.jenkins-ci.org/browse/JENKINS-39547)

- Verify checksum after loaded from slave jar cache on agent side.
- Extract checksum caching from `Checksum` class to `JarLoaderImpl` and `FileSystemJarCache`.
  - It was done twice on master side and made the system more fragile on both ends.
  - I wonder if we need checksum cashing on agent side at all as we should rarely call `#retrieve` on same jar more than once between agent restarts. Getting rid of it would improve this fix as it would detect jar cache manipulation without restart.