### PR TITLE
Remoting 2.x End Of Life

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -11,7 +11,7 @@ See [Jenkins changelog](https://jenkins.io/changelog/) for more details.
 
 ##### 2.62.6
 
-Release date: Coming Soon
+Release date: Can be released on-demand
 
 Fixed issues:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,22 +4,11 @@ Contributing
 Remoting library follows the common contribution rules/recommendations in the Jenkins project.
 These recommendations are available [here](https://wiki.jenkins-ci.org/display/JENKINS/Beginners+Guide+to+Contributing).
 
-### Proposing pull requests
+### Proposing changes
 
-New features:
 * Create pull requests (PRs) against the master branch.
-
-Bugfixes and performance improvements:
-
-* If the bug is reproducible in <code>Remoting 2.x</code>, create pull requests against the [stable-2.x](https://github.com/jenkinsci/remoting/tree/stable-2.x) branch
- * There is no guarantee that complex and barely reviewable fixes get accepted to this stabilization branch
- * Please note that Static Analysis failures do not fail the Pull Request Builder for the [stable-2.x](https://github.com/jenkinsci/remoting/tree/stable-2.x) branch.
-You will need to manually checks diffs made by your change.
-* Otherwise - create PRs against the master branch
-
-Documentation:
-* Master branch stores actual documentation for all versions. 
-* Create PRs against it
+* Bug fixes or performance improvements may be a subject for backporting to Remoting 2.x.
+If you need it, please mention it in the pull request or JIRA ticket. 
 
 ### Q&A
 

--- a/README.md
+++ b/README.md
@@ -10,35 +10,7 @@ It includes: TCP-based communication protocols, data serialization, Java classlo
 
 The library is reusable outside Jenkins.
 
-### Remoting versions
 
-Currently there are two supported baselines of Remoting.
-
-#### Remoting 3
-
-Remoting 3 is a new baseline introduced in Jenkins 2.27.
-
-Major changes:
-
-* Java 7 is a new target JVM, the new remoting version is not guaranteed to work properly on Java 9 and versions below Java 7
-* New <code>JNLP4-connect</code> protocol, 
-  which improves performance and stability compared to the JNLP3 protocol
-
-Remoting 3 does not have full binary compatibity with Remoting <code>2</code> (see [Remoting 3 Compatibility Notes](docs/remoting-3-compatibility.md)).
-
-#### Remoting 2
-
-Remoting 2 is a version, which was used in Jenkins till the <code>2.27</code> release. 
-It is not being offered in new releases of Jenkins. 
-This version is still being maintained, because it is being used in Jenkins LTS and several other projects.
-
-Maintenance approach:
-
-* The version will be maintained till at least May 2017
-* New releases may include bugfixes, security fixes and performance enhancements
-* There is no plans to introduce new features in <code>remoting-2.x</code>
-
-Changelogs for Remoting 2.x releases are available [here](CHANGELOG-2.x.md).
 
 ### Documentation
 
@@ -48,15 +20,19 @@ Feel free to contribute.
 
 User documentation:
 
-* [Changelog - Mainstream](CHANGELOG.md) - Changelog for the Remoting 3 and previous releases of Remoting 2
-* [Changelog - 2.x](CHANGELOG-2.x.md) - Changelog for the Remoting `2.x` stabilization releases after the Remoting 3 release
-* [Remoting 3 Compatibility Notes](docs/remoting-3-compatibility.md)
+* [Changelog](CHANGELOG.md) - Remoting release notes
 * [Remoting Protocols](docs/protocols.md) - Overview of protocols integrated with Jenkins
 * [Remoting Configuration](docs/configuration.md) - Configuring remoting agents
 * [Logging](docs/logging.md) - Logging
-* [Work Directory](docs/workDir.md) - Remoting work directory (new in Remoting `TODO`)
+* [Work Directory](docs/workDir.md) - Remoting work directory (new in Remoting `3.8`)
 * [Jenkins Specifics](docs/jenkins-specifics.md) - Notes on using remoting in Jenkins
 * [Troubleshooting](docs/troubleshooting.md) - Investigating and solving common remoting issues
+
+Previous versions:
+
+* [Remoting versions](docs/versions.md) - Description of Remoting `2.x` and `3.x` differences
+* [Changelog - 2.x](CHANGELOG-2.x.md) - Changelog for the Remoting `2.x` stabilization releases
+* [Remoting 3 Compatibility Notes](docs/remoting-3-compatibility.md)
 
 Developer documentation:
 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,0 +1,32 @@
+Remoting versions
+----
+
+Currently there are two supported baselines of Remoting.
+
+#### Remoting 3
+
+Remoting 3 is a new baseline introduced in Jenkins 2.27.
+
+Major changes:
+
+* Java 7 is a new target JVM, the new remoting version is not guaranteed to work properly on Java 9 and versions below Java 7
+* New [JNLP4-connect](protocols.md) protocol, 
+  which improves performance and stability compared to the [JNLP3 protocol](protocols.md)
+
+Remoting 3 does not have full binary compatibity with Remoting <code>2</code> (see [Remoting 3 Compatibility Notes](remoting-3-compatibility.md)).
+
+#### Remoting 2
+
+Remoting 2 is a deprecated version, which was used in Jenkins till the <code>2.27</code> release. 
+It is not being offered in new releases of Jenkins. 
+This version is still being maintained, because it is being used in Jenkins LTS and several other projects.
+
+Maintenance approach:
+
+* The branch reached its End of Life on _May 01, 2017_.
+* Changes **may** be backported and released upon request.
+See the [Contributing Page](../CONTRIBUTING.md).
+* New releases may include bugfixes, security fixes and performance enhancements
+* There is no plans to introduce new features in Remoting 2.x
+
+Changelogs for Remoting 2.x releases are available [here](../CHANGELOG-2.x.md).

--- a/docs/workDir.md
+++ b/docs/workDir.md
@@ -3,7 +3,7 @@ Remoting Work directory
 
 In Remoting work directory is a storage 
 
-Remoting work directory is available starting from Remoting `TODO`.
+Remoting work directory is available starting from Remoting `3.8`.
 Before this version there was no working directory concept in the library itself;
 all operations were managed by library users (e.g. Jenkins agent workspaces).
 
@@ -16,7 +16,7 @@ all operations were managed by library users (e.g. Jenkins agent workspaces).
 ### After Remoting TODO
 
 Due to compatibility reasons, Remoting retains the legacy behavior by default.
-Work directory can be enabled using the `-workDir` option in CLI or via the `TODO` [system property](configuration.md).
+Work directory can be enabled using the `-workDir` option in CLI.
 
 Once the option is enabled, Remoting starts using the following structure:
 
@@ -42,4 +42,4 @@ Once the `-workDir` flag is enabled in Remoting, admins are expected to do the f
 2. Consider upgrading configurations of agents in order to enable Work Directories
   * SSH agents can be configured in agent settings.
   * JNLP agents should be started with the `-workDir` parameter.
-  * See [JENKINS-TODO](TODO) for more information about changes in Jenkins plugins, which enable work directories by default.
+  * See [JENKINS-44108](https://issues.jenkins-ci.org/browse/JENKINS-44108) for more information about changes in Jenkins plugins, which enable work directories by default.


### PR DESCRIPTION
Remoting 2.x has reached its end of life on May 01, 2017. My plan is to release new version if required, but I want to oficially call it as a deprecated version in order to avoid proactive backporting and to simplify documentation.

* What does it change for Jenkins project? 
  * Nothing for weekly and LTS releases, Remoting is not used there anymore
  * Nothing for the SECURITY team, the backporting process is different there
* What does change for Remoting 2.x users? 
  * If you need an issue backporting, they will have to request it.

After the integration I will remove `stable-2.x` branch and start using `2.62.x` as we agreed with @jglick .

@reviewbybees @jenkinsci/code-reviewers 