### PR TITLE
[JENKINS-44973] - Ensure that JAR Cache management works correctly in Launcher

### DIFF
--- a/src/main/java/hudson/remoting/ChannelBuilder.java
+++ b/src/main/java/hudson/remoting/ChannelBuilder.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import javax.annotation.CheckForNull;
 
 /**
  * Factory for {@link Channel}, including hand-shaking between two sides
@@ -46,6 +47,7 @@ public class ChannelBuilder {
     private Mode mode = Mode.NEGOTIATE;
     private Capability capability = new Capability();
     private OutputStream header;
+    @CheckForNull
     private JarCache jarCache;
     private List<CallableDecorator> decorators = new ArrayList<CallableDecorator>();
     private boolean arbitraryCallableAllowed = true;
@@ -188,11 +190,22 @@ public class ChannelBuilder {
         return remoteClassLoadingAllowed;
     }
 
-    public ChannelBuilder withJarCache(JarCache jarCache) {
+    /**
+     * Sets the JAR cache storage.
+     * @param jarCache JAR Cache to be used. If {@code null}, a default value will be used by the {@link Channel}
+     * @return {@code this}
+     */
+    public ChannelBuilder withJarCache(@CheckForNull JarCache jarCache) {
         this.jarCache = jarCache;
         return this;
     }
 
