### PR TITLE
[FIX JENKINS-40710, JENKINS-41513] Add null check, use correct header for map key

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -428,8 +428,8 @@ public class JnlpAgentEndpointResolver {
         Map<String, List<String>> headerFields = connection.getHeaderFields();
         for (String headerName : headerNames) {
             for (String headerField : headerFields.keySet()) {
-                if (headerField.equalsIgnoreCase(headerName)) {
-                    return headerFields.get(headerName);
+                if (headerField != null && headerField.equalsIgnoreCase(headerName)) {
+                    return headerFields.get(headerField);
                 }
             }
         }


### PR DESCRIPTION
I just tested this fix (I filed the bug) and ran into an NPE (even when there are headers, it appears the keyset contains null), and then realized it was still returning null even after matching because it was indexing into the map with the incorrectly cased header.

* https://issues.jenkins-ci.org/browse/JENKINS-41513
* https://issues.jenkins-ci.org/browse/JENKINS-40710