### PR TITLE
Cleanup usages of the custom Charsets class.

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/HandshakeCiphers.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/HandshakeCiphers.java
@@ -30,10 +30,9 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.spec.KeySpec;
-import org.jenkinsci.remoting.util.Charsets;
 
 /**
  * {@link Cipher}s that will be used to during the handshake
@@ -65,7 +64,7 @@ class HandshakeCiphers {
     public String encrypt(String raw) throws IOException {
         try {
             String encrypted = new String(encryptCipher.doFinal(
-                    raw.getBytes(Charsets.UTF_8)), Charsets.ISO_8859_1);
+                    raw.getBytes(StandardCharsets.UTF_8)), StandardCharsets.ISO_8859_1);
             encryptCipher.init(Cipher.ENCRYPT_MODE, secretKey, spec);
             return encrypted;
         } catch (GeneralSecurityException e) {
@@ -82,7 +81,7 @@ class HandshakeCiphers {
     public String decrypt(String encrypted) throws IOException {
         try {
             String raw = new String(decryptCipher.doFinal(
-                    encrypted.getBytes(Charsets.ISO_8859_1)), Charsets.UTF_8);
+                    encrypted.getBytes(StandardCharsets.ISO_8859_1)), StandardCharsets.UTF_8);
             decryptCipher.init(Cipher.DECRYPT_MODE, secretKey, spec);
             return raw;
         } catch (GeneralSecurityException e) {
@@ -122,7 +121,7 @@ class HandshakeCiphers {
             throws GeneralSecurityException {
         SecretKeyFactory factory = SecretKeyFactory.getInstance(FACTORY_ALGORITHM);
         KeySpec spec = new PBEKeySpec(
-                slaveSecret.toCharArray(), slaveName.getBytes(Charsets.UTF_8),
+                slaveSecret.toCharArray(), slaveName.getBytes(StandardCharsets.UTF_8),
                 INTEGRATION_COUNT, KEY_LENGTH);
         SecretKey tmpSecret = factory.generateSecret(spec);
         return new SecretKeySpec(tmpSecret.getEncoded(), SPEC_ALGORITHM);

--- a/src/main/java/org/jenkinsci/remoting/engine/Jnlp3Util.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/Jnlp3Util.java
@@ -24,11 +24,11 @@
 package org.jenkinsci.remoting.engine;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Random;
-import org.jenkinsci.remoting.util.Charsets;
 
 /**
  * Utility methods for JNLP3.
@@ -52,7 +52,7 @@ class Jnlp3Util {
     public static byte[] generate128BitKey(String str) {
         try {
             MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
-            messageDigest.update(str.getBytes(Charsets.UTF_8));
+            messageDigest.update(str.getBytes(StandardCharsets.UTF_8));
             return Arrays.copyOf(messageDigest.digest(), 16);
         } catch (NoSuchAlgorithmException nsae) {
             // This should never happen.
@@ -64,14 +64,14 @@ class Jnlp3Util {
      * Convert the given key to a string.
      */
     public static String keyToString(byte[] key) {
-        return new String(key, Charsets.ISO_8859_1);
+        return new String(key, StandardCharsets.ISO_8859_1);
     }
 
     /**
      * Get back the original key from the given string.
      */
     public static byte[] keyFromString(String keyString) {
-        return keyString.getBytes(Charsets.ISO_8859_1);
+        return keyString.getBytes(StandardCharsets.ISO_8859_1);
     }
 
     /**
@@ -90,8 +90,8 @@ class Jnlp3Util {
     public static String createChallengeResponse(String challenge) {
         try {
             MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
-            messageDigest.update(challenge.getBytes(Charsets.UTF_8));
-            return new String(messageDigest.digest(), Charsets.UTF_8); // <--- One of the root causes of JENKINS-37315
+            messageDigest.update(challenge.getBytes(StandardCharsets.UTF_8));
+            return new String(messageDigest.digest(), StandardCharsets.UTF_8); // <--- One of the root causes of JENKINS-37315
         } catch (NoSuchAlgorithmException nsae) {
             // This should never happen.
             throw new AssertionError(nsae);
@@ -107,7 +107,7 @@ class Jnlp3Util {
             return true;
         }
         // JENKINS-37315 fallback to comparing the encoded bytes because the format should never have used UTF-8
-        if (Arrays.equals(expectedResponse.getBytes(Charsets.UTF_8), challengeResponse.getBytes(Charsets.UTF_8))) {
+        if (Arrays.equals(expectedResponse.getBytes(StandardCharsets.UTF_8), challengeResponse.getBytes(StandardCharsets.UTF_8))) {
             return true;
         }
         return false;

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol3Handler.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol3Handler.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.List;
@@ -49,7 +50,6 @@ import javax.crypto.CipherInputStream;
 import javax.crypto.CipherOutputStream;
 import org.jenkinsci.remoting.nio.NioChannelHub;
 import org.jenkinsci.remoting.protocol.impl.ConnectionRefusalException;
-import org.jenkinsci.remoting.util.Charsets;
 
 import static org.jenkinsci.remoting.engine.EngineUtil.readChars;
 import static org.jenkinsci.remoting.engine.EngineUtil.readLine;
@@ -269,7 +269,7 @@ public class JnlpProtocol3Handler extends LegacyJnlpProtocolHandler<Jnlp3Connect
         // Get initiation information from slave.
         Properties request = new Properties();
         DataInputStream in = state.getDataInputStream();
-        request.load(new ByteArrayInputStream(in.readUTF().getBytes(Charsets.UTF_8)));
+        request.load(new ByteArrayInputStream(in.readUTF().getBytes(StandardCharsets.UTF_8)));
         String clientName = request.getProperty(JnlpConnectionState.CLIENT_NAME_KEY);
         JnlpClientDatabase clientDatabase = getClientDatabase();
         if (clientDatabase == null || !clientDatabase.exists(clientName)) {
@@ -287,7 +287,7 @@ public class JnlpProtocol3Handler extends LegacyJnlpProtocolHandler<Jnlp3Connect
         // Send agent challenge response.
         String challengeResponse = Jnlp3Util.createChallengeResponse(challenge);
         String encryptedChallengeResponse = handshakeCiphers.encrypt(challengeResponse);
-        out.println(encryptedChallengeResponse.getBytes(Charsets.UTF_8).length);
+        out.println(encryptedChallengeResponse.getBytes(StandardCharsets.UTF_8).length);
         out.print(encryptedChallengeResponse);
         out.flush();
 
@@ -315,7 +315,7 @@ public class JnlpProtocol3Handler extends LegacyJnlpProtocolHandler<Jnlp3Connect
         // now validate the client
         String masterChallenge = Jnlp3Util.generateChallenge(RANDOM);
         String encryptedMasterChallenge = handshakeCiphers.encrypt(masterChallenge);
-        out.println(encryptedMasterChallenge.getBytes(Charsets.UTF_8).length);
+        out.println(encryptedMasterChallenge.getBytes(StandardCharsets.UTF_8).length);
         out.print(encryptedMasterChallenge);
         out.flush();
 

--- a/src/main/java/org/jenkinsci/remoting/engine/LegacyJnlpConnectionState.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/LegacyJnlpConnectionState.java
@@ -35,9 +35,8 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.Socket;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
-import org.jenkinsci.remoting.util.Charsets;
 
 /**
  * Base class for {@link LegacyJnlpProtocolHandler} based protocols.
@@ -90,7 +89,7 @@ public class LegacyJnlpConnectionState extends JnlpConnectionState {
     @Deprecated
     public PrintWriter getPrintWriter() {
         if (printWriter == null) {
-            printWriter = new PrintWriter(new OutputStreamWriter(bufferedOutputStream, Charsets.UTF_8), true);
+            printWriter = new PrintWriter(new OutputStreamWriter(bufferedOutputStream, StandardCharsets.UTF_8), true);
         }
         return printWriter;
     }

--- a/src/main/java/org/jenkinsci/remoting/protocol/ProtocolLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/ProtocolLayer.java
@@ -48,7 +48,7 @@ public interface ProtocolLayer {
     /**
      * A handy constant until Java 7 compatibility can be assumed.
      *
-     * @deprecated Usev {@link StandardCharsets}
+     * @deprecated Use {@link StandardCharsets}
      */
     @Deprecated
     @Restricted(DoNotUse.class)

