### PR TITLE
[JENKINS-45023] - Prevent execution of commands on closed or beingClosed channels

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -328,7 +328,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 
     /**
      * Indicates that close of the channel has been requested.
-     * After it it does not make sense to execute new user-space commands.
+     * When the value is {@code true}, it does not make sense to execute new user-space commands like {@link UserRequest}.
      */
     private boolean closeRequested = false;
     
@@ -1307,7 +1307,8 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * Closes the channel.
      * 
-     * If the channel is not closed, the 
+     * Once the call is called {@link #closeRequested} will be set immediately to prevent further executions
+     * of {@link UserRequest}s.
      *
      * @param diagnosis
      *      If someone (either this side or the other side) tries to use a channel that's already closed,

--- a/src/main/java/hudson/remoting/ChannelClosedException.java
+++ b/src/main/java/hudson/remoting/ChannelClosedException.java
@@ -1,16 +1,19 @@
 package hudson.remoting;
 
 import java.io.IOException;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /**
- * Indicates that the channel is already closed.
+ * Indicates that the channel is already closed or being closed.
  *
  * @author Kohsuke Kawaguchi
  */
 public class ChannelClosedException extends IOException {
     /**
      * @deprecated
-     *      Use {@link #ChannelClosedException(Throwable)}.
+     *      Use {@link #ChannelClosedException(Throwable)} or {@link #ChannelClosedException(java.lang.String, java.lang.Throwable)}.
+     *      This constructor will not include cause of the termination.
      */
     @Deprecated
     public ChannelClosedException() {
@@ -18,7 +21,18 @@ public class ChannelClosedException extends IOException {
     }
 
     public ChannelClosedException(Throwable cause) {
-        super("channel is already closed");
-        initCause(cause);
+        super("channel is already closed", cause);
+    }
+    
+    /**
+     * Constructor.
+     * 
+     * @param message Message
+     * @param cause Cause of the channel close/termination. 
+     *              May be {@code null} if it cannot be determined when the exception is constructed.
+     * @since TODO
+     */
+    public ChannelClosedException(@Nonnull String message, @CheckForNull Throwable cause) {
+        super(message, cause);
     }
 }

--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -97,7 +97,8 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<
         
         // We also do not want to run UserRequests when the channel is being closed
         if (channel.isClosingOrClosed()) {
-            throw new IOException("The request cannot be executed on channel " + channel + ". The channel is closing down or has closed down");
+            throw new ChannelClosedException("The request cannot be executed on channel " + channel + ". "
+                    + "The channel is closing down or has closed down", channel.getCloseRequestCause());
         }
     }
     

--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -90,6 +90,17 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<
         this.classLoaderProxy = RemoteClassLoader.export(cl, local);
     }
 
+    @Override
+    public void checkIfCanBeExecutedOnChannel(Channel channel) throws IOException {
+        // Default check for all requests
+        super.checkIfCanBeExecutedOnChannel(channel);
+        
+        // We also do not want to run UserRequests when the channel is being closed
+        if (channel.isClosingOrClosed()) {
+            throw new IOException("The request cannot be executed on channel " + channel + ". The channel is closing down or has closed down");
+        }
+    }
+    
     /**
      * Retrieves classloader for the callable.
      * For {@link DelegatingCallable} the method will try to retrieve a classloader specified there.

--- a/src/main/java/hudson/remoting/VirtualChannel.java
+++ b/src/main/java/hudson/remoting/VirtualChannel.java
@@ -39,14 +39,19 @@ public interface VirtualChannel {
      *
      * <p>
      * Sends {@link Callable} to the remote system, executes it, and returns its result.
-     *
+     * Such calls will be considered as user-space requests.
+     * If the channel cannot execute the requests (e.g. when it is being closed),
+     * the operations may be rejected even if the channel is still active.
+     * 
+     * @param callable Callable to be executed
      * @throws InterruptedException
      *      If the current thread is interrupted while waiting for the completion.
      * @throws IOException
      *      If there's any error in the communication between {@link Channel}s.
+     * @throws T User exception defined by the callable
      */
     <V,T extends Throwable>
-    V call(Callable<V,T> callable) throws IOException, T, InterruptedException;
+    V call(@Nonnull Callable<V,T> callable) throws IOException, T, InterruptedException;
 
     /**
      * Makes an asynchronous remote procedure call.
@@ -54,6 +59,9 @@ public interface VirtualChannel {
      * <p>
      * Similar to {@link #call(Callable)} but returns immediately.
      * The result of the {@link Callable} can be obtained through the {@link Future} object.
+     * Such calls will be considered as user-space requests.
+     * If the channel cannot execute the requests (e.g. when it is being closed),
+     * the operations may be rejected even if the channel is still active.
      *
      * @return
      *      The {@link Future} object that can be used to wait for the completion.
@@ -61,7 +69,7 @@ public interface VirtualChannel {
      *      If there's an error during the communication.
      */
     <V,T extends Throwable>
-    Future<V> callAsync(final Callable<V,T> callable) throws IOException;
+    Future<V> callAsync(@Nonnull final Callable<V,T> callable) throws IOException;
 
     /**
      * Performs an orderly shut down of this channel (and the remote peer.)


### PR DESCRIPTION
This is a major update of Request execution logic in Remoting Channels, which should improve stability of the channel and prevent hanging of commands if the channel gets closed.

- [x] - `Channel#close()` does not always wait for synchronization to happen. There is a sender status check before the lock gets acquired. TODO: find an issue for that
- [x] - `Channel#isClosingOrClosed()` now returns `null` once the first `Channel#close()` command arrives, we do not even wait till it acquires the instance lock. The API is [used outside Remoting](https://github.com/search?q=org%3Ajenkinsci+isClosingOrClosed&type=Code), but it seems that the change is correct in that cases
- [x] - `Channel#call()` and `Channel#callAsync()` now fail if the channel `isClosingOrClosed()`. These calls implement `UserRequest`, and I do not think there is a valid case for even trying any user-space request
- [x] - Offer new API in `hudson.remoting.Request`, which allows checking the channel state before invoking a call. By default it just checks if the channel is closed (just “fail fast” without command initialization)
- [x] - Implement the new API in `UserRequest`, to prevent low-level API calls on a channel, which `isClosingOrClosed()`

TODO:
- [x] - Automatic Tests
- [ ] - TBD: Create `SystemRequest` class, which allows running requests on channels being closed. Not sure if there is a valid non-YOLO use-case though
- [ ] - TBD: Also fail `RPCRequest`s when shutdown is pending? Otherwise there is a risk of similar hanging in Jenkins (e.g. System script invocation)

Direct issue - [JENKINS-45023](https://issues.jenkins-ci.org/browse/JENKINS-45023). Many other issues should be addressed by it, I'd guess.

@reviewbybees @jglick @stephenc 