### PR TITLE
stable-2.x should be two digit versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
   <groupId>org.jenkins-ci.main</groupId>
   <artifactId>remoting</artifactId>
-  <version>2.62.5-SNAPSHOT</version>
+  <version>2.63-SNAPSHOT</version>
 
   <name>Jenkins remoting layer</name>
   <description>


### PR DESCRIPTION
In order to avoid confusion with three digit releases and their
respective branch names, let's keep stable-2.x for two digits.