### PR TITLE
[JENKINS-38696] - Do not delete temporary files in Windows in PrefetchingTest.

### DIFF
--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -30,7 +30,7 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
     private Checksum sum1,sum2;
 
     @Override
-    protected void setUp() throws Exception {
+    protected void setUp() throws Exception {        
         super.setUp();
 
         URL jar1 = getClass().getClassLoader().getResource("remoting-test-client.jar");
@@ -68,6 +68,13 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
         cl.cleanup();
         super.tearDown();
 
+        if (Launcher.isWindows()) {
+            // Current Resource loader implementation keep files open even if we close the classloader.
+            // This check has been never working correctly in Windows.
+            // TODO: Fix it as a part of JENKINS-38696
+            return;
+        }
+        
         // because the dir is used by FIleSystemJarCache to asynchronously load stuff
         // we might fail to shut it down right away
         for (int i=0; ; i++) {


### PR DESCRIPTION
It's a bit weird, but the test uses real classloader, which keeps the files open.
Ideally the tests needs to be fixed in order to stop keeping handlers in JVM when loading JARs (I started doing it for Remoting test client in RTC 1.1), but it's not the top priority right now.

@reviewbybees @jtnord 