### PR TITLE
Prevent NullPointerException in ResourceImageBoth if cannot initialize JAR retrieval

### DIFF
--- a/src/main/java/hudson/remoting/JarCache.java
+++ b/src/main/java/hudson/remoting/JarCache.java
@@ -3,6 +3,7 @@ package hudson.remoting;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
+import javax.annotation.Nonnull;
 
 /**
  * Jar file cache.
@@ -26,9 +27,10 @@ public abstract class JarCache {
      * This method must be concurrency-safe.
      *
      * @param channel
-     *      Channel that needs this jar file. Never null.
+     *      Channel that needs this jar file.
      * @return
-     *      URL of the jar file. Must not be null.
+     *      URL of the jar file.
      */
-    public abstract Future<URL> resolve(Channel channel, long sum1, long sum2) throws IOException, InterruptedException;
+    @Nonnull
+    public abstract Future<URL> resolve(@Nonnull Channel channel, long sum1, long sum2) throws IOException, InterruptedException;
 }

--- a/src/main/java/hudson/remoting/ResourceImageBoth.java
+++ b/src/main/java/hudson/remoting/ResourceImageBoth.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -32,7 +33,14 @@ class ResourceImageBoth extends ResourceImageDirect {
             return super.resolveURL(channel, resourcePath);
     }
 
-    private Future<URL> initiateJarRetrieval(Channel channel) {
+    /**
+     * Starts JAR retrieval over the channel.
+     * 
+     * @param channel Channel instance
+     * @return Future object. In the case of error the diagnostics info will be sent to {@link #LOGGER}.
+     */
+    @Nonnull
+    private Future<URL> initiateJarRetrieval(@Nonnull Channel channel) throws IOException, InterruptedException {
         JarCache c = channel.getJarCache();
         assert c !=null : "we don't advertise jar caching to the other side unless we have a cache with us";
 
@@ -40,11 +48,12 @@ class ResourceImageBoth extends ResourceImageDirect {
             return c.resolve(channel, sum1, sum2);
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Failed to initiate retrieval", e);
+            throw e;
         } catch (InterruptedException e) {
             LOGGER.log(Level.WARNING, "Failed to initiate retrieval", e);
             Thread.currentThread().interrupt(); // process the interrupt later
+            throw e;
         }
-        return null;
     }
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
I firstly started from annotating the methods and throwing IOException, but then decided to do a proper error propagation instead. 

It smells like a real issue though there is no relevant bugtracker entries.

@reviewbybees