### PR TITLE
Allow disabling HTTPs cert validation of JNLP endpoint when starting Remoting from Main

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -23,15 +23,11 @@
  */
 package hudson.remoting;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.remoting.Channel.Mode;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.net.Socket;
 import java.net.URL;
 import java.nio.file.Path;
@@ -134,7 +130,6 @@ public class Engine extends Thread {
      */
     @CheckForNull
     private URL hudsonUrl;
-
     private final String secretKey;
     public final String slaveName;
     private String credentials;
@@ -144,6 +139,8 @@ public class Engine extends Thread {
      * See Main#tunnel in the jnlp-agent module for the details.
      */
     private String tunnel;
+
+    private boolean insecure;
 
     private boolean noReconnect;
 
@@ -156,6 +153,23 @@ public class Engine extends Thread {
 
     
     
+    /**
+     * Determines if JNLPAgentEndpointResolver will not perform certificate validation
+     * @return
+     */
+    public boolean isInsecure() {
+        return insecure;
+    }
+
+    /**
+     * Sets if JNLPAgentEndpointResolver will not perform certificate validation
+     *
+     * @param insecure
+     */
+
+    public void setInsecure(boolean insecure) {
+        this.insecure = insecure;
+    }
     
     @CheckForNull
     private JarCache jarCache = null;
@@ -327,6 +341,8 @@ public class Engine extends Thread {
         this.noReconnect = noReconnect;
     }
 
+
+
     /**
      * Sets the destination for agent logs.
      * @param agentLog Path to the agent log.
@@ -482,6 +498,7 @@ public class Engine extends Thread {
         resolver.setTunnel(tunnel);
         try {
             resolver.setSslSocketFactory(getSSLSocketFactory());
+            resolver.setInsecure(insecure);
         } catch (Exception e) {
             events.error(e);
         }
@@ -809,8 +826,8 @@ public class Engine extends Thread {
             trustManagerFactory.init(keyStore);
             // prepare the SSL context
             SSLContext ctx = SSLContext.getInstance("TLS");
-            ctx.init(null, trustManagerFactory.getTrustManagers(), null);
             // now we have our custom socket factory
+            ctx.init(null, trustManagerFactory.getTrustManagers(), null);
             sslSocketFactory = ctx.getSocketFactory();
         }
         return sslSocketFactory;

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -496,7 +496,7 @@ public class Engine extends Thread {
         resolver.setTunnel(tunnel);
         try {
             resolver.setSslSocketFactory(getSSLSocketFactory());
-            resolver.setInsecure(disableHttpsCertValidation);
+            resolver.setDisableHttpsCertValidation(disableHttpsCertValidation);
         } catch (Exception e) {
             events.error(e);
         }

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -140,7 +140,7 @@ public class Engine extends Thread {
      */
     private String tunnel;
 
-    private boolean insecure;
+    private boolean disableHttpsCertValidation;
 
     private boolean noReconnect;
 
@@ -150,26 +150,6 @@ public class Engine extends Thread {
      * @since 2.62.1
      */
     private boolean keepAlive = true;
-
-    
-    
-    /**
-     * Determines if JNLPAgentEndpointResolver will not perform certificate validation
-     * @return
-     */
-    public boolean isInsecure() {
-        return insecure;
-    }
-
-    /**
-     * Sets if JNLPAgentEndpointResolver will not perform certificate validation
-     *
-     * @param insecure
-     */
-
-    public void setInsecure(boolean insecure) {
-        this.insecure = insecure;
-    }
     
     @CheckForNull
     private JarCache jarCache = null;
@@ -341,7 +321,25 @@ public class Engine extends Thread {
         this.noReconnect = noReconnect;
     }
 
+    /**
+     * Determines if JNLPAgentEndpointResolver will not perform certificate validation in the HTTPs mode.
+     *
+     * @return {@code true} if the certificate validation is disabled.
+     * @since TODO
+     */
+    public boolean isDisableHttpsCertValidation() {
+        return disableHttpsCertValidation;
+    }
 
+    /**
+     * Sets if JNLPAgentEndpointResolver will not perform certificate validation in the HTTPs mode.
+     *
+     * @param disableHttpsCertValidation {@code true} if the certificate validation is disabled.
+     * @since TODO
+     */
+    public void setDisableHttpsCertValidation(boolean disableHttpsCertValidation) {
+        this.disableHttpsCertValidation = disableHttpsCertValidation;
+    }
 
     /**
      * Sets the destination for agent logs.
@@ -498,7 +496,7 @@ public class Engine extends Thread {
         resolver.setTunnel(tunnel);
         try {
             resolver.setSslSocketFactory(getSSLSocketFactory());
-            resolver.setInsecure(insecure);
+            resolver.setInsecure(disableHttpsCertValidation);
         } catch (Exception e) {
             events.error(e);
         }

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -352,7 +352,8 @@ public class Launcher {
                 }
             }
             if (noCertificateCheck) {
-                //TODO: Rename option?
+		// Generally it is not required since the default settings have been changed anyway.
+		// But we set it up just in case there are overrides somewhere in the logic
                 jnlpArgs.add("-disableHttpsCertValidation");
             }
             try {

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -41,6 +41,8 @@ import javax.net.ssl.TrustManagerFactory;
 
 import org.jenkinsci.remoting.engine.WorkDirManager;
 import org.jenkinsci.remoting.util.IOUtils;
+import org.jenkinsci.remoting.util.https.NoCheckHostnameVerifier;
+import org.jenkinsci.remoting.util.https.NoCheckTrustManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -191,6 +193,12 @@ public class Launcher {
                     "certificate file to read.", forbids = "-noCertificateCheck")
     public List<String> candidateCertificates;
 
+    /**
+     * Disables HTTPs Certificate validation of the server when using {@link org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver}.
+     * This option is managed by the {@code -noCertificateCheck} option.
+     */
+    private boolean noCertificateCheck = false;
+
     public InetSocketAddress connectionTarget = null;
 
     @Option(name="-connectTo",usage="make a TCP connection to the given host and port, then start communication.",metaVar="HOST:PORT")
@@ -212,15 +220,13 @@ public class Launcher {
     @Option(name="-noCertificateCheck", forbids = "-cert")
     public void setNoCertificateCheck(boolean ignored) throws NoSuchAlgorithmException, KeyManagementException {
         System.out.println("Skipping HTTPS certificate checks altogether. Note that this is not secure at all.");
+
+        this.noCertificateCheck = true;
         SSLContext context = SSLContext.getInstance("TLS");
         context.init(null, new TrustManager[]{new NoCheckTrustManager()}, new java.security.SecureRandom());
         HttpsURLConnection.setDefaultSSLSocketFactory(context.getSocketFactory());
         // bypass host name check, too.
-        HttpsURLConnection.setDefaultHostnameVerifier(new HostnameVerifier() {
-            public boolean verify(String s, SSLSession sslSession) {
-                return true;
-            }
-        });
+        HttpsURLConnection.setDefaultHostnameVerifier(new NoCheckHostnameVerifier());
     }
 
     @Option(name="-noReconnect",usage="Doesn't try to reconnect when a communication fail, and exit instead")
@@ -346,6 +352,10 @@ public class Launcher {
                     jnlpArgs.add("-cert");
                     jnlpArgs.add(c);
                 }
+            }
+            if (noCertificateCheck) {
+                //TODO: Rename option?
+                jnlpArgs.add("-disableHttpsCertValidation");
             }
             try {
                 hudson.remoting.jnlp.Main._main(jnlpArgs.toArray(new String[jnlpArgs.size()]));
@@ -766,21 +776,6 @@ public class Launcher {
         }
         channel.join();
         System.err.println("channel stopped");
-    }
-
-    /**
-     * {@link X509TrustManager} that performs no check at all.
-     */
-    private static class NoCheckTrustManager implements X509TrustManager {
-        public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
-        }
-
-        public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
-        }
-
-        public X509Certificate[] getAcceptedIssuers() {
-            return new X509Certificate[0];
-        }
     }
 
     public static boolean isWindows() {

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -27,14 +27,12 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.remoting.FileSystemJarCache;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.UnsupportedEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
 import org.jenkinsci.remoting.engine.WorkDirManager;
-import org.jenkinsci.remoting.util.IOUtils;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Argument;
@@ -51,7 +49,6 @@ import java.io.IOException;
 
 import hudson.remoting.Engine;
 import hudson.remoting.EngineListener;
-import java.nio.file.Path;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -91,6 +88,10 @@ public class Main {
     @Option(name="-noreconnect",
             usage="If the connection ends, don't retry and just exit.")
     public boolean noReconnect = false;
+
+    @Option(name="-insecure",
+        usage="Ignore SSL validation errors - use as a last resort only.")
+    public boolean insecure = false;
 
     @Option(name="-noKeepAlive",
             usage="Disable TCP socket keep alive on connection to the master.")
@@ -242,6 +243,9 @@ public class Main {
             engine.setJarCache(new FileSystemJarCache(jarCache,true));
         engine.setNoReconnect(noReconnect);
         engine.setKeepAlive(!noKeepAlive);
+        LOGGER.log(INFO, "Insecure Status: {0}", insecure);
+        engine.setInsecure(insecure);
+
         
         // TODO: ideally logging should be initialized before the "Setting up slave" entry
         if (agentLog != null) {

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -42,6 +42,8 @@ import java.io.File;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.WARNING;
+
 import java.util.List;
 import java.util.ArrayList;
 import java.net.URL;
@@ -89,10 +91,6 @@ public class Main {
             usage="If the connection ends, don't retry and just exit.")
     public boolean noReconnect = false;
 
-    @Option(name="-insecure",
-        usage="Ignore SSL validation errors - use as a last resort only.")
-    public boolean insecure = false;
-
     @Option(name="-noKeepAlive",
             usage="Disable TCP socket keep alive on connection to the master.")
     public boolean noKeepAlive = false;
@@ -102,6 +100,16 @@ public class Main {
                     "root URLs. If starting with @ then the remainder is assumed to be the name of the " +
                     "certificate file to read.")
     public List<String> candidateCertificates;
+
+    /**
+     * Disables HTTPs Certificate validation of the server when using {@link org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver}.
+     *
+     * This option is not recommended for production use.
+     * @since TODO
+     */
+    @Option(name="-disableHttpsCertValidation",
+            usage="Ignore SSL validation errors - use as a last resort only.")
+    public boolean disableHttpsCertValidation = false;
 
     /**
      * Specifies a destination for error logs.
@@ -243,8 +251,11 @@ public class Main {
             engine.setJarCache(new FileSystemJarCache(jarCache,true));
         engine.setNoReconnect(noReconnect);
         engine.setKeepAlive(!noKeepAlive);
-        LOGGER.log(INFO, "Insecure Status: {0}", insecure);
-        engine.setInsecure(insecure);
+
+        if (disableHttpsCertValidation) {
+            LOGGER.log(WARNING, "Certificate validation for HTTPs endpoints is disabled");
+        }
+        engine.setDisableHttpsCertValidation(disableHttpsCertValidation);
 
         
         // TODO: ideally logging should be initialized before the "Setting up slave" entry

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -25,12 +25,15 @@ package org.jenkinsci.remoting.engine;
 
 import hudson.remoting.Base64;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.net.NoRouteToHostException;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
@@ -315,11 +318,14 @@ public class JnlpAgentEndpointResolver {
                         return;
                     }
                     LOGGER.log(Level.INFO,
-                            "Master isn''t ready to talk to us on {0}. Will retry again: response code={1}",
+                            "Master isn''t ready to talk to us on {0}. Will try again: response code={1}",
                             new Object[]{url, con.getResponseCode()});
+                } catch (SocketTimeoutException | ConnectException | NoRouteToHostException e) {
+                    LOGGER.log(INFO, "Failed to connect to the master. Will try again: {0} {1}",
+                            new String[] { e.getClass().getName(), e.getMessage() });
                 } catch (IOException e) {
                     // report the failure
-                    LOGGER.log(INFO, "Failed to connect to the master. Will retry again", e);
+                    LOGGER.log(INFO, "Failed to connect to the master. Will try again", e);
                 }
             }
         } finally {

--- a/src/main/java/org/jenkinsci/remoting/util/https/NoCheckHostnameVerifier.java
+++ b/src/main/java/org/jenkinsci/remoting/util/https/NoCheckHostnameVerifier.java
@@ -1,0 +1,45 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.remoting.util.https;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+/**
+ * Hostname verifier, which accepts any hostname.
+ */
+@Restricted(NoExternalUse.class)
+public class NoCheckHostnameVerifier implements HostnameVerifier {
+
+    @Override
+    public boolean verify(String s, SSLSession sslSession) {
+        return true;
+    }
+}

--- a/src/main/java/org/jenkinsci/remoting/util/https/NoCheckTrustManager.java
+++ b/src/main/java/org/jenkinsci/remoting/util/https/NoCheckTrustManager.java
@@ -1,0 +1,50 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2016- CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.remoting.util.https;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.net.ssl.X509TrustManager;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+/**
+ * {@link X509TrustManager} that performs no check at all.
+ */
+@Restricted(NoExternalUse.class)
+public class NoCheckTrustManager implements X509TrustManager {
+    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+    }
+
+    public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+    }
+
+    public X509Certificate[] getAcceptedIssuers() {
+        return new X509Certificate[0];
+    }
+}


### PR DESCRIPTION
It is an attempt to improve https://github.com/jenkinsci/remoting/pull/205 and to reuse existing code from @stephenc . Originally the HTTPs certificate validation has been done in `hudson.remoting.Launcher`, but it was missing in `hudson.remoting.jnlp.Main`. So it was not possible to start a Java Web Start agent in the insecure mode. In https://github.com/jenkinsci/remoting/pull/205 @MattLud needs that.

How does it work now?
* When `-disableHttpsCertValidation` is passed from `Main`, the JNLP Endpoint HTTPs cert verification is disabled.
* JNLP agent ('Launcher.java') also sets the flag when `-noCertificateCheck` is passed

I also did some refactoring in order to prevent code duplication.

@reviewbybees @MattLud @Wadeck 