--- a/src/main/java/org/jenkinsci/remoting/protocol/ProtocolLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/ProtocolLayer.java
@@ -27,9 +27,11 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import javax.annotation.CheckForNull;
 import org.jenkinsci.remoting.util.ByteBufferUtils;
-import org.jenkinsci.remoting.util.Charsets;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 
 /**
  * A network {@link ProtocolStack} consists of a number of {@link ProtocolLayer}s. This interface represents the general
@@ -45,8 +47,12 @@ public interface ProtocolLayer {
     ByteBuffer EMPTY_BUFFER = ByteBufferUtils.EMPTY_BUFFER;
     /**
      * A handy constant until Java 7 compatibility can be assumed.
+     *
+     * @deprecated Usev {@link StandardCharsets}
      */
-    Charset UTF_8 = Charsets.UTF_8; // TODO Replace with StandardCharsets.UTF_8 once Java 7
+    @Deprecated
+    @Restricted(DoNotUse.class)
+    Charset UTF_8 = StandardCharsets.UTF_8;
 
     /**
      * Initializes the layer with its {@link ProtocolStack.Ptr}. All lower layers in the stack will be initialized

--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/ConnectionHeadersFilterLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/ConnectionHeadersFilterLayer.java
@@ -27,6 +27,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
@@ -181,7 +182,7 @@ public class ConnectionHeadersFilterLayer extends FilterLayer {
                 byte[] headerBytes = new byte[headerInputContent.capacity()];
                 headerInputContent.flip();
                 headerInputContent.get(headerBytes, 0, headerInputContent.remaining());
-                final String headerAsString = new String(headerBytes, UTF_8);
+                final String headerAsString = new String(headerBytes, StandardCharsets.UTF_8);
                 if (LOGGER.isLoggable(Level.FINER)) {
                     LOGGER.log(Level.FINER, "[{0}] Received headers \"{1}\"",
                             new Object[]{stack().name(), headerAsString});
@@ -298,7 +299,7 @@ public class ConnectionHeadersFilterLayer extends FilterLayer {
                 byte[] responseBytes = new byte[responseInputContent.capacity()];
                 responseInputContent.flip();
                 responseInputContent.get(responseBytes, 0, responseInputContent.remaining());
-                String response = new String(responseBytes, UTF_8);
+                String response = new String(responseBytes, StandardCharsets.UTF_8);
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.log(Level.FINE, "[{0}] Received response \"{1}\"",
                             new Object[]{stack().name(), response});

--- a/src/main/java/org/jenkinsci/remoting/util/ByteBufferUtils.java
+++ b/src/main/java/org/jenkinsci/remoting/util/ByteBufferUtils.java
@@ -26,6 +26,8 @@ package org.jenkinsci.remoting.util;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
 import org.jenkinsci.remoting.protocol.ProtocolLayer;
 
 /**
@@ -75,7 +77,7 @@ public final class ByteBufferUtils {
      * @param dst the destination.
      */
     public static void putUTF8(String src, ByteBuffer dst) {
-        byte[] bytes = src.getBytes(ProtocolLayer.UTF_8);
+        byte[] bytes = src.getBytes(StandardCharsets.UTF_8);
         if (bytes.length > 65535) {
             throw new IllegalArgumentException("UTF-8 encoded string must be less than 65536 bytes");
         }
@@ -106,7 +108,7 @@ public final class ByteBufferUtils {
         src.position(src.position() + 2);
         byte[] bytes = new byte[length];
         src.get(bytes);
-        return new String(bytes, ProtocolLayer.UTF_8);
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     /**
@@ -116,7 +118,7 @@ public final class ByteBufferUtils {
      * @return a {@link ByteBuffer} containing the two byte length followed by the string encoded as UTF-8.
      */
     public static ByteBuffer wrapUTF8(String string) {
-        byte[] bytes = string.getBytes(ProtocolLayer.UTF_8);
+        byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
         if (bytes.length > 65535) {
             throw new IllegalArgumentException("UTF-8 encoded string must be less than 65536 bytes");
         }

--- a/src/main/java/org/jenkinsci/remoting/util/Charsets.java
+++ b/src/main/java/org/jenkinsci/remoting/util/Charsets.java
@@ -24,17 +24,20 @@
 package org.jenkinsci.remoting.util;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Local implementation of standard charsets as the remoting library currently needs to be compiled against Java 6
  * signatures.
  *
- * @since FIXME
+ * @deprecated Use {@link StandardCharsets}
  */
-// TODO replace with StandardCharsets once Java 7
-@Restricted(NoExternalUse.class)
+@Deprecated
+@Restricted(DoNotUse.class)
 public final class Charsets {
     /**
      * Utility class.
@@ -46,26 +49,26 @@ public final class Charsets {
     /**
      * Seven-bit ASCII.
      */
-    public static final Charset US_ASCII = Charset.forName("US-ASCII");
+    public static final Charset US_ASCII = StandardCharsets.US_ASCII;
     /**
      * ISO Latin Alphabet 1.
      */
-    public static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
+    public static final Charset ISO_8859_1 = StandardCharsets.ISO_8859_1;
     /**
      * UTF-8.
      */
-    public static final Charset UTF_8 = Charset.forName("UTF-8");
+    public static final Charset UTF_8 = StandardCharsets.UTF_8;
     /**
      * Big-endian byte order UTF-16.
      */
-    public static final Charset UTF_16BE = Charset.forName("UTF-16BE");
+    public static final Charset UTF_16BE = StandardCharsets.UTF_16BE;
     /**
      * Little-endian byte order UTF-16.
      */
-    public static final Charset UTF_16LE = Charset.forName("UTF-16LE");
+    public static final Charset UTF_16LE = StandardCharsets.UTF_16LE;
     /**
      * Byte order mark detected UTF-16.
      */
-    public static final Charset UTF_16 = Charset.forName("UTF-16");
+    public static final Charset UTF_16 = StandardCharsets.UTF_16;
 
 }

--- a/src/test/java/hudson/remoting/ChecksumTest.java
+++ b/src/test/java/hudson/remoting/ChecksumTest.java
@@ -3,7 +3,6 @@ package hudson.remoting;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
-import org.jenkinsci.remoting.util.Charsets;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -12,6 +11,7 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -47,7 +47,7 @@ public class ChecksumTest {
 
     private File createTmpFile(String name, String contents) throws Exception {
         File tmpFile = tmp.newFile(name);
-        Files.append(contents, tmpFile, Charsets.UTF_8);
+        Files.append(contents, tmpFile, StandardCharsets.UTF_8);
         return tmpFile;
     }
 

--- a/src/test/java/hudson/remoting/FileSystemJarCacheTest.java
+++ b/src/test/java/hudson/remoting/FileSystemJarCacheTest.java
@@ -3,7 +3,6 @@ package hudson.remoting;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
 import org.hamcrest.core.StringContains;
-import org.jenkinsci.remoting.util.Charsets;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -19,6 +18,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -54,7 +54,7 @@ public class FileSystemJarCacheTest {
         fileSystemJarCache = new FileSystemJarCache(tmp.getRoot(), true);
 
         expectedChecksum = ChecksumTest.createdExpectedChecksum(
-                Hashing.sha256().hashBytes(CONTENTS.getBytes(Charsets.UTF_8)));
+                Hashing.sha256().hashBytes(CONTENTS.getBytes(StandardCharsets.UTF_8)));
     }
 
     @Test
@@ -92,7 +92,7 @@ public class FileSystemJarCacheTest {
             @Override
             public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
                 RemoteOutputStream o = (RemoteOutputStream) invocationOnMock.getArguments()[2];
-                o.write("Some other contents".getBytes(Charsets.UTF_8));
+                o.write("Some other contents".getBytes(StandardCharsets.UTF_8));
                 return null;
             }
         }).when(mockJarLoader).writeJarTo(
@@ -162,7 +162,7 @@ public class FileSystemJarCacheTest {
             public Boolean answer(InvocationOnMock invocationOnMock) throws Throwable {
                 Files.createParentDirs(expectedFile);
                 expectedFile.createNewFile();
-                Files.append("Some other contents", expectedFile, Charsets.UTF_8);
+                Files.append("Some other contents", expectedFile, StandardCharsets.UTF_8);
                 return false;
             }
         }).when(fileSpy).renameTo(expectedFile);
@@ -180,7 +180,7 @@ public class FileSystemJarCacheTest {
             @Override
             public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
                 RemoteOutputStream o = (RemoteOutputStream) invocationOnMock.getArguments()[2];
-                o.write(CONTENTS.getBytes(Charsets.UTF_8));
+                o.write(CONTENTS.getBytes(StandardCharsets.UTF_8));
                 return null;
             }
         }).when(mockJarLoader).writeJarTo(

--- a/src/test/java/org/jenkinsci/remoting/engine/ChannelCiphersTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/ChannelCiphersTest.java
@@ -23,9 +23,9 @@
  */
 package org.jenkinsci.remoting.engine;
 
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Random;
-import org.jenkinsci.remoting.util.Charsets;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -44,9 +44,9 @@ public class ChannelCiphersTest {
         ChannelCiphers ciphers = ChannelCiphers.create(ENTROPY);
 
         byte[] encrypted = ciphers.getEncryptCipher().doFinal(
-                "string 1".getBytes(Charsets.UTF_8));
+                "string 1".getBytes(StandardCharsets.UTF_8));
         String decrypted = new String(
-                ciphers.getDecryptCipher().doFinal(encrypted), Charsets.UTF_8);
+                ciphers.getDecryptCipher().doFinal(encrypted), StandardCharsets.UTF_8);
         assertEquals("string 1", decrypted);
     }
 
