### PR TITLE
[JENKINS-48130] - Improve handling and diagnostics of RejectedExecutionException in the code

### DIFF
--- a/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
+++ b/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import org.jenkinsci.remoting.util.ExecutorServiceUtils.FatalRejectedExecutionException;
 
 /**
  * {@link ExecutorService} that uses at most one executor.
@@ -86,7 +87,8 @@ public class AtmostOneThreadExecutor extends AbstractExecutorService {
     public void execute(Runnable command) {
         synchronized (q) {
             if (isShutdown()) {
-                throw new RejectedExecutionException("This executor has been shutdown.");
+                // No way this executor service can be recovered
+                throw new FatalRejectedExecutionException("This executor has been shutdown.");
             }
             q.add(command);
             if (!isAlive()) {

--- a/src/main/java/hudson/remoting/JarCacheSupport.java
+++ b/src/main/java/hudson/remoting/JarCacheSupport.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jenkinsci.remoting.util.ExecutorServiceUtils;
 
 /**
  * Default partial implementation of {@link JarCache}.
@@ -50,49 +51,84 @@ public abstract class JarCacheSupport extends JarCache {
 
         while (true) {// might have to try a few times before we get successfully resolve
 
-            final Checksum key = new Checksum(sum1,sum2);
-            final AsyncFutureImpl<URL> promise = new AsyncFutureImpl<URL>();
-            Future<URL> cur = inprogress.putIfAbsent(key, promise);
+            final Checksum key = new Checksum(sum1,sum2);        
+            Future<URL> cur = inprogress.get(key);
             if (cur!=null) {
                 // this computation is already in progress. piggy back on that one
                 return cur;
             } else {
                 // we are going to resolve this ourselves and publish the result in 'promise' for others
-                downloader.submit(new Runnable() {
-                    public void run() {
-                        try {
-                            URL url = retrieve(channel,sum1,sum2);
-                            inprogress.remove(key);
-                            promise.set(url);
-                        } catch (ChannelClosedException e) {
-                            // the connection was killed while we were still resolving the file
-                            bailout(e);
-                        } catch (RequestAbortedException e) {
-                            // the connection was killed while we were still resolving the file
-                            bailout(e);
-                        } catch (InterruptedException e) {
-                            // we are bailing out, but we need to allow another thread to retry later.
-                            bailout(e);
-
-                            LOGGER.log(Level.WARNING, String.format("Interrupted while resolving a jar %016x%016x",sum1,sum2), e);
-                        } catch (Throwable e) {
-                            // in other general failures, we aren't retrying
-                            // TODO: or should we?
-                            promise.set(e);
-
-                            LOGGER.log(Level.WARNING, String.format("Failed to resolve a jar %016x%016x",sum1,sum2), e);
-                        }
-                    }
-
-                    /**
-                     * Report a failure of the retrieval and allows another thread to retry.
-                     */
-                    private void bailout(Exception e) {
-                        inprogress.remove(key);     // this lets another thread to retry later
-                        promise.set(e);             // then tell those who are waiting that we aborted
-                    }
-                });
+                try {
+                    final AsyncFutureImpl<URL> promise = new AsyncFutureImpl<URL>();
+                    ExecutorServiceUtils.submitAsync(downloader, new  DownloadRunnable(channel, sum1, sum2, key, promise));
+                    // Now we are sure that the task has been accepted to the queue, hence we cache the promise
+                    // if nobody else caches it before.
+                    inprogress.putIfAbsent(key, promise);
+                } catch (ExecutorServiceUtils.ExecutionRejectedException ex) {
+                    LOGGER.log(Level.SEVERE, "Downloader executor service has rejected the download command for checksum " + key, ex);
+                    // Prevent infinite loop, try again in 100ms to let the shyutdown logic kill this operation correctly
+                    Thread.sleep(1000);
+                }
             }
