### PR TITLE
[INFRA-1248] ${user.name} might contain metacharacters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,19 @@ THE SOFTWARE.
             </configuration>
           </execution>
           <execution>
+            <id>user.name</id>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>user.name.escaped</name>
+              <value>${user.name}</value>
+              <regex>([$\\])</regex>
+              <replacement>\\$1</replacement>
+              <failIfNoMatch>false</failIfNoMatch>
+            </configuration>
+          </execution>
+          <execution>
             <id>version-property</id>
             <goals>
               <goal>regex-property</goal>
@@ -397,7 +410,7 @@ THE SOFTWARE.
               <name>build.version</name>
               <value>${project.version}</value>
               <regex>-SNAPSHOT</regex>
-              <replacement>-SNAPSHOT (${build.type}-${now}-${user.name})</replacement>
+              <replacement>-SNAPSHOT (${build.type}-${now}-${user.name.escaped})</replacement>
               <failIfNoMatch>false</failIfNoMatch>
             </configuration>
           </execution>


### PR DESCRIPTION
Supersedes #171.

```
remoting$ mvn -Duser.name='big$mon\ey' validate -e
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building Jenkins remoting layer 3.10-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:1.0.1:enforce (enforce-maven) @ remoting ---
[INFO] 
[INFO] --- maven-enforcer-plugin:1.0.1:display-info (display-info) @ remoting ---
[INFO] Maven Version: 3.5.0
[INFO] JDK Version: 1.8.0_131 normalized as: 1.8.0-131
[INFO] OS Info: Arch: amd64 Family: unix Name: linux Version: 4.10.0-22-generic
[INFO] 
[INFO] --- build-helper-maven-plugin:1.7:timestamp-property (timestamp-property) @ remoting ---
[INFO] Setting property 'now' to '06/26/2017 19:12 GMT'.
[INFO] 
[INFO] --- build-helper-maven-plugin:1.7:regex-property (user.name) @ remoting ---
[INFO] Setting property 'user.name.escaped' to 'big\$mon\\ey'.
[INFO] 
[INFO] --- build-helper-maven-plugin:1.7:regex-property (version-property) @ remoting ---
[INFO] Setting property 'build.version' to '3.10-SNAPSHOT (private-06/26/2017 19:12 GMT-big$mon\ey)'.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.172 s
[INFO] Finished at: 2017-06-26T15:12:06-04:00
[INFO] Final Memory: 11M/240M
[INFO] ------------------------------------------------------------------------
```

@reviewbybees