### PR TITLE
[FIXED JENKINS-42371] - Call disconnect() on HttpURLConnection object

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -376,8 +376,9 @@ public class Launcher {
             }
         }
         while (true) {
+            URLConnection con = null;
             try {
-                URLConnection con = Util.openURLConnection(slaveJnlpURL);
+                con = Util.openURLConnection(slaveJnlpURL);
                 if (con instanceof HttpURLConnection) {
                     HttpURLConnection http = (HttpURLConnection) con;
                     if  (slaveJnlpCredentials != null) {
@@ -462,6 +463,11 @@ public class Launcher {
                 System.err.println("Waiting 10 seconds before retry");
                 Thread.sleep(10*1000);
                 // retry
+            } finally {
+                if (con instanceof HttpURLConnection) {
+                    HttpURLConnection http = (HttpURLConnection) con;
+                    http.disconnect();
+                }
             }
         }
     }


### PR DESCRIPTION
Release the network resource(s) held by the underlying connection(s?):

 - during retry attempts
 - after obtaining the JNLP connection arguments