### PR TITLE
[JENKINS-38696] - Add File Leak Detector + Allow Disabling File cache in JARUrlConnection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -581,9 +581,6 @@ THE SOFTWARE.
     </profile>
     <profile>
       <id>surefire-with-fileleak-detector</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <properties>
         <maven-surefire-plugin.agent>-javaagent:${project.build.directory}\agents\file-leak-detector.jar=http=20000</maven-surefire-plugin.agent>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -494,6 +494,7 @@ THE SOFTWARE.
         <configuration>
           <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
           <rerunFailingTestsCount>4</rerunFailingTestsCount>
+          <argLine>${maven-surefire-plugin.agent}</argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -574,6 +575,43 @@ THE SOFTWARE.
                 <argument>http://timestamp.comodoca.com/rfc3161</argument>
               </arguments>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>surefire-with-fileleak-detector</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <maven-surefire-plugin.agent>-javaagent:${project.build.directory}\agents\file-leak-detector.jar=http=20000</maven-surefire-plugin.agent>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-fileleak-detector</id>
+                <phase>process-test-classes</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.kohsuke</groupId>
+                      <artifactId>file-leak-detector</artifactId>
+                      <version>1.8</version>
+                      <classifier>jar-with-dependencies</classifier>
+                      <outputDirectory>${project.build.directory}/agents</outputDirectory>
+                      <destFileName>file-leak-detector.jar</destFileName>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -494,7 +494,7 @@ THE SOFTWARE.
         <configuration>
           <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
           <rerunFailingTestsCount>4</rerunFailingTestsCount>
-          <argLine>${maven-surefire-plugin.agent}</argLine>
+          <argLine>${argLine} ${maven-surefire-plugin.agent}</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -582,7 +582,7 @@ THE SOFTWARE.
     <profile>
       <id>surefire-with-fileleak-detector</id>
       <properties>
-        <maven-surefire-plugin.agent>-javaagent:${project.build.directory}\agents\file-leak-detector.jar=http=20000</maven-surefire-plugin.agent>
+        <maven-surefire-plugin.agent>-javaagent:${project.build.directory}/agents/file-leak-detector.jar=http=20000</maven-surefire-plugin.agent>
       </properties>
       <build>
         <plugins>

--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -76,13 +76,8 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
         ResourceImageInJar.DISABLE_FILE_CACHING_IN_JAR_CONNECTION = oldCachingValue;
         cl.cleanup();
         super.tearDown();
-
-        // TODO: Add to RMI base?
-        if (Boolean.getBoolean("remoting.test.interactive")) {
-            
-        }
         
-        // Clenup the temporary cache and ensure we have no locked files left
+        // Cleanup the temporary cache and ensure we have no locked files left
         FileUtils.deleteDirectory(dir);
     }
 

--- a/src/test/java/hudson/remoting/RmiTestBase.java
+++ b/src/test/java/hudson/remoting/RmiTestBase.java
@@ -53,6 +53,14 @@ public abstract class RmiTestBase extends TestCase {
 
     protected void tearDown() throws Exception {
         channelRunner.stop(channel);
+        
+        // If we run with File Leak Detector, it allows stopping the test and checking the detector's web UI
+        // TODO: Make it a part of the Generic remoting Test framework?
+        if (Boolean.getBoolean("remoting.test.interactive")) {
+            System.out.println("Interactive flag is set. Waiting til somebody interrupts the test. "
+                    + "If File Leak Detector Profile is enabled, you can find its UI in http://localhost:20000");
+            Thread.sleep(Long.MAX_VALUE);
+        }
     }
 
     /*package*/ void setChannelRunner(Class<? extends ChannelRunner> runner) {


### PR DESCRIPTION
This change adds functionality, which allows fixing some failing tests in Windows due to the file leaks. See [JENKINS-38696](https://issues.jenkins-ci.org/browse/JENKINS-38696)

- [x] - Add the `surefire-with-fileleak-detector` profile, which runs tests with File Leak Detector (and its Web UI)
- [x] - Add system property, which disables File caching in `ResourceImageInJar`. I tried to do it in a generic way (ChannelBuilder): https://github.com/oleg-nenashev/remoting/commit/144922e5de65244729fbd8de2a610daa90ea13e1 . It adds too much boilerplate code for a feature, which is not supposed to be used in production
- [x] PrefetchingTest now disables file caching on Windows and fails fast if there are leaked file descriptors in `tearDown()`
- [ ] - Document changes and the new property in the developer documentation 

In the future I consider creating FileLeakDetector test rule for JUnit (with automatic checks), but it is a long shot.

This change fixes only one test, [JENKINS-45349](https://issues.jenkins-ci.org/browse/JENKINS-45349) has to be also fixed for others

@reviewbybees @jtnord 

