### PR TITLE
[JENKINS-38696] - huson.remoting.UtilTest#mkdirs() should not try creating global paths on Windows.

### DIFF
--- a/src/test/java/hudson/remoting/UtilTest.java
+++ b/src/test/java/hudson/remoting/UtilTest.java
@@ -161,13 +161,15 @@ public class UtilTest extends TestCase {
         assertTrue(file.exists());
         assertTrue(file.isFile());
 
-        // Fail to create aloud
-        try {
-            File forbidden = new File("/proc/nonono");
-            Util.mkdirs(forbidden);
-            fail();
-        } catch (IOException ex) {
-            // Expected
+        // Fail to create aloud, do not try on Windows
+        if (!Launcher.isWindows()) {
+            try {
+                File forbidden = new File("/proc/nonono");
+                Util.mkdirs(forbidden);
+                fail("The directory has been created when it should not: " + forbidden);
+            } catch (IOException ex) {
+                // Expected
+            }
         }
     }
 }


### PR DESCRIPTION
On Windows you CAN create such directories.
But it does not mean we should try it even in tests.

Ideally the test needs to be rewritten or removed at all.

@reviewbybees @jtnord 