### PR TITLE
[CID-156932] - Fix the imaginary resource leak in NullOutputStream

### DIFF
--- a/src/main/java/hudson/remoting/Checksum.java
+++ b/src/main/java/hudson/remoting/Checksum.java
@@ -74,8 +74,10 @@ final class Checksum {
     static Checksum forURL(URL url) throws IOException {
         try {
             MessageDigest md = MessageDigest.getInstance(JarLoaderImpl.DIGEST_ALGORITHM);
-            Util.copy(url.openStream(), new DigestOutputStream(new NullOutputStream(), md));
-            return new Checksum(md.digest(), md.getDigestLength() / 8);
+            try(OutputStream ostream = new DigestOutputStream(new NullOutputStream(), md)) {
+                Util.copy(url.openStream(), ostream);
+                return new Checksum(md.digest(), md.getDigestLength() / 8);
+            }
         } catch (NoSuchAlgorithmException e) {
             throw new AssertionError(e);
         }

--- a/src/main/java/hudson/remoting/Checksum.java
+++ b/src/main/java/hudson/remoting/Checksum.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.security.DigestOutputStream;
@@ -74,8 +75,8 @@ final class Checksum {
     static Checksum forURL(URL url) throws IOException {
         try {
             MessageDigest md = MessageDigest.getInstance(JarLoaderImpl.DIGEST_ALGORITHM);
-            try(OutputStream ostream = new DigestOutputStream(new NullOutputStream(), md)) {
-                Util.copy(url.openStream(), ostream);
+            try(InputStream istsream = url.openStream(); OutputStream ostream = new DigestOutputStream(new NullOutputStream(), md)) {
+                Util.copy(istsream, ostream);
                 return new Checksum(md.digest(), md.getDigestLength() / 8);
             }
         } catch (NoSuchAlgorithmException e) {


### PR DESCRIPTION
`DigestOutputStream` may change in the future, hence it worth to just refactor the code. I have not found annotations which would indicate that no closing it required for NullOutputStream. There are such warnings in the core as well OTOH

@reviewbybees

