### PR TITLE
Handle ClosedSelectorException also from Selector.keys

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/protocol/IOHub.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/IOHub.java
@@ -457,8 +457,6 @@ public class IOHub implements Executor, Closeable, Runnable, ByteBufferPool {
                         }
                         keyIterator.remove();
                     }
-                } catch (ClosedSelectorException e) {
-                    return;
                 } catch (IOException e) {
                     // we should not have any of these exceptions propagated this far, so if we get one that is a
                     // problem
@@ -487,6 +485,8 @@ public class IOHub implements Executor, Closeable, Runnable, ByteBufferPool {
                     }
                 }
             }
+        } catch (ClosedSelectorException e) {
+            // ignore, happens routinely
         } finally {
             selectorThread.setName(oldName);
         }


### PR DESCRIPTION
I see this printed at the end of (passing) functional tests, which seems to be pure noise:

```
… hudson.util.ExceptionCatchingThreadFactory uncaughtException
WARNING: Thread Computer.threadPoolForRemoting [#1] terminated unexpectedly
java.nio.channels.ClosedSelectorException
	at sun.nio.ch.SelectorImpl.keys(SelectorImpl.java:68)
	at org.jenkinsci.remoting.protocol.IOHub.run(IOHub.java:422)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)
```

We were already handling this exception from various calls in the inner `try` block—but not from the `Selector.keys` call used to set `Thread.name`.

@reviewbybees