### PR TITLE
[JENKINS-44785] - Built-in request timeout support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@ THE SOFTWARE.
   </scm>
 
   <properties>
-    <java.level>7</java.level>
+    <java.level>8</java.level>
     <build.type>private</build.type>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
@@ -418,7 +418,7 @@ THE SOFTWARE.
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java17</artifactId>
+            <artifactId>java18</artifactId>
             <version>1.0</version>
           </signature>
           <ignores>

--- a/src/main/java/hudson/remoting/ProxyInputStream.java
+++ b/src/main/java/hudson/remoting/ProxyInputStream.java
@@ -127,6 +127,8 @@ final class ProxyInputStream extends InputStream {
         private final int len;
 
         public Chunk(int oid, int len) {
+            // TODO: Another default? It is not a part of public API
+            super(DEFAULT_PERFORM_TIMEOUT, DEFAULT_EXECUTION_TIMEOUT);
             this.oid = oid;
             this.len = len;
         }

--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -34,6 +34,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
+import java.time.Duration;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
@@ -63,12 +64,29 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<
     private transient final ExportList exports;
 
     /**
+     * Constructs a user request with default timeouts.
+     * 
+     * @param local Channel, for which the request should be executed
+     * @param c Command to be executed
+     */
+    public UserRequest(Channel local, Callable<?,EXC> c) throws IOException {
+        this(local, c, DEFAULT_PERFORM_TIMEOUT, DEFAULT_EXECUTION_TIMEOUT);
+    }
+    
+    /**
      * Creates a user request to be executed on the remote side.
      * @param local Channel, for which the request should be executed
      * @param c Command to be executed
+     * @param performTimeout Timeout for {@link Request#perform(hudson.remoting.Channel)}.
+     *                       If not {@code null}, it will be controlled on the remote side
+     * @param executionTimeout Timeout for the entire request execution.
+     *                         If not {@code null}, it will be controlled on both local and remote sides.
      * @throws IOException The command cannot be serialized
+     * @since TODO
      */
-    public UserRequest(Channel local, Callable<?,EXC> c) throws IOException {
+    public UserRequest(@Nonnull Channel local, @Nonnull Callable<?,EXC> c, 
+            @CheckForNull Duration performTimeout, @CheckForNull Duration executionTimeout) throws IOException {
+        super(performTimeout, executionTimeout);
         this.toString = c.toString();
         
         // Before serializing anything, check that we actually have a classloader for it

--- a/src/main/java/org/jenkinsci/remoting/util/Timeout.java
+++ b/src/main/java/org/jenkinsci/remoting/util/Timeout.java
@@ -1,0 +1,108 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.remoting.util;
+
+import hudson.remoting.VirtualChannel;
+import java.time.Duration;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Allows operations to be limited in execution time.
+ * For example, {@link VirtualChannel#call} could otherwise may hang forever.
+ * Use in a {@code try}-with-resources block.
+ * @author Jesse Glick
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+@Restricted(NoExternalUse.class)
+public class Timeout implements AutoCloseable {
+
+    private static final Logger LOGGER = Logger.getLogger(Timeout.class.getName());
+
+    private static final Timeout NO_TIMEOUT = new Timeout(null);
+    
+    @CheckForNull
+    private final ScheduledFuture<?> task;
+
+    private Timeout(@CheckForNull ScheduledFuture<?> task) {
+        this.task = task;
+    }
+
+    @Override 
+    public void close() {
+        if (task != null) {
+            task.cancel(false);
+        }
+    }
+
+    /**
+     * Sets optional timeout.
+     * 
+     * Disabled timeout is a not recommended mode for legacy operations.
+     * A warning will be printed to the system log if it is defined.
+     * 
+     * @param timeout Timeout duration. If {@code null}, no timeout is set
+     * @return Timeout object
+     */
+    public static Timeout optLimit(final @CheckForNull Duration timeout) {
+        if (timeout != null) {
+            return limit(timeout);
+        } else {
+            if (LOGGER.isLoggable(Level.CONFIG)) {
+                LOGGER.log(Level.CONFIG, "Executing code block with disabled timeout. " +
+                        "It may hang indefinitely.", new IllegalStateException("Timeout duration is null"));
+            }
+            return NO_TIMEOUT;
+        }
+    }
+    
+    public static Timeout limit(final @Nonnull Duration timeout) {
+        return limit(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+    
+    public static Timeout limit(final long delay, final @Nonnull TimeUnit unit) {
+        final Thread thread = Thread.currentThread();
+        return new Timeout(Timer.get().schedule(new Runnable() {
+            @Override public void run() {
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    Throwable t = new Throwable();
+                    t.setStackTrace(thread.getStackTrace());
+                    LOGGER.log(Level.FINE, "Interrupting " + thread + " after " + delay + " " + unit, t);
+                }
+                thread.interrupt();
+            }
+        }, delay, unit));
+    }
+
+    // TODO JENKINS-32986 offer a variant that will escalate to Thread.stop
+
+}

--- a/src/main/java/org/jenkinsci/remoting/util/Timer.java
+++ b/src/main/java/org/jenkinsci/remoting/util/Timer.java
@@ -1,0 +1,152 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.remoting.util;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionHandler;
+import javax.annotation.Nonnull;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Holds the {@link ScheduledExecutorService} for running all background tasks in Remoting.
+ * This ExecutorService will create additional threads to execute due (enabled) tasks.
+ *
+ * Provides a minimal abstraction for locating the ScheduledExecutorService so that we
+ * can modify it's behavior going forward. For instance, to add manageability/monitoring.
+ *
+ * @author Ryan Campbell
+ * @author Jesse Glick
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+@Restricted(NoExternalUse.class)
+public class Timer {
+
+    private static final Logger LOGGER = Logger.getLogger(Timer.class.getName());
+    
+    /**
+     * The scheduled executor thread pool. 
+     * This is initialized lazily since it may be created/shutdown many times when running the test suite.
+     */
+    private static ScheduledExecutorService executorService;
+
+    private Timer() {};
+    
+    /**
+     * Returns the scheduled executor service used by all timed tasks in Jenkins.
+     *
+     * @return the single {@link ScheduledExecutorService}.
+     */
+    @Nonnull
+    public static synchronized ScheduledExecutorService get() {
+        if (executorService == null) {
+            // corePoolSize is set to 10, but will only be created if needed.
+            // ScheduledThreadPoolExecutor "acts as a fixed-sized pool using corePoolSize threads"
+            executorService =  new ErrorLoggingScheduledThreadPoolExecutor(10, new TimerThreadFactory());
+        }
+        return executorService;
+    }
+
+    /**
+     * Shutdown the timer and throw it away.
+     */
+    public static synchronized void shutdown() {
+        if (executorService != null) {
+            executorService.shutdownNow();
+            executorService = null;
+        }
+    }
+
+    private static class TimerThreadFactory implements ThreadFactory {
+        
+        private final ThreadFactory core;
+        private final AtomicInteger threadNum = new AtomicInteger();
+
+        public TimerThreadFactory() {
+            this(Executors.defaultThreadFactory());
+        }
+
+        public TimerThreadFactory(ThreadFactory core) {
+            this.core = core;
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread t = core.newThread(r);
+            t.setDaemon(true);
+            t.setName("RemotingTimerThread [#" + threadNum.incrementAndGet() + "]");
+            return t;
+        }
+    }
+    
+    private static class ErrorLoggingScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
+
+        ErrorLoggingScheduledThreadPoolExecutor(int corePoolSize, ThreadFactory threadFactory) {
+            super(corePoolSize, threadFactory);
+        }
+
+        ErrorLoggingScheduledThreadPoolExecutor(int corePoolSize, ThreadFactory threadFactory, RejectedExecutionHandler handler) {
+            super(corePoolSize, threadFactory, handler);
+        }
+
+        @Override
+        protected void afterExecute(Runnable r, Throwable t) {
+            super.afterExecute(r, t);
+            if (t == null && r instanceof Future<?>) {
+                Future<?> f = (Future<?>) r;
+                if (f.isDone()) { // TODO super Javadoc does not suggest this, but without it, we hang in FutureTask.awaitDone!
+                    try {
+                        f.get(/* just to be on the safe side, do not wait */0, TimeUnit.NANOSECONDS);
+                    } catch (TimeoutException x) {
+                        // should not happen, right?
+                    } catch (CancellationException x) {
+                        // probably best to ignore this
+                    } catch (ExecutionException x) {
+                        t = x.getCause();
+                    } catch (InterruptedException x) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            }
+            if (t != null) {
+                LOGGER.log(Level.WARNING, "Failure in task not wrapped in SafeTimerTask", t);
+            }
+        }
+
+    }
+
+}

--- a/src/test/java/hudson/remoting/ChannelTest.java
+++ b/src/test/java/hudson/remoting/ChannelTest.java
@@ -10,6 +10,7 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -175,5 +176,46 @@ public class ChannelTest extends RmiTestBase {
         assertTrue(sw.toString().contains("Channel south"));
         assertTrue(sw.toString().contains("Commands sent=0"));
         assertTrue(sw.toString().contains("Commands received=0"));
+    }
+    
+    @Bug(44785)
+    public void testDoesNotFailWithoutDefaultTimeout() throws Exception {
+        channel.call(new Sleep(5000));
+    }
+    
+    @Bug(44785)
+    public void testExecutionTimeout() throws Exception {
+        try {
+            channel.call(new Sleep(5000), null, Duration.ofMillis(100));
+        } catch(InterruptedException ex) {
+            return;
+        }
+        fail("Expected execution timeout to happen");
+    }
+    
+    @Bug(44785)
+    public void testPerformTimeout() throws Exception {
+        try {
+            channel.call(new Sleep(5000), Duration.ofMillis(100), null);
+        } catch(InterruptedException ex) {
+            return;
+        }
+        fail("Expected perform timeout to happen");
+    }
+    
+    private static class Sleep extends CallableBase<Void, InterruptedException> {
+
+        private static final long serialVersionUID = 1L;
+        private final int sleepTimeMs;
+
+        Sleep(int sleepTimeMs) {
+            this.sleepTimeMs = sleepTimeMs;
+        }
+
+        @Override
+        public Void call() throws InterruptedException {
+            Thread.sleep(sleepTimeMs);
+            return null;
+        }
     }
 }


### PR DESCRIPTION
This is a PoC implementation of the timeout support in Remoting API, See one of the use-cases in [JENKINS-44785](https://issues.jenkins-ci.org/browse/JENKINS-44785)

- [x] - Implement working PoC
- [ ] - TBD make decision about switching to Java 8. The PoC needs it for the `java.time.Duration` class, but it can be replaced if we stay on Java 7
- [ ] - If Java 8 is selected, implement new `call()` default implementations in interfaces (with `TimeoutException`s) to address the [JENKINS-44785](https://issues.jenkins-ci.org/browse/JENKINS-44785) request from @jglick 
- [ ] - `channel#callAsync()` should also support timeouts on the remote side
- [ ] - TBD: If we stay on Java 7, stick to `InterruptedException`?
- [ ] - Weaponize it! Set some default timeouts for user requests and RPC calls

@reviewbybees @jglick