@@ -57,9 +57,9 @@ public class ChannelCiphersTest {
                 ciphers1.getAesKey(), ciphers1.getSpecKey());
 
         byte[] encrypted = ciphers1.getEncryptCipher().doFinal(
-                "string 1".getBytes(Charsets.UTF_8));
+                "string 1".getBytes(StandardCharsets.UTF_8));
         String decrypted = new String(
-                ciphers2.getDecryptCipher().doFinal(encrypted), Charsets.UTF_8);
+                ciphers2.getDecryptCipher().doFinal(encrypted), StandardCharsets.UTF_8);
         assertEquals("string 1", decrypted);
         assertEquals(16, ciphers1.getAesKey().length);
         assertEquals(16, ciphers1.getSpecKey().length);

--- a/src/test/java/org/jenkinsci/remoting/engine/EngineUtilTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/EngineUtilTest.java
@@ -23,12 +23,11 @@
  */
 package org.jenkinsci.remoting.engine;
 
-import org.jenkinsci.remoting.util.Charsets;
 import org.junit.Test;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -78,6 +77,6 @@ public class EngineUtilTest {
     }
 
     private BufferedInputStream stringToStream(String str) {
-        return new BufferedInputStream(new ByteArrayInputStream(str.getBytes(Charsets.UTF_8)));
+        return new BufferedInputStream(new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/src/test/java/org/jenkinsci/remoting/engine/HandlerLoopbackLoadStress.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/HandlerLoopbackLoadStress.java
@@ -45,6 +45,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -99,7 +100,6 @@ import org.jenkinsci.remoting.protocol.IOHub;
 import org.jenkinsci.remoting.protocol.IOHubReadyListener;
 import org.jenkinsci.remoting.protocol.IOHubRegistrationCallback;
 import org.jenkinsci.remoting.protocol.cert.BlindTrustX509ExtendedTrustManager;
-import org.jenkinsci.remoting.util.Charsets;
 import org.jenkinsci.remoting.util.SettableFuture;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
@@ -257,7 +257,7 @@ public class HandlerLoopbackLoadStress {
             MessageDigest digest = MessageDigest.getInstance("MD5");
             digest.reset();
             byte[] bytes = digest.digest(
-                    (HandlerLoopbackLoadStress.class.getName() + clientName).getBytes(Charsets.UTF_8));
+                    (HandlerLoopbackLoadStress.class.getName() + clientName).getBytes(StandardCharsets.UTF_8));
             StringBuilder result = new StringBuilder(Math.max(0, bytes.length * 3 - 1));
             for (int i = 0; i < bytes.length; i++) {
                 if (i > 0) {

--- a/src/test/java/org/jenkinsci/remoting/engine/Jnlp3UtilTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/Jnlp3UtilTest.java
@@ -23,11 +23,11 @@
  */
 package org.jenkinsci.remoting.engine;
 
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Random;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
-import org.jenkinsci.remoting.util.Charsets;
 import org.junit.Test;
 
 import java.security.MessageDigest;
@@ -69,15 +69,15 @@ public class Jnlp3UtilTest {
 
     @Test
     public void testKeyToString() throws Exception {
-        byte[] key = "This is a string".getBytes(Charsets.UTF_8);
-        assertEquals(new String(key, Charsets.ISO_8859_1), Jnlp3Util.keyToString(key));
+        byte[] key = "This is a string".getBytes(StandardCharsets.UTF_8);
+        assertEquals(new String(key, StandardCharsets.ISO_8859_1), Jnlp3Util.keyToString(key));
     }
 
     @Test
     public void testKeyFromString() throws Exception {
-        byte[] key = "This is a string".getBytes(Charsets.UTF_8);
+        byte[] key = "This is a string".getBytes(StandardCharsets.UTF_8);
         assertArrayEquals(key,
-                Jnlp3Util.keyFromString(new String(key, Charsets.ISO_8859_1)));
+                Jnlp3Util.keyFromString(new String(key, StandardCharsets.ISO_8859_1)));
     }
 
     @Test
@@ -91,8 +91,8 @@ public class Jnlp3UtilTest {
     public void testCreateChallengeResponse() throws Exception {
         String challenge = "This is a challenge string";
         MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
-        messageDigest.update(challenge.getBytes(Charsets.UTF_8));
-        String expectedResponse = new String(messageDigest.digest(), Charsets.UTF_8);
+        messageDigest.update(challenge.getBytes(StandardCharsets.UTF_8));
+        String expectedResponse = new String(messageDigest.digest(), StandardCharsets.UTF_8);
         assertEquals(expectedResponse, Jnlp3Util.createChallengeResponse(challenge));
     }
 
@@ -100,8 +100,8 @@ public class Jnlp3UtilTest {
     public void testValidateChallengeResponse() throws Exception {
         String challenge = "This is a challenge string";
         MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
-        messageDigest.update(challenge.getBytes(Charsets.UTF_8));
-        String challengeResponse = new String(messageDigest.digest(), Charsets.UTF_8);
+        messageDigest.update(challenge.getBytes(StandardCharsets.UTF_8));
+        String challengeResponse = new String(messageDigest.digest(), StandardCharsets.UTF_8);
 
         assertTrue(Jnlp3Util.validateChallengeResponse(challenge, challengeResponse));
         assertFalse(Jnlp3Util.validateChallengeResponse(challenge, "some string"));

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocolHandlerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocolHandlerTest.java
@@ -8,6 +8,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -25,7 +26,6 @@ import org.jenkinsci.remoting.protocol.cert.RSAKeyPairRule;
 import org.jenkinsci.remoting.protocol.cert.SSLContextRule;
 import org.jenkinsci.remoting.protocol.cert.X509CertificateRule;
 import org.jenkinsci.remoting.protocol.impl.ConnectionRefusalException;
-import org.jenkinsci.remoting.util.Charsets;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -201,7 +201,7 @@ public class JnlpProtocolHandlerTest {
         while (content.hasRemaining()) {
             eastChannel.read(content);
         }
-        assertThat(new String(bytes, Charsets.UTF_8), is("Protocol:" + factory.toString()));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("Protocol:" + factory.toString()));
         Future<Channel> eastChan = eastProto
                 .handle(eastChannel.socket(), new HashMap<String, String>(), new JnlpConnectionStateListener() {
                     @Override
@@ -275,7 +275,7 @@ public class JnlpProtocolHandlerTest {
         while (content.hasRemaining()) {
             eastChannel.read(content);
         }
-        assertThat(new String(bytes, Charsets.UTF_8), is("Protocol:" + factory.toString()));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("Protocol:" + factory.toString()));
         Future<Channel> eastChan = eastProto
                 .handle(eastChannel.socket(), new HashMap<String, String>(), new JnlpConnectionStateListener() {
                     @Override
@@ -353,7 +353,7 @@ public class JnlpProtocolHandlerTest {
         while (content.hasRemaining()) {
             eastChannel.read(content);
         }
-        assertThat(new String(bytes, Charsets.UTF_8), is("Protocol:" + factory.toString()));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("Protocol:" + factory.toString()));
         Future<Channel> eastChan = eastProto
                 .handle(eastChannel.socket(), new HashMap<String, String>(), new JnlpConnectionStateListener() {
                     @Override
@@ -432,7 +432,7 @@ public class JnlpProtocolHandlerTest {
         while (content.hasRemaining()) {
             eastChannel.read(content);
         }
-        assertThat(new String(bytes, Charsets.UTF_8), is("Protocol:" + factory.toString()));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("Protocol:" + factory.toString()));
         Future<Channel> eastChan = eastProto
                 .handle(eastChannel.socket(), new HashMap<String, String>(), new JnlpConnectionStateListener() {
                     @Override
@@ -511,7 +511,7 @@ public class JnlpProtocolHandlerTest {
         while (content.hasRemaining()) {
             eastChannel.read(content);
         }
-        assertThat(new String(bytes, Charsets.UTF_8), is("Protocol:" + factory.toString()));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("Protocol:" + factory.toString()));
         Future<Channel> eastChan = eastProto
                 .handle(eastChannel.socket(), new HashMap<String, String>(), new JnlpConnectionStateListener() {
                     @Override
@@ -587,7 +587,7 @@ public class JnlpProtocolHandlerTest {
         while (content.hasRemaining()) {
             eastChannel.read(content);
         }
-        assertThat(new String(bytes, Charsets.UTF_8), is("Protocol:" + factory.toString()));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("Protocol:" + factory.toString()));
         Future<Channel> eastChan = eastProto
                 .handle(eastChannel.socket(), new HashMap<String, String>(), new JnlpConnectionStateListener() {
                     @Override
@@ -662,7 +662,7 @@ public class JnlpProtocolHandlerTest {
         while (content.hasRemaining()) {
             eastChannel.read(content);
         }
-        assertThat(new String(bytes, Charsets.UTF_8), is("Protocol:" + factory.toString()));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("Protocol:" + factory.toString()));
         Future<Channel> eastChan = eastProto
                 .handle(eastChannel.socket(), new HashMap<String, String>(), new JnlpConnectionStateListener() {
                     @Override

--- a/src/test/java/org/jenkinsci/remoting/util/ByteBufferQueueInputStreamTest.java
+++ b/src/test/java/org/jenkinsci/remoting/util/ByteBufferQueueInputStreamTest.java
@@ -27,6 +27,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -39,7 +41,7 @@ public class ByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         ByteBufferQueueInputStream instance = new ByteBufferQueueInputStream(queue);
 
         assertThat(read(instance), is(str));
@@ -50,7 +52,7 @@ public class ByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         ByteBufferQueueInputStream instance = new ByteBufferQueueInputStream(queue, 10);
 
         assertThat(read(instance, 10), is("AbCdEfGhIj"));
@@ -61,7 +63,7 @@ public class ByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         ByteBufferQueueInputStream instance = new ByteBufferQueueInputStream(queue);
 
         assertThat(read(instance, 10), is("AbCdEfGhIj"));
@@ -72,16 +74,16 @@ public class ByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         ByteBufferQueueInputStream instance = new ByteBufferQueueInputStream(queue);
 
         byte[] bytes = new byte[10];
         assertThat(instance.read(bytes), is(10));
-        assertThat(new String(bytes, Charsets.UTF_8), is("AbCdEfGhIj"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("AbCdEfGhIj"));
         assertThat(instance.read(bytes), is(10));
-        assertThat(new String(bytes, Charsets.UTF_8), is("KlMnOpQrSt"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("KlMnOpQrSt"));
         assertThat(instance.read(bytes), is(6));
-        assertThat(new String(bytes, Charsets.UTF_8), is("UvWxYzQrSt"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("UvWxYzQrSt"));
     }
 
     @Test
@@ -89,20 +91,20 @@ public class ByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         ByteBufferQueueInputStream instance = new ByteBufferQueueInputStream(queue);
 
         byte[] bytes = new byte[10];
         assertThat(instance.read(bytes,5,3), is(3));
-        assertThat(new String(bytes, Charsets.UTF_8), is("\u0000\u0000\u0000\u0000\u0000AbC\u0000\u0000"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("\u0000\u0000\u0000\u0000\u0000AbC\u0000\u0000"));
         assertThat(instance.read(bytes, 0, 2), is(2));
-        assertThat(new String(bytes, Charsets.UTF_8), is("dE\u0000\u0000\u0000AbC\u0000\u0000"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("dE\u0000\u0000\u0000AbC\u0000\u0000"));
         assertThat(instance.read(bytes, 2, 8), is(8));
-        assertThat(new String(bytes, Charsets.UTF_8), is("dEfGhIjKlM"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("dEfGhIjKlM"));
         assertThat(instance.read(bytes, 2, 8), is(8));
-        assertThat(new String(bytes, Charsets.UTF_8), is("dEnOpQrStU"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("dEnOpQrStU"));
         assertThat(instance.read(bytes, 2, 8), is(5));
-        assertThat(new String(bytes, Charsets.UTF_8), is("dEvWxYzStU"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("dEvWxYzStU"));
     }
 
     @Test
@@ -110,7 +112,7 @@ public class ByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         ByteBufferQueueInputStream instance = new ByteBufferQueueInputStream(queue);
 
         StringBuffer buf = new StringBuffer();
@@ -134,7 +136,7 @@ public class ByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         ByteBufferQueueInputStream instance = new ByteBufferQueueInputStream(queue);
         assumeThat(instance.markSupported(), is(true));
         instance.mark(4);
@@ -149,7 +151,7 @@ public class ByteBufferQueueInputStreamTest {
         while (-1 != (b = is.read())) {
             tmp.write(b);
         }
-        return new String(tmp.toByteArray(), Charsets.UTF_8);
+        return new String(tmp.toByteArray(), StandardCharsets.UTF_8);
     }
 
     private static String read(InputStream is, int count) throws IOException {
@@ -159,6 +161,6 @@ public class ByteBufferQueueInputStreamTest {
             tmp.write(b);
             count--;
         }
-        return new String(tmp.toByteArray(), Charsets.UTF_8);
+        return new String(tmp.toByteArray(), StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/org/jenkinsci/remoting/util/ByteBufferQueueOutputStreamTest.java
+++ b/src/test/java/org/jenkinsci/remoting/util/ByteBufferQueueOutputStreamTest.java
@@ -24,6 +24,8 @@
 package org.jenkinsci.remoting.util;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -37,7 +39,7 @@ public class ByteBufferQueueOutputStreamTest {
         ByteBufferQueue queue = new ByteBufferQueue(10);
         ByteBufferQueueOutputStream instance = new ByteBufferQueueOutputStream(queue);
 
-        instance.write(str.getBytes(Charsets.UTF_8));
+        instance.write(str.getBytes(StandardCharsets.UTF_8));
 
         assertThat(read(queue), is(str));
     }
@@ -49,7 +51,7 @@ public class ByteBufferQueueOutputStreamTest {
         ByteBufferQueue queue = new ByteBufferQueue(10);
         ByteBufferQueueOutputStream instance = new ByteBufferQueueOutputStream(queue);
 
-        instance.write(str.getBytes(Charsets.UTF_8), 0, 10);
+        instance.write(str.getBytes(StandardCharsets.UTF_8), 0, 10);
         assertThat(read(queue), is("AbCdEfGhIj"));
     }
 

--- a/src/test/java/org/jenkinsci/remoting/util/FastByteBufferQueueInputStreamTest.java
+++ b/src/test/java/org/jenkinsci/remoting/util/FastByteBufferQueueInputStreamTest.java
@@ -27,6 +27,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -39,7 +41,7 @@ public class FastByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         FastByteBufferQueueInputStream instance = new FastByteBufferQueueInputStream(queue,26);
 
         assertThat(read(instance), is(str));
@@ -50,7 +52,7 @@ public class FastByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         FastByteBufferQueueInputStream instance = new FastByteBufferQueueInputStream(queue, 10);
 
         assertThat(read(instance, 10), is("AbCdEfGhIj"));
@@ -61,7 +63,7 @@ public class FastByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         FastByteBufferQueueInputStream instance = new FastByteBufferQueueInputStream(queue,26);
 
         assertThat(read(instance, 10), is("AbCdEfGhIj"));
@@ -72,16 +74,16 @@ public class FastByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         FastByteBufferQueueInputStream instance = new FastByteBufferQueueInputStream(queue,26);
 
         byte[] bytes = new byte[10];
         assertThat(instance.read(bytes), is(10));
-        assertThat(new String(bytes, Charsets.UTF_8), is("AbCdEfGhIj"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("AbCdEfGhIj"));
         assertThat(instance.read(bytes), is(10));
-        assertThat(new String(bytes, Charsets.UTF_8), is("KlMnOpQrSt"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("KlMnOpQrSt"));
         assertThat(instance.read(bytes), is(6));
-        assertThat(new String(bytes, Charsets.UTF_8), is("UvWxYzQrSt"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("UvWxYzQrSt"));
     }
 
     @Test
@@ -89,20 +91,20 @@ public class FastByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         FastByteBufferQueueInputStream instance = new FastByteBufferQueueInputStream(queue,26);
 
         byte[] bytes = new byte[10];
         assertThat(instance.read(bytes,5,3), is(3));
-        assertThat(new String(bytes, Charsets.UTF_8), is("\u0000\u0000\u0000\u0000\u0000AbC\u0000\u0000"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("\u0000\u0000\u0000\u0000\u0000AbC\u0000\u0000"));
         assertThat(instance.read(bytes, 0, 2), is(2));
-        assertThat(new String(bytes, Charsets.UTF_8), is("dE\u0000\u0000\u0000AbC\u0000\u0000"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("dE\u0000\u0000\u0000AbC\u0000\u0000"));
         assertThat(instance.read(bytes, 2, 8), is(8));
-        assertThat(new String(bytes, Charsets.UTF_8), is("dEfGhIjKlM"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("dEfGhIjKlM"));
         assertThat(instance.read(bytes, 2, 8), is(8));
-        assertThat(new String(bytes, Charsets.UTF_8), is("dEnOpQrStU"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("dEnOpQrStU"));
         assertThat(instance.read(bytes, 2, 8), is(5));
-        assertThat(new String(bytes, Charsets.UTF_8), is("dEvWxYzStU"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8), is("dEvWxYzStU"));
     }
 
     @Test
@@ -110,7 +112,7 @@ public class FastByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         FastByteBufferQueueInputStream instance = new FastByteBufferQueueInputStream(queue,26);
 
         StringBuffer buf = new StringBuffer();
@@ -134,7 +136,7 @@ public class FastByteBufferQueueInputStreamTest {
         String str = "AbCdEfGhIjKlMnOpQrStUvWxYz";
 
         ByteBufferQueue queue = new ByteBufferQueue(10);
-        queue.put(ByteBuffer.wrap(str.getBytes(Charsets.UTF_8)));
+        queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         FastByteBufferQueueInputStream instance = new FastByteBufferQueueInputStream(queue,26);
         assertThat(instance.markSupported(), is(false));
     }
@@ -145,7 +147,7 @@ public class FastByteBufferQueueInputStreamTest {
         while (-1 != (b = is.read())) {
             tmp.write(b);
         }
-        return new String(tmp.toByteArray(), Charsets.UTF_8);
+        return new String(tmp.toByteArray(), StandardCharsets.UTF_8);
     }
 
     private static String read(InputStream is, int count) throws IOException {
@@ -155,6 +157,6 @@ public class FastByteBufferQueueInputStreamTest {
             tmp.write(b);
             count--;
         }
-        return new String(tmp.toByteArray(), Charsets.UTF_8);
+        return new String(tmp.toByteArray(), StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
Remoting is on Java 8, so we can start using StandardCharsets from Java 7

@reviewbybees