### PR TITLE
[JENKINS-46259] - Log all linkage errors during user requests

### DIFF
--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -51,6 +51,8 @@ import javax.annotation.Nonnull;
  */
 final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<RSP,EXC>,EXC> {
 
+    private static final Logger LOGGER = Logger.getLogger(UserRequest.class.getName());
+
     private final byte[] request;
     
     @Nonnull
@@ -180,7 +182,7 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<
                 try {
                     o = deserialize(channel,request,cl);
                 } catch (ClassNotFoundException e) {
-                    throw new ClassNotFoundException("Failed to deserialize the Callable object. Perhaps you needed to implement DelegatingCallable?",e);
+                    throw new ClassNotFoundException("Failed to deserialize the Callable object. Perhaps you needed to implement DelegatingCallable?", e);
                 } catch (RuntimeException e) {
                     // if the error is during deserialization, throw it in one of the types Channel.call will
                     // capture its call site stack trace. See 
@@ -204,6 +206,9 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<
                 } finally {
                     Thread.currentThread().setContextClassLoader(old);
                 }
+            } catch (LinkageError e) {
+                LOGGER.log(Level.INFO, "LinkageError while performing " + toString(), e);
+                throw e;
             } finally {
                 Channel.setCurrent(oldc);
             }

--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -207,7 +207,7 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<
                     Thread.currentThread().setContextClassLoader(old);
                 }
             } catch (LinkageError e) {
-                LOGGER.log(Level.INFO, "LinkageError while performing " + toString(), e);
+                LOGGER.log(Level.WARNING, "LinkageError while performing " + toString(), e);
                 throw e;
             } finally {
                 Channel.setCurrent(oldc);


### PR DESCRIPTION
Linkage errors are a symptom of subtle classloading problems that are hart to investigate on its own. Propagating the exception upwards and over the channel only does not help as the stacktraces are dispersed all over the place (build logs, server log, discarded by caller, etc.) making the problem discovery and chain-of-the-events reconstruction harder.

I presume this is something of an interest for instance administrator so let's log it at one place.