### PR TITLE
[JENKINS-45233] - Log errors when Response message cannot be delivered due to the closed channel

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -528,11 +528,18 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         transport.setup(this, new CommandReceiver() {
             public void handle(Command cmd) {
                 commandsReceived++;
-                lastCommandReceivedAt = System.currentTimeMillis();
-                if (logger.isLoggable(Level.FINE))
+                long receivedAt = System.currentTimeMillis();
+                lastCommandReceivedAt = receivedAt;
+                if (logger.isLoggable(Level.FINE)) {
                     logger.fine("Received " + cmd);
+                } else if (logger.isLoggable(Level.FINER)) {
+                    logger.log(Level.FINER, "Received command " + cmd, cmd.createdAt);
+                }
                 try {
                     cmd.execute(Channel.this);
+                    if (logger.isLoggable(Level.FINE)) {
+                        logger.log(Level.FINE, "Completed command {0}. It took {1}ms", new Object[] {cmd, System.currentTimeMillis() - receivedAt});
+                    }
                 } catch (Throwable t) {
                     logger.log(Level.SEVERE, "Failed to execute command " + cmd + " (channel " + Channel.this.name + ")", t);
                     logger.log(Level.SEVERE, "This command is created here", cmd.createdAt);

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -25,6 +25,7 @@ package hudson.remoting;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -346,13 +347,17 @@ abstract class Request<RSP extends Serializable,EXC extends Throwable> extends C
                         rsp.createdAt.initCause(createdAt);
 
                     synchronized (channel) {// expand the synchronization block of the send() method to a check
-                        if(!channel.isOutClosed())
+                        if(!channel.isOutClosed()) {
                             channel.send(rsp);
+                        } else {
+                            // Propagate exception to the catch clause instead of supressing it
+                            throw new ClosedChannelException();
+                        }
                     }
                 } catch (IOException e) {
                     // communication error.
                     // this means the caller will block forever
-                    logger.log(Level.SEVERE, "Failed to send back a reply",e);
+                    logger.log(Level.SEVERE, "Failed to send back a reply to the request " + this, e);
                 } finally {
                     channel.executingCalls.remove(id);
                     Thread.currentThread().setName(oldThreadName);

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -347,17 +347,12 @@ abstract class Request<RSP extends Serializable,EXC extends Throwable> extends C
                         rsp.createdAt.initCause(createdAt);
 
                     synchronized (channel) {// expand the synchronization block of the send() method to a check
-                        if(!channel.isOutClosed()) {
-                            channel.send(rsp);
-                        } else {
-                            // Propagate exception to the catch clause instead of supressing it
-                            throw new ClosedChannelException();
-                        }
+                        channel.send(rsp);
                     }
                 } catch (IOException e) {
                     // communication error.
                     // this means the caller will block forever
-                    logger.log(Level.SEVERE, "Failed to send back a reply to the request " + this, e);
+                    logger.log(Level.WARNING, "Failed to send back a reply to the request " + this, e);
                 } finally {
                     channel.executingCalls.remove(id);
                     Thread.currentThread().setName(oldThreadName);

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -346,9 +346,7 @@ abstract class Request<RSP extends Serializable,EXC extends Throwable> extends C
                     if(chainCause)
                         rsp.createdAt.initCause(createdAt);
 
-                    synchronized (channel) {// expand the synchronization block of the send() method to a check
-                        channel.send(rsp);
-                    }
+                    channel.send(rsp);
                 } catch (IOException e) {
                     // communication error.
                     // this means the caller will block forever


### PR DESCRIPTION
Just noticed some issues in command execution logic...

- [x] [JENKINS-45233](https://issues.jenkins-ci.org/browse/JENKINS-45233) - Command processing does not print errors when the Response cannot be delivered due to the closed channel
- [x] Add FINE/FINER logging for better diagnostics of incoming command processing

@reviewbybees