### PR TITLE
[JENKINS-44290] - Prevent crash when starting Remoting agents in the default mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,13 @@ THE SOFTWARE.
       <type>jar</type>
       <optional>true</optional><!-- no need to have this at runtime -->
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>test-annotations</artifactId>
+      <version>1.2</version>
+      <scope>test</scope>
+      <type>jar</type>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -158,7 +158,7 @@ public class Engine extends Thread {
     /**
      * Default JAR cache location for disabled workspace Manager.
      */
-    private static final File DEFAULT_NOWS_JAR_CACHE_LOCATION = 
+    /*package*/ static final File DEFAULT_NOWS_JAR_CACHE_LOCATION = 
         new File(System.getProperty("user.home"),".jenkins/cache/jars");
     
     @CheckForNull
@@ -230,7 +230,15 @@ public class Engine extends Thread {
      * @since TODO
      */
     public synchronized void startEngine() throws IOException {
-        
+        startEngine(false);
+    }
+     
+    /**
+     * Starts engine.
+     * @param dryRun If {@code true}, do not actually start the engine.
+     *               This method can be used for testing startup logic.
+     */
+    /*package*/ void startEngine(boolean dryRun) throws IOException {
         @CheckForNull File jarCacheDirectory = null;
         
         // Prepare the working directory if required
@@ -265,7 +273,9 @@ public class Engine extends Thread {
         }
         
         // Start the engine thread
-        this.start();
+        if (!dryRun) {
+            this.start();
+        }
     }
 
     /**

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -256,7 +256,7 @@ public class Engine extends Thread {
             final Path path = workDirManager.initializeWorkDir(workDir.toFile(), internalDir, failIfWorkDirIsMissing);
             jarCacheDirectory = workDirManager.getLocation(WorkDirManager.DirType.JAR_CACHE_DIR);
             workDirManager.setupLogging(path, agentLog);
-        } else if (jarCache != null) {
+        } else if (jarCache == null) {
             LOGGER.log(Level.WARNING, "No Working Directory. Using the legacy JAR Cache location: {0}", DEFAULT_NOWS_JAR_CACHE_LOCATION);
             jarCacheDirectory = DEFAULT_NOWS_JAR_CACHE_LOCATION;
         }

--- a/src/test/java/hudson/remoting/EngineTest.java
+++ b/src/test/java/hudson/remoting/EngineTest.java
@@ -1,0 +1,145 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.remoting;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import static org.hamcrest.Matchers.*;
+import org.jenkinsci.remoting.engine.WorkDirManager;
+import org.jenkinsci.remoting.engine.WorkDirManagerRule;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * Tests of {@link Engine}
+ * @author Oleg Nenashev
+ */
+public class EngineTest {
+    
+    private static final String SECRET_KEY = "Hello, world!";
+    private static final String AGENT_NAME = "testAgent";
+    private List<URL> jenkinsUrls;
+    
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+    
+    @Rule
+    public WorkDirManagerRule mgr = new WorkDirManagerRule();
+    
+    @Before
+    public void init() throws Exception {
+        jenkinsUrls = Arrays.asList(new URL("http://my.jenkins.not.existent"));
+    }
+    
+    @Test
+    @Issue("JENKINS-44290")
+    public void shouldInitializeCorrectlyWithDefaults() throws Exception {
+        EngineListener l = new TestEngineListener();
+        Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
+        engine.startEngine(true);
+        
+        // Cache will go to ~/.jenkins , we do not want to worry anbout this repo
+        Assert.assertTrue("Default JarCache should be touched: " + Engine.DEFAULT_NOWS_JAR_CACHE_LOCATION.getAbsolutePath(), 
+                Engine.DEFAULT_NOWS_JAR_CACHE_LOCATION.exists());
+    }
+    
+    @Test
+    public void shouldInitializeCorrectlyWithCustomCache() throws Exception {
+        File jarCache = new File(tmpDir.getRoot(), "jarCache");
+        
+        EngineListener l = new TestEngineListener();
+        Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
+        engine.setJarCache(new FileSystemJarCache(jarCache, true));
+        engine.startEngine(true);
+        
+        // Cache will go to ~/.jenkins , should be touched by default
+        Assert.assertTrue("The specified JarCache should be touched: " + jarCache.getAbsolutePath(), 
+                jarCache.exists());
+    }
+    
+    @Test
+    public void shouldInitializeCorrectlyWithWorkDir() throws Exception {
+        File workDir = new File(tmpDir.getRoot(), "workDir");
+        EngineListener l = new TestEngineListener();
+        Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
+        engine.setWorkDir(workDir.toPath());
+        engine.startEngine(true);
+        
+        WorkDirManager mgr = WorkDirManager.getInstance();
+        File workDirLoc = mgr.getLocation(WorkDirManager.DirType.WORK_DIR);
+        Assert.assertThat("The initialized work directory should equal to the one passed in parameters", 
+                workDirLoc, equalTo(workDir));
+        Assert.assertTrue("The work directory should exist", workDir.exists());
+    }
+    
+    @Test
+    public void shouldUseCustomCacheDirIfRequired() throws Exception {
+        File workDir = new File(tmpDir.getRoot(), "workDir");
+        File jarCache = new File(tmpDir.getRoot(), "jarCache");
+        EngineListener l = new TestEngineListener();
+        Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
+        engine.setWorkDir(workDir.toPath());
+        engine.setJarCache(new FileSystemJarCache(jarCache, true));
+        engine.startEngine(true);
+        
+        WorkDirManager mgr = WorkDirManager.getInstance();
+        File location = mgr.getLocation(WorkDirManager.DirType.JAR_CACHE_DIR);
+        Assert.assertThat("WorkDir manager should not be aware about external JAR cache location", location, nullValue());
+    }
+    
+    private static class TestEngineListener implements EngineListener {
+
+        @Override
+        public void status(String msg) {
+            // Do nothing
+        }
+
+        @Override
+        public void status(String msg, Throwable t) {
+            // Do nothing
+        }
+
+        @Override
+        public void error(Throwable t) {
+            // Do nothing
+        }
+
+        @Override
+        public void onDisconnect() {
+            // Do nothing
+        }
+
+        @Override
+        public void onReconnect() {
+            // Do nothing
+        }
+        
+    }
+}

--- a/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerRule.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerRule.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.remoting.engine;
+
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Contains automatic state reset for {@link WorkDirManager}.
+ * @author Oleg Nenashev
+ */
+public class WorkDirManagerRule extends ExternalResource {
+
+    WorkDirManager instance;
+
+    public WorkDirManager getInstance() {
+        return instance;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        instance = WorkDirManager.getInstance();
+        return super.apply(base, description);
+    }
+    
+    @Override
+    protected void after() {
+        WorkDirManager.reset();
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        WorkDirManager.reset();
+    }
+}

--- a/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerTest.java
@@ -61,16 +61,8 @@ public class WorkDirManagerTest {
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();
     
-    @Before
-    public void resetWorkDirManagerBeforeTest() {
-        WorkDirManager.reset();
-    }
-    
-    @After
-    public void resetWorkDirManagerAfterTest() {
-        // Resets logging settings
-        WorkDirManager.reset();
-    }
+    @Rule
+    public WorkDirManagerRule mgr = new WorkDirManagerRule();
 
     @Test
     public void shouldInitializeCorrectlyForExistingDirectory() throws Exception {


### PR DESCRIPTION
The class was not covered by tests at all, so the issue has sneaked into the Remoting 3.8 release. `JNLPLauncher` test caught it in CI though. Added test + one-liner fix

https://issues.jenkins-ci.org/browse/JENKINS-44290

@reviewbybees

