### PR TITLE
[JENKINS-37566] - FindBugs - Cleanup issues in ExportTable implementation

### DIFF
--- a/src/main/java/hudson/remoting/ExportTable.java
+++ b/src/main/java/hudson/remoting/ExportTable.java
@@ -23,6 +23,7 @@
  */
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -41,6 +42,8 @@ import static java.util.logging.Level.*;
 import javax.annotation.CheckForNull;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.meta.When;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Manages unique ID for exported objects, and allows look-up from IDs.
@@ -274,10 +277,14 @@ final class ExportTable {
 
     /**
      * Captures the list of export, so that they can be unexported later.
-     *
      * This is tied to a particular thread, so it only records operations
      * on the current thread.
+     * The class is not serializable.
      */
+    @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "SE_BAD_FIELD_INNER_CLASS",
+            justification = "ExportList is supposed to be serializable as ArrayList, but it is not. "
+                          + "The issue is ignored since the class does not belong to the public API")
     public final class ExportList extends ArrayList<Entry> {
         private final ExportList old;
         private ExportList() {


### PR DESCRIPTION
This pull request just suppresses two issues in `ExportTable` implementation.

- [x] Caching of stacktrace for heapdumps. No warnings anymore
- [x] Ignore Serialization warnings for `ExportList` since this class is a part of internal API && is not being actually serialized

For discussion about caching or `Source` stacktraces:

* It is a legacy behavior introduced by @kohsuke in https://github.com/jenkinsci/remoting/commit/5db46de05db55262e75755ba47a99c4b12965d9b (remoting-2.40). 
* For every `object Deallocation` and `Reference Counter Increment` Remoting calculates the stacktrace and then also clones it. Implementation in `Throwable` is provided below
* The current behavior causes calculation and memory overheads, just to make heapdumps to provide more info
* I doubt we want this behavior to be enabled by default

Throwable implemetation:

```java
    public StackTraceElement[] getStackTrace() {
        return getOurStackTrace().clone();
    }

    private synchronized StackTraceElement[] getOurStackTrace() {
        // Initialize stack trace field with information from
        // backtrace if this is the first call to this method
        if (stackTrace == UNASSIGNED_STACK ||
            (stackTrace == null && backtrace != null) /* Out of protocol state */) {
            int depth = getStackTraceDepth();
            stackTrace = new StackTraceElement[depth];
            for (int i=0; i < depth; i++)
                stackTrace[i] = getStackTraceElement(i);
        } else if (stackTrace == null) {
            return UNASSIGNED_STACK;
        }
        return stackTrace;
    }
```

[JENKINS-37566](https://issues.jenkins-ci.org/browse/JENKINS-37566)

@reviewbybees