### PR TITLE
[JENKINS-37567] - Update maven Jar Signer and add provider/tsa options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-jarsigner-plugin</artifactId>
-        <version>1.2</version>
+        <version>1.4</version>
         <configuration>
           <!--
             during the development, debug profile will cause
@@ -278,6 +278,10 @@ THE SOFTWARE.
           <alias>${hudson.sign.alias}</alias>
           <storepass>${hudson.sign.storepass}</storepass>
           <keystore>${hudson.sign.keystore}</keystore>
+          <storetype>${hudson.sign.storetype}</storetype>
+          <providerClass>${hudson.sign.providerClass}</providerClass>
+          <providerArg>${hudson.sign.providerArg}</providerArg>
+          <tsa>${hudson.sign.tsa}</tsa>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
I have a hardware crypto key for signing remoting, hence the original available options are not enough for me. I decided to add more options, but it needs sign-off from @kohsuke that he still can sign the stuff with his key.

https://issues.jenkins-ci.org/browse/JENKINS-37567

@reviewbybees @kohsuke