### PR TITLE
FindBugs - Unravel the classloading clew coming from the PreloadJarTask

### DIFF
--- a/src/main/java/hudson/remoting/ClassLoaderHolder.java
+++ b/src/main/java/hudson/remoting/ClassLoaderHolder.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import javax.annotation.CheckForNull;
 
 /**
  * Remoting-aware holder of {@link ClassLoader} that replaces ClassLoader by its {@link RemoteClassLoader}.
@@ -14,6 +15,8 @@ import java.io.Serializable;
  * @since 2.12
  */
 public class ClassLoaderHolder implements Serializable {
+    
+    @CheckForNull
     private transient ClassLoader classLoader;
 
     public ClassLoaderHolder(ClassLoader classLoader) {
@@ -23,11 +26,12 @@ public class ClassLoaderHolder implements Serializable {
     public ClassLoaderHolder() {
     }
 
+    @CheckForNull
     public ClassLoader get() {
         return classLoader;
     }
 
-    public void set(ClassLoader classLoader) {
+    public void set(@CheckForNull ClassLoader classLoader) {
         this.classLoader = classLoader;
     }
 

--- a/src/main/java/hudson/remoting/DelegatingCallable.java
+++ b/src/main/java/hudson/remoting/DelegatingCallable.java
@@ -23,6 +23,8 @@
  */
 package hudson.remoting;
 
+import javax.annotation.CheckForNull;
+
 /**
  * {@link Callable} that nominates another claassloader for serialization.
  *
@@ -37,10 +39,12 @@ package hudson.remoting;
  * In such a case, implement this interface, instead of plain {@link Callable} and
  * return a classloader that can see all the classes.
  *
- * In case of Hudson, {@code PluginManager.uberClassLoader} is a good candidate.  
+ * In case of Jenkins, {@code PluginManager.uberClassLoader} is a good candidate.  
  *
  * @author Kohsuke Kawaguchi
  */
 public interface DelegatingCallable<V,T extends Throwable> extends Callable<V,T> {
+    
+    @CheckForNull
     ClassLoader getClassLoader();
 }

--- a/src/main/java/hudson/remoting/DelegatingCallable.java
+++ b/src/main/java/hudson/remoting/DelegatingCallable.java
@@ -45,6 +45,14 @@ import javax.annotation.CheckForNull;
  */
 public interface DelegatingCallable<V,T extends Throwable> extends Callable<V,T> {
     
+    /**
+     * Returns the class loader to be used for the callable.
+     * 
+     * @return {@link ClassLoader} to be used.
+     *         The value may be {@code null} if the classloader is not being propagated to the remote side.
+     *         If all classes in the call are primitives or {@code Void}, the value may be also {@code null}. 
+     *         In such cased  the handling code should try other possible classloaders.
+     */
     @CheckForNull
     ClassLoader getClassLoader();
 }

--- a/src/main/java/hudson/remoting/DumbClassLoaderBridge.java
+++ b/src/main/java/hudson/remoting/DumbClassLoaderBridge.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /**
  * Implements full {@link IClassLoader} from a legacy one
@@ -23,9 +24,10 @@ import javax.annotation.CheckForNull;
  * @see Capability#supportsPrefetch()
  */
 class DumbClassLoaderBridge implements IClassLoader {
+    @Nonnull
     private final IClassLoader base;
 
-    DumbClassLoaderBridge(IClassLoader base) {
+    DumbClassLoaderBridge(@Nonnull IClassLoader base) {
         this.base = base;
     }
 

--- a/src/main/java/hudson/remoting/ImportedClassLoaderTable.java
+++ b/src/main/java/hudson/remoting/ImportedClassLoaderTable.java
@@ -27,9 +27,13 @@ import hudson.remoting.RemoteClassLoader.IClassLoader;
 
 import java.util.Hashtable;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 /**
+ * Imported {@link ClassLoader} table.
+ * Stores references to {@link ClassLoader} instances, which have been exported to the instance by the remote side.
  * @author Kohsuke Kawaguchi
+ * @since 2.0
  */
 final class ImportedClassLoaderTable {
     final Channel channel;
@@ -45,11 +49,19 @@ final class ImportedClassLoaderTable {
      * <p>
      * This method "consumes" the given oid for the purpose of reference counting.
      */
+    @Nonnull
     public synchronized ClassLoader get(int oid) {
         return get(RemoteInvocationHandler.wrap(channel,oid,IClassLoader.class,false,false));
     }
 
-    public synchronized ClassLoader get(IClassLoader classLoaderProxy) {
+    /**
+     * Retrieves classloader for the specified proxy class.
+     * If the classloader instance is missing in the cache, it will be created during the call.
+     * @param classLoaderProxy Proxy instance
+     * @return Classloader instance
+     */
+    @Nonnull
+    public synchronized ClassLoader get(@Nonnull IClassLoader classLoaderProxy) {
         ClassLoader r = classLoaders.get(classLoaderProxy);
         if(r==null) {
             // we need to be able to use the same hudson.remoting classes, hence delegate

--- a/src/main/java/hudson/remoting/PreloadJarTask.java
+++ b/src/main/java/hudson/remoting/PreloadJarTask.java
@@ -28,6 +28,7 @@ import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.IOException;
 import java.net.URL;
+import javax.annotation.CheckForNull;
 
 /**
  * {@link Callable} used to deliver a jar file to {@link RemoteClassLoader}.
@@ -40,13 +41,18 @@ final class PreloadJarTask implements DelegatingCallable<Boolean,IOException> {
      */
     private final URL[] jars;
 
-    private transient ClassLoader target;
+    //TODO: This implementation exists starting from https://github.com/jenkinsci/remoting/commit/f3d0a81fdf46a10c3c6193faf252efaeaee98823
+    // Since this time nothing has blown up, but it still seems to be suspicious.
+    // The solution for null classloaders is available in RemoteDiagnostics.Script#call() in the Jenkins core codebase
+    @CheckForNull
+    private transient ClassLoader target = null;
 
-    PreloadJarTask(URL[] jars, ClassLoader target) {
+    PreloadJarTask(URL[] jars, @CheckForNull ClassLoader target) {
         this.jars = jars;
         this.target = target;
     }
 
+    @Override
     public ClassLoader getClassLoader() {
         return target;
     }

--- a/src/main/java/hudson/remoting/RemoteInvocationHandler.java
+++ b/src/main/java/hudson/remoting/RemoteInvocationHandler.java
@@ -875,6 +875,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
             // this callable only executes public methods exported by this side, so these methods are assumed to be safe
         }
 
+        @Override
         public ClassLoader getClassLoader() {
             if(classLoader!=null)
                 return classLoader;


### PR DESCRIPTION
It appears that the target classloader in PreloadJarTask may be actually null. And FindBugs is grumbling about it. So I made an attempt to process the dependencies and to properly annotate methods and to catch possible edge cases.

The only real problem is that UserRequest#perform() may fail horribly if the request has been constructed with null classloader ref. So I have added explicit handling for this case on the invoking side.

@reviewbybees, esp. @kohsuke and @stephenc who are involved into this logic