### PR TITLE
Docs - Rephrasing JNLP4-plaintext a bit to clarify

### DIFF
--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -56,9 +56,9 @@ Protocol uses non-blocking I/O wherever possible which removes the performance b
 * For performance testing **only**, not supported for other purposes
 * Cannot be used in Jenkins
 
-This protocol was developed to allow for like for like performance comparison 
-  between the original NIO engine used by <code>JNLP2-connect</code> and the new NIO engine 
-  used by <connect>JNLP4-connect</code>. 
+This protocol was developed to allow performance comparison 
+  between the original NIO engine used by <code>JNLP2-connect</code> and the new NIO engine
+  used by <connect>JNLP4-connect</code>.
 
 The protocol is similar to <code>JNLP4-connect</code>, 
   but it does not setup the TLS encryption between agent and master.


### PR DESCRIPTION
Seems like "like for like" might exist, but IMO it makes the sentence a bit more complicated that required.
And as a non-native person, it felt surprising, so maybe without it it'll be a bit easier to read.

@reviewbybees