### PR TITLE
[JENKINS-39596,JENKINS-39617] - hudsonUrl in Remoting Engine was always null since 3.0

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -128,6 +128,7 @@ public class Engine extends Thread {
      * This value is determined from {@link #candidateUrls} after a successful connection.
      * Note that this URL <b>DOES NOT</b> have "tcpSlaveAgentListener" in it.
      */
+    @CheckForNull
     private URL hudsonUrl;
 
     private final String secretKey;
@@ -171,6 +172,12 @@ public class Engine extends Thread {
         this.jarCache = jarCache;
     }
 
+    /**
+     * Provides Jenkins URL if available.
+     * @return Jenkins URL. May return {@code null} if the connection is not established or if the URL cannot be determined
+     *         in the {@link JnlpAgentEndpointResolver}.
+     */
+    @CheckForNull
     public URL getHudsonUrl() {
         return hudsonUrl;
     }
@@ -334,6 +341,7 @@ public class Engine extends Thread {
                     events.status("Could not resolve server among " + candidateUrls);
                     return;
                 }
+                hudsonUrl = endpoint.getServiceUrl();
 
                 events.status(String.format("Agent discovery successful%n"
                         + "  Agent address: %s%n"

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.URL;
 import java.nio.channels.SocketChannel;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Collections;
@@ -65,7 +66,23 @@ public class JnlpAgentEndpoint {
      */
     @CheckForNull
     private final Set<String> protocols;
+    
+    /**
+     * Jenkins URL for the discovered endpoint.
+     * @since TODO
+     */
+    @CheckForNull
+    private final URL serviceUrl;
 
+    /**
+     * @deprecated Use {@link #JnlpAgentEndpoint(java.lang.String, int, java.security.interfaces.RSAPublicKey, java.util.Set, java.lang.String)}
+     */
+    @Deprecated
+    public JnlpAgentEndpoint(@Nonnull String host, int port, @CheckForNull RSAPublicKey publicKey,
+                             @CheckForNull Set<String> protocols) {
+        this(host, port, publicKey, protocols, null);
+    }
+    
     /**
      * Constructor for a remote {@code Jenkins} instance.
      *
@@ -73,9 +90,12 @@ public class JnlpAgentEndpoint {
      * @param port      the port.
      * @param publicKey the {@code InstanceIdentity.getPublic()} of the remote instance (if known).
      * @param protocols The supported protocols.
+     * @param serviceURL URL of the service hosting the remoting endpoint.
+     *                   Use {@code null} if it is not a web service or if the URL cannot be determined
+     * @since TODO
      */
     public JnlpAgentEndpoint(@Nonnull String host, int port, @CheckForNull RSAPublicKey publicKey,
-                             @CheckForNull Set<String> protocols) {
+                             @CheckForNull Set<String> protocols, @CheckForNull URL serviceURL) {
         if (port <= 0 || 65536 <= port) {
             throw new IllegalArgumentException("Port " + port + " is not in the range 1-65535");
         }
@@ -83,6 +103,7 @@ public class JnlpAgentEndpoint {
         this.port = port;
         this.publicKey = publicKey;
         this.protocols = protocols == null ? null : Collections.unmodifiableSet(new LinkedHashSet<String>(protocols));
+        this.serviceUrl = serviceURL;
     }
 
     /**
@@ -95,6 +116,15 @@ public class JnlpAgentEndpoint {
         return new InetSocketAddress(host, port);
     }
 
+    /**
+     * Retrieves URL of the web service providing the remoting endpoint.
+     * @return Service URL if available. {@code null} otherwise.
+     */
+    @CheckForNull
+    public URL getServiceUrl() {
+        return serviceUrl;
+    }
+    
     /**
      * Gets the hostname.
      *

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -127,7 +127,16 @@ public class JnlpAgentEndpointResolver {
     public JnlpAgentEndpoint resolve() throws IOException {
         IOException firstError = null;
         for (String jenkinsUrl : jenkinsUrls) {
-            URL salURL = toAgentListenerURL(jenkinsUrl);
+            
+            final URL selectedJenkinsURL;
+            final URL salURL;
+            try {
+                selectedJenkinsURL = new URL(jenkinsUrl);
+                salURL = toAgentListenerURL(jenkinsUrl);
+            } catch (MalformedURLException ex) {
+                LOGGER.log(Level.WARNING, String.format("Cannot parse agent endpoint URL %s. Skipping it", jenkinsUrl), ex);
+                continue;
+            }
 
             // find out the TCP port
             HttpURLConnection con =

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -232,7 +232,8 @@ public class JnlpAgentEndpointResolver {
                     if (tokens[0].length() > 0) host = tokens[0];
                     if (tokens[1].length() > 0) port = Integer.parseInt(tokens[1]);
                 }
-                return new JnlpAgentEndpoint(host, port, identity, agentProtocolNames);
+                
+                return new JnlpAgentEndpoint(host, port, identity, agentProtocolNames, selectedJenkinsURL);
             } finally {
                 con.disconnect();
             }


### PR DESCRIPTION
Starting from Jenkins 2.16 (remoting 3.0) JNLP agents cannot be connected via Java Web Start [JENKINS-39596](https://issues.jenkins-ci.org/browse/JENKINS-39596). It happens, because Slave Installer Module in Jenkins core relies on the `hudsonUrl` in `hudson.remoting.Engine`, but starting from remoting 3.0 this field was alway null. Hence we were getting crappy exceptions in Jenkins, which were blocking the agent connection:

```
java.net.MalformedURLException: no protocol: jnlpJars/slave.jar
	at java.net.URL.<init>(URL.java:593)
	at java.net.URL.<init>(URL.java:490)
	at org.jenkinsci.modules.slave_installer.impl.InstallerGui.call(InstallerGui.java:65)
	at org.jenkinsci.modules.slave_installer.impl.InstallerGui.call(InstallerGui.java:34)
	at hudson.remoting.UserRequest.perform(UserRequest.java:153)
	at hudson.remoting.UserRequest.perform(UserRequest.java:50)
```

Changes:
- [x] JnlpAgentEndpointResolver now records service URL to the discovered Endpoint
- [x] Remoting Engine assigns the discovered service URL as `hudsonUrl` and passes it to API users
- [x] Remoting Engine does not fail the connection if one of the passed parameters is invalid ([JENKINS-39617](https://issues.jenkins-ci.org/browse/JENKINS-39617)). We needed such check for URL parsing for this issue in any case

* https://issues.jenkins-ci.org/browse/JENKINS-39596
* https://issues.jenkins-ci.org/browse/JENKINS-39617