+        }
+    }
+    
+    private class DownloadRunnable implements Runnable {
+    
+        final Channel channel;
+        final long sum1;
+        final long sum2;
+        final Checksum key;
+        final AsyncFutureImpl<URL> promise;
+
+        public DownloadRunnable(Channel channel, long sum1, long sum2, Checksum key, AsyncFutureImpl<URL> promise) {
+            this.channel = channel;
+            this.sum1 = sum1;
+            this.sum2 = sum2;
+            this.key = key;
+            this.promise = promise;
+        }
+        
+        @Override
+        public void run() {
+            try {
+                // Deduplication: There is a risk that multiple downloadables get scheduled, hence we check if
+                // the promise is actually in the queue
+                Future<URL> inprogressDownload = inprogress.get(key);
+                if (promise != inprogressDownload) {
+                    // Duplicated entry due to the race condition, do nothing
+                    return;
+                }
+                
+                URL url = retrieve(channel, sum1, sum2);
+                inprogress.remove(key);
+                promise.set(url);
+            } catch (ChannelClosedException e) {
+                // the connection was killed while we were still resolving the file
+                bailout(e);
+            } catch (RequestAbortedException e) {
+                // the connection was killed while we were still resolving the file
+                bailout(e);
+            } catch (InterruptedException e) {
+                // we are bailing out, but we need to allow another thread to retry later.
+                bailout(e);
+
+                LOGGER.log(Level.WARNING, String.format("Interrupted while resolving a jar %016x%016x", sum1, sum2), e);
+            } catch (Throwable e) {
+                // in other general failures, we aren't retrying
+                // TODO: or should we?
+                promise.set(e);
+
+                LOGGER.log(Level.WARNING, String.format("Failed to resolve a jar %016x%016x", sum1, sum2), e);
+            }
+        }
+
+        /**
+         * Report a failure of the retrieval and allows another thread to retry.
+         */
+        private void bailout(Exception e) {
+            inprogress.remove(key);     // this lets another thread to retry later
+            promise.set(e);             // then tell those who are waiting that we aborted
         }
     }
 
@@ -104,6 +140,6 @@ public abstract class JarCacheSupport extends JarCache {
         }
         return jl;
     }
-
+    
     private static final Logger LOGGER = Logger.getLogger(JarCacheSupport.class.getName());
 }