+    /**
+     * Gets the JAR Cache storage.
+     * @return {@code null} if it is not defined.
+     *         {@link Channel} implementation should use a default cache value then.
+     */
+    @CheckForNull
     public JarCache getJarCache() {
         return jarCache;
     }

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -155,11 +155,7 @@ public class Engine extends Thread {
     private boolean keepAlive = true;
 
     
-    /**
-     * Default JAR cache location for disabled workspace Manager.
-     */
-    /*package*/ static final File DEFAULT_NOWS_JAR_CACHE_LOCATION = 
-        new File(System.getProperty("user.home"),".jenkins/cache/jars");
+    
     
     @CheckForNull
     private JarCache jarCache = null;
@@ -257,8 +253,8 @@ public class Engine extends Thread {
             jarCacheDirectory = workDirManager.getLocation(WorkDirManager.DirType.JAR_CACHE_DIR);
             workDirManager.setupLogging(path, agentLog);
         } else if (jarCache == null) {
-            LOGGER.log(Level.WARNING, "No Working Directory. Using the legacy JAR Cache location: {0}", DEFAULT_NOWS_JAR_CACHE_LOCATION);
-            jarCacheDirectory = DEFAULT_NOWS_JAR_CACHE_LOCATION;
+            LOGGER.log(Level.WARNING, "No Working Directory. Using the legacy JAR Cache location: {0}", JarCache.DEFAULT_NOWS_JAR_CACHE_LOCATION);
+            jarCacheDirectory = JarCache.DEFAULT_NOWS_JAR_CACHE_LOCATION;
         }
         
         if (jarCache == null){

--- a/src/main/java/hudson/remoting/FileSystemJarCache.java
+++ b/src/main/java/hudson/remoting/FileSystemJarCache.java
@@ -49,7 +49,7 @@ public class FileSystemJarCache extends JarCacheSupport {
         this.rootDir = rootDir;
         this.touch = touch;
         if (rootDir==null)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Root directory is null");
 
         try {
             Util.mkdirs(rootDir);

--- a/src/main/java/hudson/remoting/JarCache.java
+++ b/src/main/java/hudson/remoting/JarCache.java
@@ -1,8 +1,10 @@
 package hudson.remoting;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
+import javax.annotation.Nonnull;
 
 /**
  * Jar file cache.
@@ -18,6 +20,18 @@ import java.net.URL;
  * @since 2.24
  */
 public abstract class JarCache {
+    
+    /**
+     * Default JAR cache location for disabled workspace Manager.
+     */
+    /*package*/ static final File DEFAULT_NOWS_JAR_CACHE_LOCATION = 
+        new File(System.getProperty("user.home"),".jenkins/cache/jars");
+    
+    @Nonnull
+    /*package*/ static JarCache getDefault() {
+        return new FileSystemJarCache(DEFAULT_NOWS_JAR_CACHE_LOCATION, true);
+    }
+    
     /**
      * Looks up the jar in cache, and if not found, use {@link JarLoader} to retrieve it
      * from the other side.

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -173,6 +173,7 @@ public class Launcher {
     /**
      * @since 2.24
      */
+    @CheckForNull
     @Option(name="-jar-cache",metaVar="DIR",usage="Cache directory that stores jar files sent from the master")
     public File jarCache = null;
 
@@ -622,7 +623,7 @@ public class Launcher {
         s.setTcpNoDelay(true);
         main(new BufferedInputStream(SocketChannelStream.in(s)),
              new BufferedOutputStream(SocketChannelStream.out(s)), mode,ping,
-             new FileSystemJarCache(jarCache,true));
+             jarCache != null ? new FileSystemJarCache(jarCache,true) : null);
     }
 
     /**
@@ -676,7 +677,7 @@ public class Launcher {
 
         // System.in/out appear to be already buffered (at least that was the case in Linux and Windows as of Java6)
         // so we are not going to double-buffer these.
-        main(System.in, os, mode, ping, new FileSystemJarCache(jarCache,true));
+        main(System.in, os, mode, ping, jarCache != null ? new FileSystemJarCache(jarCache,true) : null);
     }
 
     private static void ttyCheck() {
@@ -719,13 +720,15 @@ public class Launcher {
      */
     @Deprecated
     public static void main(InputStream is, OutputStream os, Mode mode, boolean performPing) throws IOException, InterruptedException {
-        main(is, os, mode, performPing,
-                new FileSystemJarCache(new File(System.getProperty("user.home"),".jenkins/cache/jars"),true));
+        main(is, os, mode, performPing, null);
     }
     /**
+     * 
+     * @param cache JAR cache to be used.
+     *              If {@code null}, a default value will be used.
      * @since 2.24
      */
-    public static void main(InputStream is, OutputStream os, Mode mode, boolean performPing, JarCache cache) throws IOException, InterruptedException {
+    public static void main(InputStream is, OutputStream os, Mode mode, boolean performPing, @CheckForNull JarCache cache) throws IOException, InterruptedException {
         ExecutorService executor = Executors.newCachedThreadPool();
         ChannelBuilder cb = new ChannelBuilder("channel", executor)
                 .withMode(mode)

--- a/src/test/java/hudson/remoting/EngineTest.java
+++ b/src/test/java/hudson/remoting/EngineTest.java
@@ -66,8 +66,8 @@ public class EngineTest {
         engine.startEngine(true);
         
         // Cache will go to ~/.jenkins , we do not want to worry anbout this repo
-        Assert.assertTrue("Default JarCache should be touched: " + Engine.DEFAULT_NOWS_JAR_CACHE_LOCATION.getAbsolutePath(), 
-                Engine.DEFAULT_NOWS_JAR_CACHE_LOCATION.exists());
+        Assert.assertTrue("Default JarCache should be touched: " + JarCache.DEFAULT_NOWS_JAR_CACHE_LOCATION.getAbsolutePath(), 
+                JarCache.DEFAULT_NOWS_JAR_CACHE_LOCATION.exists());
     }
     
     @Test


### PR DESCRIPTION
It is an unreleased regression caused by me in https://github.com/jenkinsci/remoting/pull/166 . Filed it as [JENKINS-44973](https://issues.jenkins-ci.org/browse/JENKINS-44973).

Discovered it during testing the recent remoting version on SSH. Effectively launches with STDERR/STDOUT (SSH) and socket (tests) are failing now.

Also annotated all the things to prevent it in the future.

@reviewbybees

