### PR TITLE
[JENKINS-47965, JENKINS-38696] - IOHub should not wait infinitely for Selector in Windows.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,7 @@ properties([[$class: 'BuildDiscarderProperty',
 /* These platforms correspond to labels in ci.jenkins.io, see:
  *  https://github.com/jenkins-infra/documentation/blob/master/ci.adoc
  */
-//TODO: Enable Windows once JENKINS-38696 is fixed. No sense to spend CPU cycles before that
-List platforms = ['linux']
+List platforms = ['linux', 'windows']
 Map branches = [:]
 
 for (int i = 0; i < platforms.size(); ++i) {

--- a/src/main/java/org/jenkinsci/remoting/protocol/IOHub.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/IOHub.java
@@ -433,7 +433,10 @@ public class IOHub implements Executor, Closeable, Runnable, ByteBufferPool {
                         // in an immediately ready selection key, hence we use the non-blocking form
                         selected = selector.selectNow();
                     } else {
-                        selected = selector.select(); // WINDOWS!!! Waiting the whole timeout anyway if timeout specified?!?
+                        // We just wait for one second if the data is not available
+                        // Before Remoting 3.15 it was an infinite wait, which was causing hanging of the test logic
+                        // If the timeout happens, we will get 0 in selected, and all statistics calculation below will be skipped.
+                        selected = selector.select(1000);
                     }
                     if (selected == 0) {
                         // don't stress the GC by creating instantiating the selected keys

--- a/src/main/java/org/jenkinsci/remoting/protocol/IOHub.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/IOHub.java
@@ -93,6 +93,7 @@ public class IOHub implements Executor, Closeable, Runnable, ByteBufferPool {
      */
     private final Selector selector;
     private volatile boolean ioHubRunning = false;
+    private Object winIoHubLockObject = new Object();
 
     /**
      * Our executor.
@@ -515,6 +516,7 @@ public class IOHub implements Executor, Closeable, Runnable, ByteBufferPool {
         } finally {
             selectorThread.setName(oldName);
             ioHubRunning = false;
+            winIoHubLockObject.notify();
         }
     }
 
@@ -539,8 +541,8 @@ public class IOHub implements Executor, Closeable, Runnable, ByteBufferPool {
             try {
                 watcherThread.setName(watcherName);
                 while (iohub.ioHubRunning) {
-                    Thread.sleep(1000);
                     iohub.selector.wakeup();
+                    iohub.winIoHubLockObject.wait(1000);
                 }
             } catch (InterruptedException ex) {
                 // interrupted


### PR DESCRIPTION
Windows implementation of NIO Channel Selector does not request "Select now" in https://github.com/jenkinsci/remoting/blob/6165d6fb6a71a7f4fce52ce5fc4cac479052ce04/src/main/java/org/jenkinsci/remoting/protocol/IOHub.java#L436 and hence calls selector#select()... and this method has no timeout.

When the code gets into this branch, Selector will be waiting infinitely without calling selector#isOpen(). Such implementation relies on the Selector implementation, which shout interrupt the select() wait if the selector is being closed. But apparently it does not on my machine (Win 10, amd64, Oracle JDK 8u131)

This change adds wait timeout and makes the IOHub implementation to loop in the logic.

- [x] PoC
- [x] Cleanup concurrency, threading, etc

https://issues.jenkins-ci.org/browse/JENKINS-47965

@reviewbybees @stephenc @jtnord 