--- a/src/main/java/hudson/remoting/SingleLaneExecutorService.java
+++ b/src/main/java/hudson/remoting/SingleLaneExecutorService.java
@@ -136,9 +136,7 @@ public class SingleLaneExecutorService extends AbstractExecutorService {
                     assert scheduled;
                     if (!tasks.isEmpty()) {
                         // we have still more things to do
-                        base.submit(this);
                         try {
-                            // Submit task in the async mode
                             ExecutorServiceUtils.submitAsync(base, this);
                         } catch (ExecutorServiceUtils.ExecutionRejectedException ex) {
                             // It is supposed to be a fatal error, but we cannot propagate it properly

--- a/src/main/java/hudson/remoting/SingleLaneExecutorService.java
+++ b/src/main/java/hudson/remoting/SingleLaneExecutorService.java
@@ -119,7 +119,7 @@ public class SingleLaneExecutorService extends AbstractExecutorService {
                 ExecutorServiceUtils.submitAsync(base, runner);
             } catch (ExecutorServiceUtils.ExecutionRejectedException ex) {
                 // Wrap by the runtime exception since there is no other solution here
-                throw new RejectedExecutionException("Base executor service has rejected the task", ex);
+                throw new RejectedExecutionException("Base executor service " + base + " has rejected the task " + command, ex);
             }
         }
     }

--- a/src/main/java/hudson/remoting/SingleLaneExecutorService.java
+++ b/src/main/java/hudson/remoting/SingleLaneExecutorService.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jenkinsci.remoting.util.ExecutorServiceUtils;
+import org.jenkinsci.remoting.util.ExecutorServiceUtils.FatalRejectedExecutionException;
 
 /**
  * Creates an {@link ExecutorService} that executes submitted tasks sequentially
@@ -104,7 +105,7 @@ public class SingleLaneExecutorService extends AbstractExecutorService {
     @Override
     public synchronized void execute(Runnable command) {
         if (shuttingDown) {
-            throw new RejectedExecutionException("Cannot execute the command " + command +
+            throw new FatalRejectedExecutionException("Cannot execute the command " + command +
                     ". The executor service is shutting down");
         }
             
@@ -147,7 +148,7 @@ public class SingleLaneExecutorService extends AbstractExecutorService {
                             LOGGER.log(Level.SEVERE, String.format(
                                     "Base executor service %s has rejected the queue task %s. Propagating the RuntimeException to the caller.", 
                                     ex.getExecutorServiceDisplayName(), ex.getRunnableDisplayName()), ex);
-                            throw new RejectedExecutionException("Base executor service has rejected the task from the queue", ex);
+                            throw ExecutorServiceUtils.createRuntimeException("Base executor service has rejected the task from the queue", ex);
                         }
                     } else {
                         scheduled = false;

--- a/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
@@ -637,6 +637,7 @@ public class NioChannelHub implements Runnable, Closeable {
                             LOGGER.log(SEVERE, "Communication problem in " + t + ". NIO Transport will be aborted.", e);
                             t.abort(e);
                         } catch (ExecutorServiceUtils.ExecutionRejectedException e) {
+                            // TODO: should we try to reschedule the task if the issue is not fatal?
                             // The swimlane has rejected the execution, e.g. due to the "shutting down" state.
                             LOGGER.log(SEVERE, "The underlying executor service rejected the task in " + t + ". NIO Transport will be aborted.", e);
                             t.abort(e);

--- a/src/main/java/org/jenkinsci/remoting/util/ExecutorServiceUtils.java
+++ b/src/main/java/org/jenkinsci/remoting/util/ExecutorServiceUtils.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.remoting.util;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import javax.annotation.Nonnull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Helper class for {@link ExecutorService} operations.
+ * @author Oleg Nenashev
+ */
+@Restricted(NoExternalUse.class)
+public class ExecutorServiceUtils {
+    
+    private ExecutorServiceUtils() {
+        // The class cannot be constructed
+    }
+    
+    /**
+     * Submits a task to the executor service without further handling. 
+     * The original {@link ExecutorService#submit(java.lang.Runnable)} method actually expects this return value 
+     * to be handled, but this method explicitly relies on the external logic to handle the future operation.
+     * Use on your own risk.
+     * @param es Executor service
+     * @param runnable Operation to be executed
+     * @throws ExecutionRejectedException Execution is rejected by the executor service
+     */
+    @Nonnull
+    @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE", 
+            justification = "User of this API explicitly submits the task in the async mode on his own risk")
+    public static void submitAsync(@Nonnull ExecutorService es, @Nonnull Runnable runnable) 
+            throws ExecutionRejectedException {
+        try {
+            es.submit(runnable);
+        } catch (RejectedExecutionException ex) {
+            // Rethrow and make API users handle this.
+            throw new ExecutionRejectedException(runnable, es, ex);
+        }
+    }
+    
+    /**
+     * Wraps the runtime {@link RejectedExecutionException}.
+     * The exception also caches the serializable metadata.
+     */
+    @Restricted(NoExternalUse.class)
+    public static class ExecutionRejectedException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+        private final String executorServiceDisplayName;
+        private final String runnableDisplayName;
+        
+        public ExecutionRejectedException(Runnable runnable, ExecutorService es, String message) {
+            super(message);
+            this.executorServiceDisplayName = es.toString();
+            this.runnableDisplayName = es.toString();
+        }
+        
+        public ExecutionRejectedException(Runnable runnable, ExecutorService es, RejectedExecutionException cause) {
+            super(cause);
+            this.executorServiceDisplayName = es.toString();
+            this.runnableDisplayName = es.toString();
+        }
+
+        public String getExecutorServiceDisplayName() {
+            return executorServiceDisplayName;
+        }
+
+        public String getRunnableDisplayName() {
+            return runnableDisplayName;
+        }
+    }
+}

