### PR TITLE
[JENKINS-47425] Do not print a stack trace on connection error

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -31,6 +31,7 @@ import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
@@ -317,6 +318,9 @@ public class JnlpAgentEndpointResolver {
                     LOGGER.log(Level.INFO,
                             "Master isn't ready to talk to us on {0}. Will retry again: response code={1}",
                             new Object[]{url, con.getResponseCode()});
+                } catch (SocketTimeoutException e) {
+                    LOGGER.log(INFO, "Failed to connect to the master. Will retry again: {0} {1}",
+                            new String[] { e.getClass().getName(), e.getMessage() });
                 } catch (IOException e) {
                     // report the failure
                     LOGGER.log(INFO, "Failed to connect to the master. Will retry again", e);

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -318,14 +318,14 @@ public class JnlpAgentEndpointResolver {
                         return;
                     }
                     LOGGER.log(Level.INFO,
-                            "Master isn't ready to talk to us on {0}. Will retry again: response code={1}",
+                            "Master isn't ready to talk to us on {0}. Will try again: response code={1}",
                             new Object[]{url, con.getResponseCode()});
                 } catch (SocketTimeoutException | ConnectException | NoRouteToHostException e) {
-                    LOGGER.log(INFO, "Failed to connect to the master. Will retry again: {0} {1}",
+                    LOGGER.log(INFO, "Failed to connect to the master. Will try again: {0} {1}",
                             new String[] { e.getClass().getName(), e.getMessage() });
                 } catch (IOException e) {
                     // report the failure
-                    LOGGER.log(INFO, "Failed to connect to the master. Will retry again", e);
+                    LOGGER.log(INFO, "Failed to connect to the master. Will try again", e);
                 }
             }
         } finally {

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -25,9 +25,11 @@ package org.jenkinsci.remoting.engine;
 
 import hudson.remoting.Base64;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.net.NoRouteToHostException;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
@@ -318,7 +320,7 @@ public class JnlpAgentEndpointResolver {
                     LOGGER.log(Level.INFO,
                             "Master isn't ready to talk to us on {0}. Will retry again: response code={1}",
                             new Object[]{url, con.getResponseCode()});
-                } catch (SocketTimeoutException e) {
+                } catch (SocketTimeoutException | ConnectException | NoRouteToHostException e) {
                     LOGGER.log(INFO, "Failed to connect to the master. Will retry again: {0} {1}",
                             new String[] { e.getClass().getName(), e.getMessage() });
                 } catch (IOException e) {


### PR DESCRIPTION
It is a possible condition and just pollutes the logs

https://issues.jenkins-ci.org/browse/JENKINS-47425

@reviewbybees
