### PR TITLE
[JENKINS-41730] - Add option to ignore the X-Jenkins-Agent-Protocols header

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,10 +99,18 @@ These properties require independent configuration on both sides of the channel.
       <td>org.jenkinsci.remoting.nio.NioChannelHub.disabled</td>
       <td>false</td>
       <td>2.62.3</td>
-      <td>?</td>
+      <td>TODO</td>
       <td><a href="https://issues.jenkins-ci.org/browse/JENKINS-39290">JENKINS-39290</a></td>
       <td>Boolean flag to disable NIO-based socket connection handling, and switch back to classic IO. Used to isolate the problem.</td>
-    </tr>-
+    </tr>
+    <tr>
+      <td>org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.ignoreJenkinsAgentProtocolsHeader</td>
+      <td>false</td>
+      <td>TODO</td>    
+      <td>TODO</td>
+      <td><a href="https://issues.jenkins-ci.org/browse/JENKINS-41730">JENKINS-41730</a></td>
+      <td>If enabled, the remoting client will ignore the list of supported protocols returned by the server. Then it will try to connect by iterating through available protocols till it finds the server accepts connection.</td>
+    </tr>
     <!--Template
     <tr>
       <td></td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,12 +104,12 @@ These properties require independent configuration on both sides of the channel.
       <td>Boolean flag to disable NIO-based socket connection handling, and switch back to classic IO. Used to isolate the problem.</td>
     </tr>
     <tr>
-      <td>org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.ignoreJenkinsAgentProtocolsHeader</td>
+      <td>org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.protocolNamesToTry</td>
       <td>false</td>
       <td>TODO</td>    
       <td>TODO</td>
       <td><a href="https://issues.jenkins-ci.org/browse/JENKINS-41730">JENKINS-41730</a></td>
-      <td>If enabled, the remoting client will ignore the list of supported protocols returned by the server. Then it will try to connect by iterating through available protocols till it finds the server accepts connection.</td>
+      <td>If specified, only the protocols from the list will be tried during the connection. The option provides protocol names, but the order of the check is defined internally and cannot be changed.</td>
     </tr>
     <!--Template
     <tr>

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -191,9 +191,9 @@ public class JnlpAgentEndpointResolver {
                                 "In the case of the header corruption as a workaround you can use the " +
                                 "'org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.protocolNamesToTry' system property " +
                                 "to define the supported protocols.");
+                    } else {
+                        LOGGER.log(Level.INFO, "Remoting server accepts the following protocols: {0}", agentProtocolNames);
                     }
-                    
-                    LOGGER.log(Level.INFO, "Remoting server accepts the following protocols: {0}", agentProtocolNames);
                 }
                 
                 if (PROTOCOL_NAMES_TO_TRY != null) {

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -268,8 +268,6 @@ public class JnlpAgentEndpointResolver {
                     if (tokens[1].length() > 0) port = Integer.parseInt(tokens[1]);
                 }
                 
-                
-                
                 return new JnlpAgentEndpoint(host, port, identity, agentProtocolNames, selectedJenkinsURL);
             } finally {
                 con.disconnect();


### PR DESCRIPTION
In particular cases the `X-Jenkins-Agent-Protocols` response header may change (e.g. due to the improperly configured proxy). This change adds diagnostics for such case and also adds a system property, which allows working around the issue by sacrificing the performance.

- [x] Add the `org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.ignoreJenkinsAgentProtocolsHeader` property, which disables the cache
- [x] Print warning in the case if the list of supported protocols is empty
- [x] Add documentation

https://issues.jenkins-ci.org/browse/JENKINS-41730

@reviewbybees, esp. @stephenc 