### PR TITLE
[FIX JENKINS-40710] Match headers case-insensitively

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -427,8 +427,10 @@ public class JnlpAgentEndpointResolver {
     private static List<String> header(@Nonnull HttpURLConnection connection, String... headerNames) {
         Map<String, List<String>> headerFields = connection.getHeaderFields();
         for (String headerName : headerNames) {
-            if (headerFields.containsKey(headerName)) {
-                return headerFields.get(headerName);
+            for (String headerField : headerFields.keySet()) {
+                if (headerField.equalsIgnoreCase(headerName)) {
+                    return headerFields.get(headerName);
+                }
             }
         }
         return null;


### PR DESCRIPTION
Untested (tests seem broken for me).

[JENKINS-40710](https://issues.jenkins-ci.org/browse/JENKINS-40710)