### PR TITLE
[JENKINS-46724] - Remove obsolete ClassloadingLock reflection in RemoteClassloader.

### DIFF
--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.MalformedURLException;
 import java.net.URLClassLoader;
@@ -272,7 +271,7 @@ final class RemoteClassLoader extends URLClassLoader {
                 ClassLoader cl = cr.classLoader;
                 if (cl instanceof RemoteClassLoader) {
                     RemoteClassLoader rcl = (RemoteClassLoader) cl;
-                    synchronized (_getClassLoadingLock(rcl, name)) {
+                    synchronized (rcl.getClassLoadingLock(name)) {
                         Class<?> c = rcl.findLoadedClass(name);
 
                         boolean interrupted = false;
@@ -333,28 +332,6 @@ final class RemoteClassLoader extends URLClassLoader {
         }
     }
 
-    private static Method gCLL;
-    static {
-        try {
-            gCLL = ClassLoader.class.getDeclaredMethod("getClassLoadingLock", String.class);
-            gCLL.setAccessible(true);
-        } catch (NoSuchMethodException x) {
-            // OK, Java 6
-        } catch (Exception x) {
-            LOGGER.log(WARNING, null, x);
-        }
-    }
-    private static Object _getClassLoadingLock(RemoteClassLoader rcl, String name) {
-        // Java 7: return rcl.getClassLoadingLock(name);
-        if (gCLL != null) {
-            try {
-                return gCLL.invoke(rcl, name);
-            } catch (Exception x) {
-                LOGGER.log(WARNING, null, x);
-            }
-        }
-        return rcl;
-    }
     /**
      * Intercept {@link RemoteClassLoader#findClass(String)} to allow unittests to be written.
      *


### PR DESCRIPTION
Remoting now required Java 8, so this Java 6 compatibility logic is not required at all.
Getting some extra performance is not bad as well.

https://issues.jenkins-ci.org/browse/JENKINS-46724

@reviewbybees @MarkEWaite @rysteboe @batmat
