### PR TITLE
[JENKINS-45294] - RemoteInvocationHandler#RPCRequest is now a subject for channel status checks

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -530,7 +530,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 
         if(internalExport(IChannel.class, this, false)!=1)
             throw new AssertionError(); // export number 1 is reserved for the channel itself
-        remoteChannel = RemoteInvocationHandler.wrap(this,1,IChannel.class,true,false);
+        remoteChannel = RemoteInvocationHandler.wrapSystem(this,1,IChannel.class,true,false);
 
         this.remoteCapability = transport.getRemoteCapability();
         this.pipeWriter = new PipeWriter(createPipeWriterExecutor());
@@ -678,7 +678,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      */
     @Override
     public <T> T export(Class<T> type, T instance) {
-        return export(type, instance, true);
+        return export(type, instance, true, true);
     }
 
     /**
@@ -695,7 +695,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *      {@code null} if the input instance is {@code null}.     
      */
     @Nullable
-    /*package*/ <T> T export(Class<T> type, @CheckForNull T instance, boolean userProxy) {
+    /*package*/ <T> T export(Class<T> type, @CheckForNull T instance, boolean userProxy, boolean userScope) {
         if(instance==null) {
             return null;
         }
@@ -714,7 +714,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         // either local side will auto-unexport, or the remote side will unexport when it's GC-ed
         boolean autoUnexportByCaller = exportedObjects.isRecording();
         final int id = internalExport(type, instance, autoUnexportByCaller);
-        return RemoteInvocationHandler.wrap(null, id, type, userProxy, autoUnexportByCaller);
+        return userScope
+                ? RemoteInvocationHandler.wrapUser(null, id, type, userProxy, autoUnexportByCaller)
+                : RemoteInvocationHandler.wrapSystem(null, id, type, userProxy, autoUnexportByCaller);
     }
 
     /*package*/ <T> int internalExport(Class<T> clazz, T instance) {

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -530,7 +530,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 
         if(internalExport(IChannel.class, this, false)!=1)
             throw new AssertionError(); // export number 1 is reserved for the channel itself
-        remoteChannel = RemoteInvocationHandler.wrapSystem(this,1,IChannel.class,true,false);
+        remoteChannel = RemoteInvocationHandler.wrap(this,1,IChannel.class,true,false,false);
 
         this.remoteCapability = transport.getRemoteCapability();
         this.pipeWriter = new PipeWriter(createPipeWriterExecutor());
@@ -714,9 +714,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         // either local side will auto-unexport, or the remote side will unexport when it's GC-ed
         boolean autoUnexportByCaller = exportedObjects.isRecording();
         final int id = internalExport(type, instance, autoUnexportByCaller);
-        return userScope
-                ? RemoteInvocationHandler.wrapUser(null, id, type, userProxy, autoUnexportByCaller)
-                : RemoteInvocationHandler.wrapSystem(null, id, type, userProxy, autoUnexportByCaller);
+        return RemoteInvocationHandler.wrap(null, id, type, userProxy, autoUnexportByCaller, userScope);
     }
 
     /*package*/ <T> int internalExport(Class<T> clazz, T instance) {

--- a/src/main/java/hudson/remoting/ImportedClassLoaderTable.java
+++ b/src/main/java/hudson/remoting/ImportedClassLoaderTable.java
@@ -51,7 +51,7 @@ final class ImportedClassLoaderTable {
      */
     @Nonnull
     public synchronized ClassLoader get(int oid) {
-        return get(RemoteInvocationHandler.wrapSystem(channel,oid,IClassLoader.class,false,false));
+        return get(RemoteInvocationHandler.wrap(channel,oid,IClassLoader.class,false,false,false));
     }
 
     /**

--- a/src/main/java/hudson/remoting/ImportedClassLoaderTable.java
+++ b/src/main/java/hudson/remoting/ImportedClassLoaderTable.java
@@ -51,7 +51,7 @@ final class ImportedClassLoaderTable {
      */
     @Nonnull
     public synchronized ClassLoader get(int oid) {
-        return get(RemoteInvocationHandler.wrap(channel,oid,IClassLoader.class,false,false));
+        return get(RemoteInvocationHandler.wrapSystem(channel,oid,IClassLoader.class,false,false));
     }
 
     /**

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -740,7 +740,10 @@ final class RemoteClassLoader extends URLClassLoader {
                 return new RemoteIClassLoader(oid,rcl.proxy);
             }
         }
-        return local.export(IClassLoader.class, new ClassLoaderProxy(cl,local), false);
+        // Remote classloader operates in the System scope (JENKINS-45294).
+        // It's probably YOLO, but otherwise the termination calls may be unable
+        // to execute correctly.
+        return local.export(IClassLoader.class, new ClassLoaderProxy(cl,local), false, false);
     }
 
     public static void pin(ClassLoader cl, Channel local) {

--- a/src/main/java/hudson/remoting/RemoteInvocationHandler.java
+++ b/src/main/java/hudson/remoting/RemoteInvocationHandler.java
@@ -289,7 +289,9 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         // delegate the rest of the methods to the remote object
 
         boolean async = method.isAnnotationPresent(Asynchronous.class);
-        RPCRequest req = new RPCRequest(oid, method, args, userProxy ? dc.getClassLoader() : null);
+        RPCRequest req = userSpace
+                ? new UserRPCRequest(oid, method, args, userProxy ? dc.getClassLoader() : null)
+                : new RPCRequest(oid, method, args, userProxy ? dc.getClassLoader() : null);
         try {
             if(userProxy) {
                 if (async)  channelOrFail().callAsync(req);

--- a/src/main/java/hudson/remoting/RemoteInvocationHandler.java
+++ b/src/main/java/hudson/remoting/RemoteInvocationHandler.java
@@ -140,35 +140,14 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         this.userSpace = userSpace;
     }
 
-
-
-    /**
-     * Wraps an OID to the user-spaced typed wrapper.
-     *
-     * RPC operations with this object will be checking the channel state before sending the request.
-     * @see UserRPCRequest
-     */
-    @Nonnull
-    public static <T> T wrapUser(Channel channel, int id, Class<T> type, boolean userProxy, boolean autoUnexportByCaller) {
-        return internalWrap(channel, id, type, userProxy, autoUnexportByCaller, true);
-    }
-
-    /**
-     * Wraps an OID to the system-spaced typed wrapper.
-     *
-     * This method is restricted to internal {@link Channel}-specific use only.
-     * Usage of this method in external logic or on the {@link VirtualChannel} level is not supported.
-     */
-    @Nonnull
-    public static <T> T wrapSystem(Channel channel, int id, Class<T> type, boolean userProxy, boolean autoUnexportByCaller) {
-        return internalWrap(channel, id, type, userProxy, autoUnexportByCaller, false);
-    }
-
     /**
      * Wraps an OID to the typed wrapper.
+     *
+     * @param userProxy If {@code true} (recommended), all commands will be wrapped into {@link UserRequest}s.
+     * @param userSpace If {@code true} (recommended), the requests will be executed in a user scope
      */
     @Nonnull
-    private static <T> T internalWrap(Channel channel, int id, Class<T> type, boolean userProxy, boolean autoUnexportByCaller, boolean userSpace) {
+    static <T> T wrap(Channel channel, int id, Class<T> type, boolean userProxy, boolean autoUnexportByCaller, boolean userSpace) {
         ClassLoader cl = type.getClassLoader();
         // if the type is a JDK-defined type, classloader should be for IReadResolve
         if(cl==null || cl==ClassLoader.getSystemClassLoader())

--- a/src/test/java/hudson/remoting/ChannelTest.java
+++ b/src/test/java/hudson/remoting/ChannelTest.java
@@ -11,15 +11,22 @@ import java.io.StringWriter;
 import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.channels.ClosedChannelException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.jenkinsci.remoting.RoleChecker;
+import org.jvnet.hudson.test.Issue;
+import sun.rmi.runtime.Log;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -241,7 +248,57 @@ public class ChannelTest extends RmiTestBase {
             assertFailsWithChannelClosedException(TestRunnable.forUserRequest_callAsync(delayedRequest, testPayload));
         }
     }
-    
+
+    /**
+     * Checks if {@link UserRequest}s can be executed during the pending close operation.
+     * @throws Exception Test Error
+     */
+    @Issue("JENKINS-45294")
+    public void testShouldNotAcceptUserRPCRequestsWhenIsBeingClosed() throws Exception {
+
+        Collection<String> src = new ArrayList<>();
+        src.add("Hello");
+        src.add("World");
+
+        //TODO: System request will just hang. Once JENKINS-44785 is implemented, all system requests
+        // in Remoting codebase must have a timeout.
+        final Collection remoteList = channel.call(new RMIObjectExportedCallable<>(src, Collection.class, true));
+
+        try (ChannelCloseLock lock = new ChannelCloseLock(channel)) {
+            // Call Async
+            assertFailsWithChannelClosedException(new TestRunnable() {
+                @Override
+                public void run(Channel channel) throws Exception, AssertionError {
+                    remoteList.size();
+                }
+            });
+        }
+    }
+
+    private static class RMIObjectExportedCallable<TInterface> implements Callable<TInterface, Exception> {
+
+        private final TInterface object;
+        private final Class<TInterface> clazz;
+        private final boolean userSpace;
+
+        RMIObjectExportedCallable(TInterface object, Class<TInterface> clazz, boolean userSpace) {
+            this.object = object;
+            this.clazz = clazz;
+            this.userSpace = userSpace;
+        }
+
+        @Override
+        public TInterface call() throws Exception {
+            // UserProxy is used only for the user space, otherwise it will be wrapped into UserRequest
+            return Channel.current().export(clazz, object, userSpace, userSpace);
+        }
+
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+
+        }
+    }
+
     private static final class NeverEverCallable implements Callable<Void, Exception> {
 
         private static final long serialVersionUID = 1L;
@@ -361,11 +418,13 @@ public class ChannelTest extends RmiTestBase {
         try {
             call.run(channel);
         } catch(Exception ex) {
-            if (ex instanceof ChannelClosedException) {
+            Logger.getLogger(ChannelTest.class.getName()).log(Level.WARNING, "Call execution failed with exception", ex);
+            Throwable cause = ex instanceof RemotingSystemException ? ex.getCause() : ex;
+            if (cause instanceof ChannelClosedException) {
                 // Fine
                 return;
             } else {
-                throw new AssertionError("Expected ChannelClosedException, but got another exception", ex);
+                throw new AssertionError("Expected ChannelClosedException, but got another exception", cause);
             }
         }
         fail("Expected ChannelClosedException, but the call has completed without any exception");

--- a/src/test/java/hudson/remoting/PipeWriterTest.java
+++ b/src/test/java/hudson/remoting/PipeWriterTest.java
@@ -23,7 +23,8 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        checker = channel.export(PipeWriterTestChecker.class, this, false);
+        // Checker operates using the user-space RMI
+        checker = channel.export(PipeWriterTestChecker.class, this, false, true);
     }
 
     /**


### PR DESCRIPTION
It is same as https://github.com/jenkinsci/remoting/pull/175, but for RPC Requests.
The idea is to prevent hanging of RPC Requests in edge cases when the channel goes down.

- [x] - Draft implementation
- [x] - Functional tests

https://issues.jenkins-ci.org/browse/JENKINS-45294

@reviewbybees @jglick 