### PR TITLE
[JENKINS-47714] - Introduce SerializableOnlyOverRemoting and cleanup FindBugs in Channel#current().

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>access-modifier-annotation</artifactId>
-      <version>1.7</version>
+      <version>1.12</version>
       <type>jar</type>
       <optional>true</optional><!-- no need to have this at runtime -->
     </dependency>

--- a/src/main/java/hudson/remoting/Callable.java
+++ b/src/main/java/hudson/remoting/Callable.java
@@ -27,6 +27,7 @@ import org.jenkinsci.remoting.RoleSensitive;
 
 import java.io.Serializable;
 
+//TODO: Make it SerializableOnlyOverRemoting?
 /**
  * Represents computation to be done on a remote system.
  *

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1722,7 +1722,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *
      * @return Current channel
      * @throws IllegalStateException the calling thread has no associated channel.
-     * @since TODO
+     * @since 3.14
      * @see org.jenkinsci.remoting.SerializableOnlyOverRemoting
      */
     @Nonnull

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -42,7 +42,6 @@ import java.io.InputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
 import java.net.URL;
@@ -1176,7 +1175,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
             this.level = level;
         }
         public Void call() throws RuntimeException {
-            Channel.currentOrIllegalState().maximumBytecodeLevel = level;
+            Channel.currentOrFail().maximumBytecodeLevel = level;
             return null;
         }
 
