### PR TITLE
Update Jacoco to 0.7.9 and move it to the profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,25 +417,6 @@ THE SOFTWARE.
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.0.201403182114</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>report</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
         <configuration>
@@ -563,6 +544,32 @@ THE SOFTWARE.
                   <providerClass>${hudson.sign.providerClass}</providerClass>
                   <providerArg>${hudson.sign.providerArg}</providerArg>
                 </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jacoco</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.7.9</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>report</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Jacoc agent is quite heavy, and I see no reason in running it by default in any Remoting build.
This change moves the agent to an optional profile. It also picks the latest version, so IntellijIDEA is now able to read and show the `jacoco.exe` report.

@reviewbybees
