### PR TITLE
[JENKINS-46341] - Disable Windows build for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,8 @@ properties([[$class: 'BuildDiscarderProperty',
 /* These platforms correspond to labels in ci.jenkins.io, see:
  *  https://github.com/jenkins-infra/documentation/blob/master/ci.adoc
  */
-List platforms = ['linux', 'windows']
+//TODO: Enable Windows once JENKINS-38696 is fixed. No sense to spend CPU cycles before that
+List platforms = ['linux']
 Map branches = [:]
 
 for (int i = 0; i < platforms.size(); ++i) {


### PR DESCRIPTION
It just does not make sense while [JENKINS-38696](https://issues.jenkins-ci.org/browse/JENKINS-38696) is not fixed

@reviewbybees