@@ -1633,7 +1632,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     private static final class IOSyncer implements Callable<Object, InterruptedException> {
         @Override
         public Object call() throws InterruptedException {
-            Channel.currentOrIllegalState().syncLocalIO();
+            Channel.currentOrFail().syncLocalIO();
             return null;
         }
 
@@ -1727,7 +1726,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * @see org.jenkinsci.remoting.SerializableOnlyOverRemoting
      */
     @Nonnull
-    public static Channel currentOrIllegalState() throws IllegalStateException {
+    public static Channel currentOrFail() throws IllegalStateException {
         final Channel ch = CURRENT.get();
         if (ch == null) {
             final Thread t = Thread.currentThread();

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -42,6 +42,7 @@ import java.io.InputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
 import java.net.URL;
@@ -1175,7 +1176,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
             this.level = level;
         }
         public Void call() throws RuntimeException {
-            Channel.current().maximumBytecodeLevel = level;
+            Channel.currentOrIllegalState().maximumBytecodeLevel = level;
             return null;
         }
 
@@ -1630,8 +1631,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     }
 
     private static final class IOSyncer implements Callable<Object, InterruptedException> {
+        @Override
         public Object call() throws InterruptedException {
-            Channel.current().syncLocalIO();
+            Channel.currentOrIllegalState().syncLocalIO();
             return null;
         }
 
@@ -1714,6 +1716,24 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     @CheckForNull
     public static Channel current() {
         return CURRENT.get();
+    }
+
+    /**
+     * Gets current channel or fails with {@link IllegalStateException}.
+     *
+     * @return Current channel
+     * @throws IllegalStateException the calling thread has no associated channel.
+     * @since TODO
+     * @see org.jenkinsci.remoting.SerializableOnlyOverRemoting
+     */
+    @Nonnull
+    public static Channel currentOrIllegalState() throws IllegalStateException {
+        final Channel ch = CURRENT.get();
+        if (ch == null) {
+            final Thread t = Thread.currentThread();
+            throw new IllegalStateException("The calling thread " + t + " has no associated channel");
+        }
+        return ch;
     }
 
     // TODO: Unrestrict after the merge into the master.

--- a/src/main/java/hudson/remoting/ClassLoaderHolder.java
+++ b/src/main/java/hudson/remoting/ClassLoaderHolder.java
@@ -37,14 +37,14 @@ public class ClassLoaderHolder implements SerializableOnlyOverRemoting {
 
     private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
         IClassLoader proxy = (IClassLoader)ois.readObject();
-        classLoader = proxy==null ? null : getChannelForSerDes().importedClassLoaders.get(proxy);
+        classLoader = proxy==null ? null : getChannelForSerialization().importedClassLoaders.get(proxy);
     }
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
         if (classLoader==null)
             oos.writeObject(null);
         else {
-            IClassLoader proxy = RemoteClassLoader.export(classLoader, getChannelForSerDes());
+            IClassLoader proxy = RemoteClassLoader.export(classLoader, getChannelForSerialization());
             oos.writeObject(proxy);
         }
     }

--- a/src/main/java/hudson/remoting/ClassLoaderHolder.java
+++ b/src/main/java/hudson/remoting/ClassLoaderHolder.java
@@ -1,11 +1,11 @@
 package hudson.remoting;
 
 import hudson.remoting.RemoteClassLoader.IClassLoader;
+import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.Serializable;
 import javax.annotation.CheckForNull;
 
 /**
@@ -14,7 +14,7 @@ import javax.annotation.CheckForNull;
  * @author Kohsuke Kawaguchi
  * @since 2.12
  */
-public class ClassLoaderHolder implements Serializable {
+public class ClassLoaderHolder implements SerializableOnlyOverRemoting {
     
     @CheckForNull
     private transient ClassLoader classLoader;
@@ -37,14 +37,14 @@ public class ClassLoaderHolder implements Serializable {
 
     private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
         IClassLoader proxy = (IClassLoader)ois.readObject();
-        classLoader = proxy==null ? null : Channel.current().importedClassLoaders.get(proxy);
+        classLoader = proxy==null ? null : getChannelForSerDes().importedClassLoaders.get(proxy);
     }
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
         if (classLoader==null)
             oos.writeObject(null);
         else {
-            IClassLoader proxy = RemoteClassLoader.export(classLoader, Channel.current());
+            IClassLoader proxy = RemoteClassLoader.export(classLoader, getChannelForSerDes());
             oos.writeObject(proxy);
         }
     }

--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -1,9 +1,11 @@
 package hudson.remoting;
 
+import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
+
 import java.io.File;
 import java.io.IOException;
+import java.io.NotSerializableException;
 import java.io.OutputStream;
-import java.io.Serializable;
 import java.net.URL;
 import java.util.Collections;
 import java.util.HashSet;
@@ -17,7 +19,7 @@ import java.util.concurrent.ConcurrentMap;
  * @author Kohsuke Kawaguchi
  */
 @edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_BAD_FIELD")
-class JarLoaderImpl implements JarLoader, Serializable {
+class JarLoaderImpl implements JarLoader, SerializableOnlyOverRemoting {
     private final ConcurrentMap<Checksum,URL> knownJars = new ConcurrentHashMap<>();
 
     @edu.umd.cs.findbugs.annotations.SuppressWarnings("DMI_COLLECTION_OF_URLS") // TODO: fix this
@@ -71,8 +73,8 @@ class JarLoaderImpl implements JarLoader, Serializable {
     /**
      * When sent to the remote node, send a proxy.
      */
-    private Object writeReplace() {
-        return Channel.current().export(JarLoader.class, this);
+    private Object writeReplace() throws NotSerializableException {
+        return getChannelForSerDes().export(JarLoader.class, this);
     }
 
     public static final String DIGEST_ALGORITHM = System.getProperty(JarLoaderImpl.class.getName()+".algorithm","SHA-256");

--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -74,7 +74,7 @@ class JarLoaderImpl implements JarLoader, SerializableOnlyOverRemoting {
      * When sent to the remote node, send a proxy.
      */
     private Object writeReplace() throws NotSerializableException {
-        return getChannelForSerDes().export(JarLoader.class, this);
+        return getChannelForSerialization().export(JarLoader.class, this);
     }
 
     public static final String DIGEST_ALGORITHM = System.getProperty(JarLoaderImpl.class.getName()+".algorithm","SHA-256");

--- a/src/main/java/hudson/remoting/Pipe.java
+++ b/src/main/java/hudson/remoting/Pipe.java
@@ -150,7 +150,7 @@ public final class Pipe implements SerializableOnlyOverRemoting, ErrorPropagatin
     }
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
-        final Channel ch = getChannelForSerDes();
+        final Channel ch = getChannelForSerialization();
 
         // TODO: there's a discrepancy in the pipe window size and FastPipedInputStream buffer size.
         // The former uses 1M, while the latter uses 64K, so if the sender is too fast, it'll cause
@@ -174,7 +174,7 @@ public final class Pipe implements SerializableOnlyOverRemoting, ErrorPropagatin
     }
 
     private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
-        final Channel channel = getChannelForSerDes();
+        final Channel channel = getChannelForSerialization();
 
         if(ois.readBoolean()) {
             // local will write to remote

--- a/src/main/java/hudson/remoting/Pipe.java
+++ b/src/main/java/hudson/remoting/Pipe.java
@@ -23,12 +23,13 @@
  */
 package hudson.remoting;
 
+import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
-import java.io.Serializable;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -96,7 +97,7 @@ import java.util.logging.Logger;
  *
  * @author Kohsuke Kawaguchi
  */
-public final class Pipe implements Serializable, ErrorPropagatingOutputStream {
+public final class Pipe implements SerializableOnlyOverRemoting, ErrorPropagatingOutputStream {
     private InputStream in;
     private OutputStream out;
 
@@ -149,6 +150,8 @@ public final class Pipe implements Serializable, ErrorPropagatingOutputStream {
     }
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
+        final Channel ch = getChannelForSerDes();
+
         // TODO: there's a discrepancy in the pipe window size and FastPipedInputStream buffer size.
         // The former uses 1M, while the latter uses 64K, so if the sender is too fast, it'll cause
         // the pipe IO thread to block other IO activities. Fix this by first using adaptive growing buffer
@@ -156,14 +159,14 @@ public final class Pipe implements Serializable, ErrorPropagatingOutputStream {
         if(in!=null && out==null) {
             // remote will write to local
             FastPipedOutputStream pos = new FastPipedOutputStream((FastPipedInputStream)in);
-            int oid = Channel.current().internalExport(Object.class, pos, false);  // this export is unexported in ProxyOutputStream.finalize()
+            int oid = ch.internalExport(Object.class, pos, false);  // this export is unexported in ProxyOutputStream.finalize()
 
             oos.writeBoolean(true); // marker
             oos.writeInt(oid);
         } else {
             // remote will read from local this object gets unexported when the pipe is connected.
             // see ConnectCommand
-            int oid = Channel.current().internalExport(Object.class, out, false);
+            int oid = ch.internalExport(Object.class, out, false);
 
             oos.writeBoolean(false);
             oos.writeInt(oid);
@@ -171,8 +174,7 @@ public final class Pipe implements Serializable, ErrorPropagatingOutputStream {
     }
 
     private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
-        final Channel channel = Channel.current();
-        assert channel !=null;
+        final Channel channel = getChannelForSerDes();
 
         if(ois.readBoolean()) {
             // local will write to remote

--- a/src/main/java/hudson/remoting/ProxyOutputStream.java
+++ b/src/main/java/hudson/remoting/ProxyOutputStream.java
@@ -23,6 +23,7 @@
  */
 package hudson.remoting;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
@@ -67,14 +68,14 @@ final class ProxyOutputStream extends OutputStream implements ErrorPropagatingOu
      * @param oid
      *      The object id of the exported {@link OutputStream}.
      */
-    public ProxyOutputStream(Channel channel, int oid) throws IOException {
+    public ProxyOutputStream(@Nonnull Channel channel, int oid) throws IOException {
         connect(channel,oid);
     }
 
     /**
      * Connects this stream to the specified remote object.
      */
-    synchronized void connect(Channel channel, int oid) throws IOException {
+    synchronized void connect(@Nonnull Channel channel, int oid) throws IOException {
         if(this.channel!=null)
             throw new IllegalStateException("Cannot connect twice");
         if(oid==0)

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -1080,7 +1080,7 @@ final class RemoteClassLoader extends URLClassLoader {
 
         private Object readResolve() throws ObjectStreamException {
             try {
-                return getChannelForSerDes().getExportedObject(oid);
+                return getChannelForSerialization().getExportedObject(oid);
             } catch (ExecutionException ex) {
                 //TODO: Implement something better?
                 throw new IllegalStateException("Cannot resolve remoting classloader", ex);

--- a/src/main/java/hudson/remoting/RemoteInputStream.java
+++ b/src/main/java/hudson/remoting/RemoteInputStream.java
@@ -23,11 +23,12 @@
  */
 package hudson.remoting;
 
+import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
+
 import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.io.ObjectOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -47,7 +48,7 @@ import static hudson.remoting.RemoteInputStream.Flag.*;
  *
  * @author Kohsuke Kawaguchi
  */
-public class RemoteInputStream extends InputStream implements Serializable {
+public class RemoteInputStream extends InputStream implements SerializableOnlyOverRemoting {
     private static final Logger LOGGER = Logger.getLogger(RemoteInputStream.class.getName());
     private transient InputStream core;
     private boolean autoUnexport;
@@ -107,7 +108,7 @@ public class RemoteInputStream extends InputStream implements Serializable {
     }
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
-        Channel ch = Channel.current();
+        final Channel ch = getChannelForSerDes();
         if (ch.remoteCapability.supportsGreedyRemoteInputStream()) {
             oos.writeBoolean(greedy);
 
@@ -175,9 +176,7 @@ public class RemoteInputStream extends InputStream implements Serializable {
     }
 
     private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
-        final Channel channel = Channel.current();
-        assert channel !=null;
-
+        final Channel channel = getChannelForSerDes();
         if (channel.remoteCapability.supportsGreedyRemoteInputStream()) {
             boolean greedy = ois.readBoolean();
             if (greedy) {

--- a/src/main/java/hudson/remoting/RemoteInputStream.java
+++ b/src/main/java/hudson/remoting/RemoteInputStream.java
@@ -108,7 +108,7 @@ public class RemoteInputStream extends InputStream implements SerializableOnlyOv
     }
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
-        final Channel ch = getChannelForSerDes();
+        final Channel ch = getChannelForSerialization();
         if (ch.remoteCapability.supportsGreedyRemoteInputStream()) {
             oos.writeBoolean(greedy);
 
@@ -176,7 +176,7 @@ public class RemoteInputStream extends InputStream implements SerializableOnlyOv
     }
 
     private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
-        final Channel channel = getChannelForSerDes();
+        final Channel channel = getChannelForSerialization();
         if (channel.remoteCapability.supportsGreedyRemoteInputStream()) {
             boolean greedy = ois.readBoolean();
             if (greedy) {

--- a/src/main/java/hudson/remoting/RemoteInvocationHandler.java
+++ b/src/main/java/hudson/remoting/RemoteInvocationHandler.java
@@ -232,7 +232,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         if(method.getDeclaringClass()==IReadResolve.class) {
             // readResolve on the proxy.
             // if we are going back to where we came from, replace the proxy by the real object
-            if(goingHome)   return Channel.currentOrIllegalState().getExportedObject(oid);
+            if(goingHome)   return Channel.currentOrFail().getExportedObject(oid);
             else            return proxy;
         }
 
@@ -871,7 +871,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         }
 
         public Serializable call() throws Throwable {
-            return perform(Channel.currentOrIllegalState());
+            return perform(Channel.currentOrFail());
         }
 
         @Override

--- a/src/main/java/hudson/remoting/RemoteOutputStream.java
+++ b/src/main/java/hudson/remoting/RemoteOutputStream.java
@@ -80,12 +80,12 @@ public final class RemoteOutputStream extends OutputStream implements Serializab
     }
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
-        int id = getChannelForSerDes().internalExport(OutputStream.class, core, false); // this export is unexported in ProxyOutputStream.finalize()
+        int id = getChannelForSerialization().internalExport(OutputStream.class, core, false); // this export is unexported in ProxyOutputStream.finalize()
         oos.writeInt(id);
     }
 
     private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
-        this.core = new ProxyOutputStream(getChannelForSerDes(), ois.readInt());
+        this.core = new ProxyOutputStream(getChannelForSerialization(), ois.readInt());
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/remoting/RemoteWriter.java
+++ b/src/main/java/hudson/remoting/RemoteWriter.java
@@ -23,6 +23,8 @@
  */
 package hudson.remoting;
 
+import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -48,7 +50,7 @@ import java.io.Writer;
  * @see RemoteInputStream
  * @author Kohsuke Kawaguchi
  */
-public final class RemoteWriter extends Writer implements Serializable {
+public final class RemoteWriter extends Writer implements SerializableOnlyOverRemoting {
     /**
      * On local machine, this points to the {@link Writer} where
      * the data will be sent ultimately.
@@ -63,14 +65,12 @@ public final class RemoteWriter extends Writer implements Serializable {
     }
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
-        int id = Channel.current().internalExport(Writer.class, core, false);  // this export is unexported in ProxyWriter.finalize()
+        int id = getChannelForSerDes().internalExport(Writer.class, core, false);  // this export is unexported in ProxyWriter.finalize()
         oos.writeInt(id);
     }
 
     private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
-        final Channel channel = Channel.current();
-        assert channel !=null;
-
+        final Channel channel = getChannelForSerDes();
         this.core = new ProxyWriter(channel, ois.readInt());
     }
 

--- a/src/main/java/hudson/remoting/RemoteWriter.java
+++ b/src/main/java/hudson/remoting/RemoteWriter.java
@@ -28,7 +28,6 @@ import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.Serializable;
 import java.io.Writer;
 
 /**
@@ -65,12 +64,12 @@ public final class RemoteWriter extends Writer implements SerializableOnlyOverRe
     }
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
-        int id = getChannelForSerDes().internalExport(Writer.class, core, false);  // this export is unexported in ProxyWriter.finalize()
+        int id = getChannelForSerialization().internalExport(Writer.class, core, false);  // this export is unexported in ProxyWriter.finalize()
         oos.writeInt(id);
     }
 
     private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
-        final Channel channel = getChannelForSerDes();
+        final Channel channel = getChannelForSerialization();
         this.core = new ProxyWriter(channel, ois.readInt());
     }
 

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -33,8 +33,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Request/response pattern over {@link Channel}, the layer-1 service.
@@ -60,7 +60,7 @@ abstract class Request<RSP extends Serializable,EXC extends Throwable> extends C
      *      The exception will be forwarded to the calling process.
      *      If no checked exception is supposed to be thrown, use {@link RuntimeException}.
      */
-    @CheckForNull
+    @Nullable
     protected abstract RSP perform(@Nonnull Channel channel) throws EXC;
 
     /**

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /**
@@ -51,7 +52,7 @@ abstract class Request<RSP extends Serializable,EXC extends Throwable> extends C
      *
      * @param channel
      *      The local channel. From the view point of the JVM that
-     *      {@link #call(Channel) made the call}, this channel is
+     *      {@link #call(Channel)} made the call, this channel is
      *      the remote channel.
      * @return
      *      the return value will be sent back to the calling process.
@@ -59,7 +60,8 @@ abstract class Request<RSP extends Serializable,EXC extends Throwable> extends C
      *      The exception will be forwarded to the calling process.
      *      If no checked exception is supposed to be thrown, use {@link RuntimeException}.
      */
-    protected abstract RSP perform(Channel channel) throws EXC;
+    @CheckForNull
+    protected abstract RSP perform(@Nonnull Channel channel) throws EXC;
 
     /**
      * Uniquely identifies this request.

--- a/src/main/java/hudson/remoting/forward/ForwarderFactory.java
+++ b/src/main/java/hudson/remoting/forward/ForwarderFactory.java
@@ -24,15 +24,16 @@
 package hudson.remoting.forward;
 
 import hudson.remoting.Callable;
-import hudson.remoting.Channel;
 import hudson.remoting.RemoteOutputStream;
 import hudson.remoting.SocketChannelStream;
 import hudson.remoting.VirtualChannel;
 import org.jenkinsci.remoting.Role;
 import org.jenkinsci.remoting.RoleChecker;
+import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectStreamException;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.util.logging.Level;
@@ -69,7 +70,7 @@ public class ForwarderFactory {
         return new ForwarderImpl(remoteHost,remotePort);
     }
 
-    private static class ForwarderImpl implements Forwarder {
+    private static class ForwarderImpl implements Forwarder, SerializableOnlyOverRemoting {
         private final String remoteHost;
         private final int remotePort;
 
@@ -99,8 +100,8 @@ public class ForwarderFactory {
         /**
          * When sent to the remote node, send a proxy.
          */
-        private Object writeReplace() {
-            return Channel.current().export(Forwarder.class, this);
+        private Object writeReplace() throws ObjectStreamException {
+            return getChannelForSerDes().export(Forwarder.class, this);
         }
 
         private static final long serialVersionUID = 8382509901649461466L;

--- a/src/main/java/hudson/remoting/forward/ForwarderFactory.java
+++ b/src/main/java/hudson/remoting/forward/ForwarderFactory.java
@@ -101,7 +101,7 @@ public class ForwarderFactory {
          * When sent to the remote node, send a proxy.
          */
         private Object writeReplace() throws ObjectStreamException {
-            return getChannelForSerDes().export(Forwarder.class, this);
+            return getChannelForSerialization().export(Forwarder.class, this);
         }
 
         private static final long serialVersionUID = 8382509901649461466L;

--- a/src/main/java/hudson/remoting/forward/PortForwarder.java
+++ b/src/main/java/hudson/remoting/forward/PortForwarder.java
@@ -136,7 +136,7 @@ public class PortForwarder extends Thread implements Closeable, ListeningPort {
             public ListeningPort call() throws IOException {
                 PortForwarder t = new PortForwarder(acceptingPort, proxy);
                 t.start();
-                return Channel.current().export(ListeningPort.class,t);
+                return Channel.currentOrIllegalState().export(ListeningPort.class,t);
             }
 
             @Override

--- a/src/main/java/hudson/remoting/forward/PortForwarder.java
+++ b/src/main/java/hudson/remoting/forward/PortForwarder.java
@@ -136,7 +136,7 @@ public class PortForwarder extends Thread implements Closeable, ListeningPort {
             public ListeningPort call() throws IOException {
                 PortForwarder t = new PortForwarder(acceptingPort, proxy);
                 t.start();
-                return Channel.currentOrIllegalState().export(ListeningPort.class,t);
+                return Channel.currentOrFail().export(ListeningPort.class,t);
             }
 
             @Override

--- a/src/main/java/org/jenkinsci/remoting/SerializableOnlyOverRemoting.java
+++ b/src/main/java/org/jenkinsci/remoting/SerializableOnlyOverRemoting.java
@@ -42,7 +42,7 @@ import java.io.Serializable;
  * Attempts to serialize the instance of this interface for different purposes lead to undefined behavior.
  *
  * @author Oleg Nenashev
- * @since TODO
+ * @since 3.14
  */
 public interface SerializableOnlyOverRemoting extends Serializable {
 

--- a/src/main/java/org/jenkinsci/remoting/SerializableOnlyOverRemoting.java
+++ b/src/main/java/org/jenkinsci/remoting/SerializableOnlyOverRemoting.java
@@ -1,0 +1,72 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.remoting;
+
+import hudson.remoting.Channel;
+
+import javax.annotation.Nonnull;
+import java.io.NotSerializableException;
+import java.io.Serializable;
+
+/**
+ * This interface indicates objects, which are {@link Serializable} only for sending over the Remoting {@link Channel}.
+ *
+ * Usually it means that the object requires export of the class via {@link Channel}
+ * and {@code hudson.remoting.ExportTable}.
+ * Attempts to serialize the instance of this interface for different purposes lead to undefined behavior.
+ *
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+public interface SerializableOnlyOverRemoting extends Serializable {
+
+
+
+    /**
+     * Gets current channel or fails with {@link NotSerializableException}.
+     *
+     * This method is designed for serialization/deserialization methods in the channel.
+     * @return Current channel
+     * @throws NotSerializableException the calling thread has no associated channel.
+     *      In such case the object cannot be serialized.
+     */
+    @Nonnull
+    default Channel getChannelForSerDes() throws NotSerializableException {
+        final Channel ch = Channel.current();
+        if (ch == null) {
+            // This logic does not prevent from improperly serializing objects within Remoting calls.
+            // If it happens in API calls in external usages, we wish good luck with diagnosing Remoting issues
+            // and leaks in ExportTable.
+            //TODO: maybe there is a way to actually diagnose this case?
+            final Thread t = Thread.currentThread();
+            throw new NotSerializableException("The calling thread " + t + " has no associated channel. "
+                    + "The current object " + this + " is " + SerializableOnlyOverRemoting.class +
+                    ", but it is likely being serialized/deserialized without the channel");
+        }
+        return ch;
+    }
+}

--- a/src/main/java/org/jenkinsci/remoting/SerializableOnlyOverRemoting.java
+++ b/src/main/java/org/jenkinsci/remoting/SerializableOnlyOverRemoting.java
@@ -27,13 +27,15 @@
 package org.jenkinsci.remoting;
 
 import hudson.remoting.Channel;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.ProtectedExternally;
 
 import javax.annotation.Nonnull;
 import java.io.NotSerializableException;
 import java.io.Serializable;
 
 /**
- * This interface indicates objects, which are {@link Serializable} only for sending over the Remoting {@link Channel}.
+ * This interface indicates objects which are {@link Serializable} only for sending over the Remoting {@link Channel}.
  *
  * Usually it means that the object requires export of the class via {@link Channel}
  * and {@code hudson.remoting.ExportTable}.
@@ -44,8 +46,6 @@ import java.io.Serializable;
  */
 public interface SerializableOnlyOverRemoting extends Serializable {
 
-
-
     /**
      * Gets current channel or fails with {@link NotSerializableException}.
      *
@@ -55,7 +55,8 @@ public interface SerializableOnlyOverRemoting extends Serializable {
      *      In such case the object cannot be serialized.
      */
     @Nonnull
-    default Channel getChannelForSerDes() throws NotSerializableException {
+    @Restricted(ProtectedExternally.class)
+    default Channel getChannelForSerialization() throws NotSerializableException {
         final Channel ch = Channel.current();
         if (ch == null) {
             // This logic does not prevent from improperly serializing objects within Remoting calls.

--- a/src/test/java/hudson/remoting/ChannelFilterTest.java
+++ b/src/test/java/hudson/remoting/ChannelFilterTest.java
@@ -86,7 +86,7 @@ public class ChannelFilterTest extends RmiTestBase {
 
     static class ReverseGunImporter extends CallableBase<String, Exception> {
         public String call() throws Exception {
-            return Channel.current().call(new GunImporter());
+            return Channel.currentOrIllegalState().call(new GunImporter());
         }
     }
 }

--- a/src/test/java/hudson/remoting/ChannelFilterTest.java
+++ b/src/test/java/hudson/remoting/ChannelFilterTest.java
@@ -86,7 +86,7 @@ public class ChannelFilterTest extends RmiTestBase {
 
     static class ReverseGunImporter extends CallableBase<String, Exception> {
         public String call() throws Exception {
-            return Channel.currentOrIllegalState().call(new GunImporter());
+            return Channel.currentOrFail().call(new GunImporter());
         }
     }
 }

--- a/src/test/java/hudson/remoting/ChannelTest.java
+++ b/src/test/java/hudson/remoting/ChannelTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.io.StringWriter;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -124,7 +123,7 @@ public class ChannelTest extends RmiTestBase {
     private static class WaitForRemotePropertyCallable extends CallableBase<Void, Exception> {
         public Void call() throws Exception {
             Thread.sleep(500);
-            Channel.currentOrIllegalState().setProperty("foo","bar");
+            Channel.currentOrFail().setProperty("foo","bar");
             return null;
         }
     }
@@ -140,7 +139,7 @@ public class ChannelTest extends RmiTestBase {
         }
 
         private Object writeReplace() throws ObjectStreamException {
-            return getChannelForSerDes().export(Greeter.class,this);
+            return getChannelForSerialization().export(Greeter.class,this);
         }
     }
 

--- a/src/test/java/hudson/remoting/ClassFilterTest.java
+++ b/src/test/java/hudson/remoting/ClassFilterTest.java
@@ -2,6 +2,7 @@ package hudson.remoting;
 
 import hudson.remoting.Channel.Mode;
 import hudson.remoting.CommandTransport.CommandReceiver;
+import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 import org.jenkinsci.remoting.nio.NioChannelBuilder;
 import org.junit.After;
 import org.junit.Test;
@@ -250,7 +251,7 @@ public class ClassFilterTest implements Serializable {
      * An attack payload that leaves a trace on the receiver side if it gets read from the stream.
      * Extends from {@link Command} to be able to test command stream.
      */
-    static class Security218 extends Command implements Serializable {
+    static class Security218 extends Command implements SerializableOnlyOverRemoting {
         private final String attack;
 
         public Security218(String attack) {
@@ -259,7 +260,7 @@ public class ClassFilterTest implements Serializable {
 
         private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
             ois.defaultReadObject();
-            System.setProperty("attack", attack + ">" + Channel.current().getName());
+            System.setProperty("attack", attack + ">" + getChannelForSerDes().getName());
         }
 
         @Override

--- a/src/test/java/hudson/remoting/ClassFilterTest.java
+++ b/src/test/java/hudson/remoting/ClassFilterTest.java
@@ -260,7 +260,7 @@ public class ClassFilterTest implements Serializable {
 
         private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
             ois.defaultReadObject();
-            System.setProperty("attack", attack + ">" + getChannelForSerDes().getName());
+            System.setProperty("attack", attack + ">" + getChannelForSerialization().getName());
         }
 
         @Override

--- a/src/test/java/hudson/remoting/ClassRemotingTest.java
+++ b/src/test/java/hudson/remoting/ClassRemotingTest.java
@@ -204,7 +204,7 @@ public class ClassRemotingTest extends RmiTestBase {
 
     private static class RemotePropertyVerifier extends CallableBase<Object, IOException> {
         public Object call() throws IOException {
-            Object o = Channel.current().getRemoteProperty("test");
+            Object o = Channel.currentOrIllegalState().getRemoteProperty("test");
             assertEquals(o.getClass().getName(), CLASSNAME);
             assertTrue(Channel.class.getClassLoader() != o.getClass().getClassLoader());
             assertTrue(o.getClass().getClassLoader() instanceof RemoteClassLoader);

--- a/src/test/java/hudson/remoting/ClassRemotingTest.java
+++ b/src/test/java/hudson/remoting/ClassRemotingTest.java
@@ -204,7 +204,7 @@ public class ClassRemotingTest extends RmiTestBase {
 
     private static class RemotePropertyVerifier extends CallableBase<Object, IOException> {
         public Object call() throws IOException {
-            Object o = Channel.currentOrIllegalState().getRemoteProperty("test");
+            Object o = Channel.currentOrFail().getRemoteProperty("test");
             assertEquals(o.getClass().getName(), CLASSNAME);
             assertTrue(Channel.class.getClassLoader() != o.getClass().getClassLoader());
             assertTrue(o.getClass().getClassLoader() instanceof RemoteClassLoader);

--- a/src/test/java/hudson/remoting/PipeTest.java
+++ b/src/test/java/hudson/remoting/PipeTest.java
@@ -197,7 +197,7 @@ public class PipeTest extends RmiTestBase implements Serializable {
         }
 
         public ISaturationTest call() throws IOException {
-            return Channel.currentOrIllegalState().export(ISaturationTest.class, new ISaturationTest() {
+            return Channel.currentOrFail().export(ISaturationTest.class, new ISaturationTest() {
                 private InputStream in;
                 public void ensureConnected() throws IOException {
                     in = pipe.getIn();

--- a/src/test/java/hudson/remoting/PipeTest.java
+++ b/src/test/java/hudson/remoting/PipeTest.java
@@ -197,7 +197,7 @@ public class PipeTest extends RmiTestBase implements Serializable {
         }
 
         public ISaturationTest call() throws IOException {
-            return Channel.current().export(ISaturationTest.class, new ISaturationTest() {
+            return Channel.currentOrIllegalState().export(ISaturationTest.class, new ISaturationTest() {
                 private InputStream in;
                 public void ensureConnected() throws IOException {
                     in = pipe.getIn();

--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -47,7 +47,7 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
         channel.setJarCache(new FileSystemJarCache(dir, true));
         channel.call(new CallableBase<Void, IOException>() {
             public Void call() throws IOException {
-                Channel.current().setJarCache(new FileSystemJarCache(dir, true));
+                Channel.currentOrIllegalState().setJarCache(new FileSystemJarCache(dir, true));
                 return null;
             }
         });
@@ -214,7 +214,7 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
 
         public Void call() throws IOException {
             try {
-                Channel ch = Channel.current();
+                final Channel ch = Channel.currentOrIllegalState();
                 final JarCache jarCache = ch.getJarCache();
                 if (jarCache == null) {
                     throw new IOException("Cannot Force JAR load, JAR cache is disabled");

--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -47,7 +47,7 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
         channel.setJarCache(new FileSystemJarCache(dir, true));
         channel.call(new CallableBase<Void, IOException>() {
             public Void call() throws IOException {
-                Channel.currentOrIllegalState().setJarCache(new FileSystemJarCache(dir, true));
+                Channel.currentOrFail().setJarCache(new FileSystemJarCache(dir, true));
                 return null;
             }
         });
@@ -214,7 +214,7 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
 
         public Void call() throws IOException {
             try {
-                final Channel ch = Channel.currentOrIllegalState();
+                final Channel ch = Channel.currentOrFail();
                 final JarCache jarCache = ch.getJarCache();
                 if (jarCache == null) {
                     throw new IOException("Cannot Force JAR load, JAR cache is disabled");

--- a/src/test/java/hudson/remoting/RemoteInvocationHandlerTest.java
+++ b/src/test/java/hudson/remoting/RemoteInvocationHandlerTest.java
@@ -1,5 +1,8 @@
 package hudson.remoting;
 
+import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
+
+import java.io.ObjectStreamException;
 import java.io.Serializable;
 
 public class RemoteInvocationHandlerTest extends RmiTestBase {
@@ -34,7 +37,7 @@ public class RemoteInvocationHandlerTest extends RmiTestBase {
         void meth2(String arg);
     }
 
-    private static class Impl implements Contract, Serializable, Contract2 {
+    private static class Impl implements Contract, SerializableOnlyOverRemoting, Contract2 {
         String arg;
         public void meth(String arg1, String arg2) {
             assert false : "should be ignored";
@@ -45,8 +48,9 @@ public class RemoteInvocationHandlerTest extends RmiTestBase {
         public void meth2(String arg) {
             this.arg = arg;
         }
-        private Object writeReplace() {
-            return Channel.current().export(Contract.class, this);
+
+        private Object writeReplace() throws ObjectStreamException {
+            return getChannelForSerDes().export(Contract.class, this);
         }
     }
 

--- a/src/test/java/hudson/remoting/RemoteInvocationHandlerTest.java
+++ b/src/test/java/hudson/remoting/RemoteInvocationHandlerTest.java
@@ -50,7 +50,7 @@ public class RemoteInvocationHandlerTest extends RmiTestBase {
         }
 
         private Object writeReplace() throws ObjectStreamException {
-            return getChannelForSerDes().export(Contract.class, this);
+            return getChannelForSerialization().export(Contract.class, this);
         }
     }
 

--- a/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackImplTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackImplTest.java
@@ -51,7 +51,6 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 import javax.net.ssl.SSLEngine;
 import org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer;
 import org.junit.ClassRule;
@@ -1176,7 +1175,7 @@ public class ProtocolStackImplTest {
 
         @Override
         public String call() throws IOException {
-            System.out.println("Hello from: " + Channel.current());
+            System.out.println("Hello from: " + Channel.currentOrIllegalState());
             return null;
         }
 
@@ -1194,7 +1193,7 @@ public class ProtocolStackImplTest {
         }
 
         public ISaturationTest call() throws IOException {
-            return Channel.current().export(ISaturationTest.class, new ISaturationTest() {
+            return Channel.currentOrIllegalState().export(ISaturationTest.class, new ISaturationTest() {
                 private InputStream in;
 
                 public void ensureConnected() throws IOException {

--- a/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackImplTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackImplTest.java
@@ -1175,7 +1175,7 @@ public class ProtocolStackImplTest {
 
         @Override
         public String call() throws IOException {
-            System.out.println("Hello from: " + Channel.currentOrIllegalState());
+            System.out.println("Hello from: " + Channel.currentOrFail());
             return null;
         }
 
@@ -1193,7 +1193,7 @@ public class ProtocolStackImplTest {
         }
 
         public ISaturationTest call() throws IOException {
-            return Channel.currentOrIllegalState().export(ISaturationTest.class, new ISaturationTest() {
+            return Channel.currentOrFail().export(ISaturationTest.class, new ISaturationTest() {
                 private InputStream in;
 
                 public void ensureConnected() throws IOException {


### PR DESCRIPTION
Discovered it during the experiments with #109

`Channel#current()` uses thread-local storage to determine the current channel. It returns null if the channel does not exist Some writeReplace/readObject/etc. serialization logic retrieves the channel in order to export the object via ExportTable. Obviously, such operations will fail if we try to serialize the object without Remoting context.

I propose to add a new interface to verify that serialization logic is being invoked for the remoting context and hence to avoid undesired NPEs.

https://issues.jenkins-ci.org/browse/JENKINS-47714

@reviewbybees @rysteboe @jglick @stephenc 