### PR TITLE
[JENKINS-18578] - Do not use the old cache when starting agents from CLI

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -174,7 +174,7 @@ public class Launcher {
      * @since 2.24
      */
     @Option(name="-jar-cache",metaVar="DIR",usage="Cache directory that stores jar files sent from the master")
-    public File jarCache = new File(System.getProperty("user.home"),".jenkins/cache/jars");
+    public File jarCache = null;
 
     /**
      * Specified location of the property file with JUL settings.


### PR DESCRIPTION
Just a leftover from the previous fix, nulls are handled in hudson.remoting.Engine. I need to setup more end-to-end tests to capture such issues.

https://issues.jenkins-ci.org/browse/JENKINS-18578

@reviewbybees