--- a/src/test/java/hudson/remoting/PipeTest.java
+++ b/src/test/java/hudson/remoting/PipeTest.java
@@ -222,7 +222,12 @@ public class PipeTest extends RmiTestBase implements Serializable {
         }
 
         public Integer call() throws IOException {
-            read(pipe);
+            try {
+                read(pipe);
+            } catch(AssertionError ex) {
+                // Propagate the assetion to the remote side
+                throw new IOException("Assertion failed", ex);
+            }
             return 5;
         }
 
@@ -238,12 +243,13 @@ public class PipeTest extends RmiTestBase implements Serializable {
         os.close();
     }
 
-    private static void read(Pipe p) throws IOException {
-        InputStream in = p.getIn();
-        for( int cnt=0; cnt<256*256; cnt++ )
-            assertEquals(cnt/256,in.read());
-        assertEquals(-1,in.read());
-        in.close();
+    private static void read(Pipe p) throws IOException, AssertionError {
+        try (InputStream in = p.getIn()) {
+            for( int cnt=0; cnt<256*256; cnt++ ) {
+                assertEquals(cnt/256,in.read());
+            }
+            assertEquals(-1,in.read());
+        }
     }
 
 


### PR DESCRIPTION
Background: I was analysing JIRA issues related to the NIOHub fatal channel termination causing massive disconnection of agents. It appears that the `SingleLaneExecutor` is not completely correctly used there...

TL;DR: A single packet sent to the channel with pending shutdown may cause the termination of all remoting channels in `JNLP1`, `JNLP2`, `CLI`, and `CLI2` protocols. `JNLP4` does not seem to be affected.

* When we receive the command in a particular `NioTransport`, message parts are are being submitted to its `SingleLaneExecutor` 
* If the executor service rejects the task (e.g. due to the pending shutdown), a runtime `RejectedExecutionException` is being thrown. E.g. [here](https://github.com/jenkinsci/remoting/blob/master/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java#L595-L599)
* This exception is not being caught on the `NioTransport` level and gets proparated to the top level of `NioChannelHub#run()`
* `NioChannelHub#run()` catches the unhandled `RuntimeException`... and terminates the entire `NioHub`. [code is here](https://github.com/jenkinsci/remoting/blob/master/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java#L655-L660)

https://issues.jenkins-ci.org/browse/JENKINS-48130

### Applied changes

- [x] - Introduced the `ExecutorServiceUtils` class, which encapsulates the unsafe task submission and its runtime exception 
 ** FindBugs was raising the flag about the method handling BTW. [Here is also a discussion](https://mailman.cs.umd.edu/pipermail/findbugs-discuss/2010-November/003223.html) about this feature in FindBugs
- [x] - Also introduced distinguishing of  `RejectedExecutionException` and FATAL `RejectedExecutionException` in the logic
- [x] - Modified `NioChannelHub` to handle the task submission errors without BOOM
- [x] - Modified `JarCacheSupport` to handle the task submission errors (e.g. when remoting gets shutdown in parallel with classloading) - same cause
- [x] - Modified `SingleLaneExecutorService` to properly handle the issues happening in its proxied Executor Service

### Related issues

* I would expect the messages like "Unexpected shutdown of the selector thread" or "The executor service is shutting down" to be reported in system logs for the root cause, but there is no such JIRA tickets
* I see no issues with such pattern in JIRA, so the log messages are not being reported on the master side. But it still may happen on the agent side. Or my analysis may be wrong
* I have seen many issues regarding spontaneous failures reported to JNLP2, which have been fixed by migrating to JNLP4. It could be one of the rootcases