### PR TITLE
Migrate to SpotBugs 3.1.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ THE SOFTWARE.
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <findbugs.failOnError>false</findbugs.failOnError>
+    <spotbugs.failOnError>false</spotbugs.failOnError>
     <!-- TODO: Required to override by a version with certchain support (MJARSIGNER-53) on @oleg-nenashev's machine. Remove once it's in upstream -->
     <maven-jarsigner-plugin.version>1.4</maven-jarsigner-plugin.version>
   </properties>
@@ -417,8 +417,9 @@ THE SOFTWARE.
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>3.1.0-RC8</version>
         <configuration>
           <xmlOutput>true</xmlOutput>
           <effort>Max</effort>


### PR DESCRIPTION
Just 4 test. The Maven plugin is still RC, so I am not 100% sure it makes sense to proceed right now.
OTOH the plugin is compatible for our cases.

Current output after cleanup pull requests:

```
[INFO] --- spotbugs-maven-plugin:3.1.0-RC8:check (default) @ remoting ---
[INFO] BugInstance size is 12
[INFO] Error size is 0
[INFO] Total bugs: 12
[INFO] Wait not in loop in hudson.remoting.AsyncFutureImpl.get(long, TimeUnit) [hudson.remoting.AsyncFutureImpl] At AsyncFutureImpl.java:[line 83] WA_NOT_IN_LOOP
[INFO] Unconditional wait in hudson.remoting.Channel.waitForProperty(Object) [hudson.remoting.Channel] At Channel.java:[line 1468] UW_UNCOND_WAIT
[INFO] Exceptional return value of java.util.concurrent.ExecutorService.submit(Runnable) ignored in hudson.remoting.JarCacheSupport.resolve(Channel, long, long) [hudson.remoting.JarCacheSupport] At JarCacheSupport.java:[line 61] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[INFO] ProxyOutputStream.java:[line 186] is set to null inside finalize method in hudson.remoting.ProxyOutputStream [hudson.remoting.ProxyOutputStream] At ProxyOutputStream.java:[line 186] FI_FINALIZER_NULLS_FIELDS
[INFO] Exceptional return value of java.util.concurrent.ExecutorService.submit(Runnable) ignored in hudson.remoting.SingleLaneExecutorService.execute(Runnable) [hudson.remoting.SingleLaneExecutorService] At SingleLaneExecutorService.java:[line 105] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[INFO] Exceptional return value of java.util.concurrent.ExecutorService.submit(Runnable) ignored in hudson.remoting.SingleLaneExecutorService$1.run() [hudson.remoting.SingleLaneExecutorService$1] At SingleLaneExecutorService.java:[line 120] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[INFO] Class hudson.remoting.UserRequest defines non-transient non-serializable instance field classLoaderProxy [hudson.remoting.UserRequest] In UserRequest.java SE_BAD_FIELD
[INFO] Found reliance on default encoding in org.jenkinsci.remoting.engine.WorkDirManager.setupLogging(Path, Path): new java.io.PrintStream(OutputStream) [org.jenkinsci.remoting.engine.WorkDirManager] At WorkDirManager.java:[line 285] DM_DEFAULT_ENCODING
[INFO] Private method org.jenkinsci.remoting.engine.WorkDirManager.findConsoleHandler(Logger) is never called [org.jenkinsci.remoting.engine.WorkDirManager] At WorkDirManager.java:[lines 329-334] UPM_UNCALLED_PRIVATE_METHOD
[INFO] Exceptional return value of java.util.concurrent.AbstractExecutorService.submit(Runnable) ignored in org.jenkinsci.remoting.nio.NioChannelHub.run() [org.jenkinsci.remoting.nio.NioChannelHub, org.jenkinsci.remoting.nio.NioChannelHub] At NioChannelHub.java:[line 601]Another occurrence at NioChannelHub.java:[line 624] RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
[INFO] Class org.jenkinsci.remoting.nio.NioChannelHub$NioTransport$1 defines non-transient non-serializable instance field this$1 [org.jenkinsci.remoting.nio.NioChannelHub$NioTransport$1] In NioChannelHub.java SE_BAD_FIELD
[INFO] Class org.jenkinsci.remoting.nio.NioChannelHub$NioTransport$2 defines non-transient non-serializable instance field this$1 [org.jenkinsci.remoting.nio.NioChannelHub$NioTransport$2] In NioChannelHub.java SE_BAD_FIELD
[INFO] 
```

@reviewbybees