### PR TITLE
fix jar cache from user.home to user.dir - Fixes official jenkins docker image

### DIFF
--- a/src/main/java/hudson/remoting/JarCache.java
+++ b/src/main/java/hudson/remoting/JarCache.java
@@ -29,6 +29,7 @@ public abstract class JarCache {
     
     @Nonnull
     /*package*/ static JarCache getDefault() {
+        DEFAULT_NOWS_JAR_CACHE_LOCATION.getAbsoluteFile()
         return new FileSystemJarCache(DEFAULT_NOWS_JAR_CACHE_LOCATION, true);
     }
     

--- a/src/main/java/hudson/remoting/JarCache.java
+++ b/src/main/java/hudson/remoting/JarCache.java
@@ -25,11 +25,10 @@ public abstract class JarCache {
      * Default JAR cache location for disabled workspace Manager.
      */
     /*package*/ static final File DEFAULT_NOWS_JAR_CACHE_LOCATION = 
-        new File(System.getProperty("user.home"),".jenkins/cache/jars");
+        new File(System.getProperty("user.dir"),".jenkins/cache/jars");
     
     @Nonnull
     /*package*/ static JarCache getDefault() {
-        DEFAULT_NOWS_JAR_CACHE_LOCATION.getAbsoluteFile()
         return new FileSystemJarCache(DEFAULT_NOWS_JAR_CACHE_LOCATION, true);
     }
     


### PR DESCRIPTION
### Problem

 * :bangbang: `user.home` info IS NOT TAKEN from `$HOME` EnvVar, but from `/etc/passwd` instead.
 * :white_check_mark: `user.dir` IS TAKEN from `$HOME` EnvVar

Due to most people using dockerized builds and setting HOME EnvVar **it would be better to use `user.dir` instead of `user.home` for the JarCache** to avoid errors like this one:

![image](https://user-images.githubusercontent.com/12599965/29713672-06872b02-89a0-11e7-8444-28563f85ebde.png)

### Where does it happen?

In official docker image `jenkinsci/jenkins:2.75` (when working with kubernetes-plugin).

![image](https://user-images.githubusercontent.com/12599965/29718995-d81b6c14-89b4-11e7-938a-a94bc2de6e36.png)


### How to test

Test under Ubuntu 16.04

```
docker run -i -t ubuntu:16.04 bash
```

Inside Docker as root:

```
apt-get install openjdk-8-jdk vim
groupadd -g 10000 jenkins
useradd -c "Jenkins user" -d /home/jenkins -u 10000 -g 10000 -m jenkins
```

Change /etc/passwd from `jenkins:x:10000:10000:Jenkins user:/home/jenkins:` to `jenkins:x:10000:10000:Jenkins user:/home/jenkins2:`.

Switch to Jenkins User and create `Test.java`:

```
su - jenkins
cd /home/jenkins
vim /home/jenkins/Test.java
```

```java
import java.io.File;

public class Test {

  public static void main(String[] args){
      System.out.println(System.getProperty("user.home"));
      System.out.println(System.getProperty("user.dir"));
      File file = new File(System.getProperty("user.dir"),".jenkins/cache/jars");
      file.mkdir();
      System.out.println(file.getAbsoluteFile());
    }
}
```

Compile and run:

```
javac Test.java
java Test
```

It Prints out:

```
/home/jenkins2
/home/jenkins
/home/jenkins/.jenkins/cache/jars
```
