### PR TITLE
[JENKINS-25218] - Hardening of FifoBuffer operation logic

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
@@ -370,13 +370,12 @@ public class FifoBuffer implements Closeable {
             int chunk;
 
             final boolean shouldWaitToCleanTheBuffer;
-            synchronized (lock) {
-                if (closeRequested) {
-                    handleCloseRequest();
-                    throw new IOException("closed during write() operation");
-                }
-                
+            synchronized (lock) { 
                 while ((chunk = Math.min(len,writable()))==0) {
+                    if (closeRequested) {
+                        handleCloseRequest();
+                        throw new IOException("closed during write() operation");
+                    }
                     // The buffer is full, but we give other threads a chance to cleanup it
                     lock.wait(100);
                 }

--- a/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
@@ -369,11 +369,11 @@ public class FifoBuffer implements Closeable {
             synchronized (lock) {
                 if (closeRequested) {
                     handleCloseRequest();
-                    throw new IOException("closed during write operation");
+                    throw new IOException("closed during write() operation");
                 }
                 
                 while ((chunk = Math.min(len,writable()))==0) {
-                    
+                    // The buffer is full, but we give other threads a chance to cleanup
                     lock.wait(100);
                 }
 

--- a/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
@@ -279,6 +279,8 @@ public class FifoBuffer implements Closeable {
                     if (sent == 0)    // channel filled up
                         return read;
                 } catch (ClosedChannelException e) {
+                    // If the underlying channel is closed, we should close the buffer as well
+                    close();
                     return -1; // propagate EOF
                 }
             }
@@ -344,6 +346,8 @@ public class FifoBuffer implements Closeable {
                     sz += received;
                     written += received;
                 } catch (ClosedChannelException e) {
+                    // If the underlying channel is closed, we should close the buffer as well
+                    close();
                     if (written == 0) return -1; // propagate EOF
                     return written;
                 }
@@ -373,7 +377,7 @@ public class FifoBuffer implements Closeable {
                 }
                 
                 while ((chunk = Math.min(len,writable()))==0) {
-                    // The buffer is full, but we give other threads a chance to cleanup
+                    // The buffer is full, but we give other threads a chance to cleanup it
                     lock.wait(100);
                 }
 


### PR DESCRIPTION
It is a version of #100 submitted against the master branch

The most of [JENKINS-25218](https://issues.jenkins-ci.org/browse/JENKINS-25218) has been handled in https://github.com/jenkinsci/remoting/commit/3ea38c8b95a8d4ca8e245fc0999d7e4a9a6b1424 by @andresrc. But there are still potential issues in the FifoBuffer behavior.

Changes:
- [x] - Add closedRequested and handle it in multiple threads, which used to prevent <code>close()</code> calls previously
- [x] Fix potential NPE in FifoBuffer receiver
- [x] Do not rely on external code when we receive <code>ClosedChannelException</code> from the underlying channel