### PR TITLE
Replacing MimicException with the older ProxyException

### DIFF
--- a/src/main/java/hudson/remoting/Capability.java
+++ b/src/main/java/hudson/remoting/Capability.java
@@ -55,6 +55,8 @@ public final class Capability implements Serializable {
         return (mask& MASK_PIPE_THROTTLING)!=0;
     }
 
+    /** @deprecated no longer used */
+    @Deprecated
     public boolean hasMimicException() {
         return (mask&MASK_MIMIC_EXCEPTION)!=0;
     }
@@ -172,6 +174,7 @@ public final class Capability implements Serializable {
     /**
      * Supports {@link MimicException}.
      */
+    @Deprecated
     private static final long MASK_MIMIC_EXCEPTION = 1L << 3;
 
     /**

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1111,7 +1111,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * {@link ObjectOutputStream}, and it's the last command to be read.
      */
     private static final class CloseCommand extends Command {
-        private CloseCommand(Channel channel, Throwable cause) {
+        private CloseCommand(Channel channel, @CheckForNull Throwable cause) {
             super(channel, cause);
         }
 
@@ -1266,7 +1266,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *
      * @since 2.8
      */
-    public synchronized void close(Throwable diagnosis) throws IOException {
+    public synchronized void close(@CheckForNull Throwable diagnosis) throws IOException {
         if(outClosed!=null)  return;  // already closed
 
         try {

--- a/src/main/java/hudson/remoting/Command.java
+++ b/src/main/java/hudson/remoting/Command.java
@@ -28,6 +28,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.concurrent.ExecutionException;
+import javax.annotation.CheckForNull;
 
 /**
  * One-way command to be sent over to the remote system and executed there.
@@ -53,10 +54,10 @@ abstract class Command implements Serializable {
         this(true);
     }
 
-    protected Command(Channel channel, Throwable cause) {
+    protected Command(Channel channel, @CheckForNull Throwable cause) {
         // Command object needs to be deserializable on the other end without requiring custom classloading,
         // so we wrap this in ProxyException
-        this.createdAt = new Source(new ProxyException(cause));
+        this.createdAt = new Source(cause != null ? new ProxyException(cause) : null);
     }
 
     /**
@@ -105,7 +106,7 @@ abstract class Command implements Serializable {
         public Source() {
         }
 
-        private Source(Throwable cause) {
+        private Source(@CheckForNull Throwable cause) {
             super(cause);
         }
 

--- a/src/main/java/hudson/remoting/Command.java
+++ b/src/main/java/hudson/remoting/Command.java
@@ -55,7 +55,7 @@ abstract class Command implements Serializable {
 
     protected Command(Channel channel, Throwable cause) {
         // Command object needs to be deserializable on the other end without requiring custom classloading,
-        // so we wrap this in ProxyEkception
+        // so we wrap this in ProxyException
         this.createdAt = new Source(new ProxyException(cause));
     }
 

--- a/src/main/java/hudson/remoting/Command.java
+++ b/src/main/java/hudson/remoting/Command.java
@@ -55,8 +55,8 @@ abstract class Command implements Serializable {
 
     protected Command(Channel channel, Throwable cause) {
         // Command object needs to be deserializable on the other end without requiring custom classloading,
-        // so we wrap this in MimicException
-        this.createdAt = new Source(MimicException.make(channel,cause));
+        // so we wrap this in ProxyEkception
+        this.createdAt = new Source(new ProxyException(cause));
     }
 
     /**

--- a/src/main/java/hudson/remoting/MimicException.java
+++ b/src/main/java/hudson/remoting/MimicException.java
@@ -8,7 +8,9 @@ package hudson.remoting;
  *
  * @author Kohsuke Kawaguchi
  * @see Capability#hasMimicException()
+ * @deprecated Use {@link ProxyException} instead.
  */
+@Deprecated
 class MimicException extends Exception {
     private final String className;
     MimicException(Throwable cause) {

--- a/src/main/java/hudson/remoting/ProxyException.java
+++ b/src/main/java/hudson/remoting/ProxyException.java
@@ -24,6 +24,7 @@
 package hudson.remoting;
 
 import java.io.IOException;
+import javax.annotation.Nonnull;
 
 /**
  * Used when the exception thrown by the remoted code cannot be serialized.
@@ -35,7 +36,7 @@ import java.io.IOException;
  * @author Kohsuke Kawaguchi
  */
 public class ProxyException extends IOException {
-    public ProxyException(Throwable cause) {
+    public ProxyException(@Nonnull Throwable cause) {
         super(cause.toString()); // use toString() to capture the class name and error message
         setStackTrace(cause.getStackTrace());
 


### PR DESCRIPTION
`ProxyException` dates back to 2007 in 2515c1cddf732d5af6120060a2055b6795addf92. Yet for some reason @kohsuke added the nearly identical `MimicException` in 2012 in d084f5095f11a8bcb80913266d664b9d1f17dc3b. There is no reason to have both, especially when #136 improved the former.

The capability is unnecessary since `ProxyException` predates the introduction of capabilities themselves, in b310dd5443799a755b19631b88cef5c5a985dc2d in 2009.

Possibly `MimicException` could be simply deleted, not just deprecated, though it is not obvious to me whether it might be serialized somewhere on disk.

@reviewbybees esp. @oleg-nenashev