### PR TITLE
[JENKINS-37567] - Add option to specify certchain, enforce certificate checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,8 @@ THE SOFTWARE.
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <findbugs.failOnError>false</findbugs.failOnError>
+    <!-- TODO: Required to override by a version with certchain support (MJARSIGNER-53) on @oleg-nenashev's machine. Remove once it's in upstream -->
+    <maven-jarsigner-plugin.version>1.4</maven-jarsigner-plugin.version>
   </properties>
 
   <repositories>
@@ -274,7 +276,7 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-jarsigner-plugin</artifactId>
-        <version>1.4</version>
+        <version>${maven-jarsigner-plugin.version}</version>
         <configuration>
           <!--
             during the development, debug profile will cause
@@ -289,11 +291,18 @@ THE SOFTWARE.
           <providerClass>${hudson.sign.providerClass}</providerClass>
           <providerArg>${hudson.sign.providerArg}</providerArg>
           <tsa>${hudson.sign.tsa}</tsa>
+          <!-- 
+            This option is required for JENKINS-37567, not required on any release machine.
+            In order to take effect, a version with MJARSIGNER-53 should be used.
+            See the "maven-jarsigner-plugin.version" parameter.
+          -->
+          <certchain>${hudson.sign.certchain}</certchain>
         </configuration>
         <executions>
           <execution>
             <goals>
               <goal>sign</goal>
+              <goal>verify</goal>
             </goals>
           </execution>
         </executions>
@@ -568,12 +577,39 @@ THE SOFTWARE.
           </plugin>
           <plugin>
             <artifactId>maven-jarsigner-plugin</artifactId>
-            <configuration>
-              <arguments>
-                <argument>-tsa</argument>
-                <argument>http://timestamp.comodoca.com/rfc3161</argument>
-              </arguments>
-            </configuration>
+            <executions>
+              <execution>
+                <id>add-tsa</id>
+                <!-- Phase and goal are the default ones -->
+                <!-- TODO: Does it cause conflict with signing parameters in the build? Seems "no". Should also use ${hudson.sign.tsa} -->
+                <configuration>
+                    <arguments>
+                        <argument>-tsa</argument>
+                        <argument>http://timestamp.comodoca.com/rfc3161</argument>
+                    </arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>verify-signature</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <processMainArtifact>true</processMainArtifact>
+                  <processAttachedArtifacts>false</processAttachedArtifacts>
+                  <certs>true</certs>
+                  <errorWhenNotSigned>true</errorWhenNotSigned>
+                  <arguments>-strict</arguments> <!--otherwise certificate chains will be ignored-->
+                  <alias>${hudson.sign.alias}</alias>
+                  <storepass>${hudson.sign.storepass}</storepass>
+                  <keystore>${hudson.sign.keystore}</keystore>
+                  <storetype>${hudson.sign.storetype}</storetype>
+                  <providerClass>${hudson.sign.providerClass}</providerClass>
+                  <providerArg>${hudson.sign.providerArg}</providerArg> 
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
It should finalize [JENKINS-37567](https://issues.jenkins-ci.org/browse/JENKINS-37567).

- [x] - Add `certchain` option (requires a custom profile now)
  * See https://github.com/apache/maven-plugins/pull/125 and https://github.com/apache/maven-shared/pull/24
- [x] - Start **REALLY** validating the signing correctness when the release flow is enabled

I have checked the default options, the change does not impact the local dev build and @kohsuke 's release flow. I am quite aware about the `jarsigner -tsa` step in the `release` profile, but it seems to be harmless on my local machine.

@reviewbybees @olamy @kohsuke 
