### PR TITLE
[JENKINS-45349] - Test Client: Allow disabling file caching in HelloGetResource and HelloGetResources.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.26</version>
+    <version>1.37</version>
   </parent>
 
   <artifactId>remoting-test-client</artifactId>
@@ -39,6 +39,10 @@ THE SOFTWARE.
     This module is separate because some of the tests
     require code in a jar file not available in the default classpath.
   </description>
+  
+  <properties>
+    <java.level>7</java.level>
+  </properties>
 
   <licenses>
     <license>

--- a/src/main/java/test/HelloGetResource.java
+++ b/src/main/java/test/HelloGetResource.java
@@ -4,14 +4,47 @@ import hudson.remoting.Callable;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
 
 /**
+ * Gets a single resource as a string.
+ * This method retrieves resource URL and then uses low-level methods to read it.
+ * 
  * @author Kohsuke Kawaguchi
  */
 public class HelloGetResource implements Callable<String,IOException> {
+    
+    final boolean useCaches;
+
+    @Deprecated
+    public HelloGetResource() {
+        this(true);
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param useCaches If {@code false}, caching in the {@link URLConnection} will be disabled.
+     *                  A default value will be used otherwise.
+     * @since 1.1
+     */
+    public HelloGetResource(boolean useCaches) {
+        this.useCaches = useCaches;
+    }
+        
+    @Override
     public String call() throws IOException {
         URL u = getClass().getResource("hello.txt");
-        return u+"::"+IOUtils.toString(u);
+        
+        URLConnection connection = u.openConnection();
+        if (!useCaches) {
+            connection.setUseCaches(false);
+        }
+        
+        try(InputStream istream = connection.getInputStream()) {
+            return u+"::" + IOUtils.toString(istream);
+        }
     }
 }

--- a/src/main/java/test/HelloGetResourceAsStream.java
+++ b/src/main/java/test/HelloGetResourceAsStream.java
@@ -6,9 +6,18 @@ import org.apache.commons.io.IOUtils;
 import java.io.IOException;
 
 /**
+ * Gets a single resource as a stream.
+ * This call uses {@link Class#getResourceAsStream(java.lang.String)} instead 
+ * of access by URL like {@link HelloGetResource} does.
+ * 
  * @author Kohsuke Kawaguchi
+ * @see HelloGetResource
  */
 public class HelloGetResourceAsStream implements Callable<String,IOException> {
+    
+    // TODO: So, how do we protect it from the resource leak in Windows?
+    // Perhaps ResourceImageBoth patch in the Remoting library is enough
+    @Override
     public String call() throws IOException {
         return IOUtils.toString(getClass().getResourceAsStream("hello.txt"));
     }

--- a/src/main/java/test/HelloGetResources.java
+++ b/src/main/java/test/HelloGetResources.java
@@ -4,21 +4,51 @@ import hudson.remoting.Callable;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.Enumeration;
 
 /**
+ * Lists all resources as a single string.
  * @author Kohsuke Kawaguchi
  */
 public class HelloGetResources implements Callable<String,IOException> {
+
+    final boolean useCaches;
+    
+    @Deprecated
+    public HelloGetResources() {
+        this(true);
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param useCaches If {@code false}, caching in the {@link URLConnection} will be disabled.
+     *                  A default value will be used otherwise.
+     * @since 1.1
+     */
+    public HelloGetResources(boolean useCaches) {
+        this.useCaches = useCaches;
+    }
+    
+    @Override
     public String call() throws IOException {
         Enumeration<URL> e = getClass().getClassLoader().getResources("test/hello.txt");
         StringBuilder b = new StringBuilder();
         while (e.hasMoreElements()) {
             URL u = e.nextElement();
+            URLConnection connection = u.openConnection();
+            if (!useCaches) {
+                connection.setUseCaches(false);
+            }
+            
             b.append(u);
             b.append("::");
-            b.append(IOUtils.toString(u));
+            try (InputStream istream = connection.getInputStream()) {
+                b.append(IOUtils.toString(istream));
+            }
             b.append('\n');
         }
         return b.toString();


### PR DESCRIPTION
This change adds an optional parameter, which disables file caching. My plan is to reuse it in Remoting tests in order to suppress some issues in Windows tests.

https://issues.jenkins-ci.org/browse/JENKINS-45349

@reviewbybees @jtnord 