### PR TITLE
[JENKINS-41513] Prevent NPE in JnlpAgentEndpointResolver

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -428,7 +428,7 @@ public class JnlpAgentEndpointResolver {
         Map<String, List<String>> headerFields = connection.getHeaderFields();
         for (String headerName : headerNames) {
             for (String headerField : headerFields.keySet()) {
-                if (headerField.equalsIgnoreCase(headerName)) {
+                if (headerField != null && headerField.equalsIgnoreCase(headerName)) {
                     return headerFields.get(headerName);
                 }
             }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-41513

@reviewbybees

```
Jan 27, 2017 9:15:35 AM hudson.remoting.jnlp.Main$CuiListener error
SEVERE: null
java.lang.NullPointerException
	at org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.header(JnlpAgentEndpointResolver.java:431)
	at org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.resolve(JnlpAgentEndpointResolver.java:163)
	at hudson.remoting.Engine.innerRun(Engine.java:335)
	at hudson.remoting.Engine.run(Engine.java:287)
```