### PR TITLE
Explicitly deprecate and Restrict JNLP3 utility classes.

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/ChannelCiphers.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/ChannelCiphers.java
@@ -23,6 +23,9 @@
  */
 package org.jenkinsci.remoting.engine;
 
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Random;
@@ -32,11 +35,16 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 /**
+ * Provides ciphers required by the JNLP3 protocol.
+ *
  * {@link javax.crypto.Cipher}s that will be used to construct an encrypted
  * {@link hudson.remoting.Channel} after a successful handshake.
  *
+ * @deprecated JNLP3 protocol is deprecated
  * @author Akshay Dayal
  */
+@Deprecated
+@Restricted(NoExternalUse.class)
 class ChannelCiphers {
 
     private final byte[] aesKey;

--- a/src/main/java/org/jenkinsci/remoting/engine/EngineUtil.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/EngineUtil.java
@@ -23,6 +23,9 @@
  */
 package org.jenkinsci.remoting.engine;
 
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -34,12 +37,16 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Engine utility methods.
+ * Engine utility methods for JNLP3.
  * 
  * Internal class. DO NOT USE FROM OUTSIDE.
  *
+ * @deprecated JNLP3 protocol is deprecated
  * @author Akshay Dayal
  */
+@Restricted(NoExternalUse.class)
+@Deprecated
+//TODO: @RestrictedSince
 public class EngineUtil {
 
     /**

--- a/src/main/java/org/jenkinsci/remoting/engine/HandshakeCiphers.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/HandshakeCiphers.java
@@ -34,13 +34,18 @@ import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
 import java.security.spec.KeySpec;
 import org.jenkinsci.remoting.util.Charsets;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * {@link Cipher}s that will be used to during the handshake
  * process for JNLP3 protocol.
  *
+ * @deprecated JNLP3 protocol is deprecated
  * @author Akshay Dayal
  */
+@Deprecated
+@Restricted(NoExternalUse.class)
 class HandshakeCiphers {
 
     private final SecretKey secretKey;

--- a/src/main/java/org/jenkinsci/remoting/engine/Jnlp3ConnectionState.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/Jnlp3ConnectionState.java
@@ -31,6 +31,7 @@ import javax.annotation.Nonnull;
 /**
  * Represents the connection state of a {@link JnlpProtocol3Handler} connection.
  *
+ * @deprecated JNLP3 protocol is deprecated
  * @since 3.0
  */
 @Deprecated

--- a/src/main/java/org/jenkinsci/remoting/engine/Jnlp3Util.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/Jnlp3Util.java
@@ -29,13 +29,18 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Random;
 import org.jenkinsci.remoting.util.Charsets;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Utility methods for JNLP3.
  *
+ * @deprecated JNLP3 Protocol is deprecated.
  * @author Akshay Dayal
  */
-class Jnlp3Util {
+@Restricted(NoExternalUse.class)
+@Deprecated
+/*package*/ class Jnlp3Util {
 
     /**
      * Generate a random 128bit key.

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocolHandlerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocolHandlerTest.java
@@ -701,6 +701,7 @@ public class JnlpProtocolHandlerTest {
     @DataPoints
     public static Factory[] protocols() {
         return new Factory[]{
+                //TODO: Disable JNLP-1 tests by default?
                 new Factory() {
                     @Override
                     public JnlpProtocolHandler<? extends JnlpConnectionState> create(JnlpClientDatabase db,
@@ -731,6 +732,7 @@ public class JnlpProtocolHandlerTest {
                         return "JNLP2-connect";
                     }
                 },
+                //TODO: Disable JNLP3 tests by default?
                 new Factory() {
                     @Override
                     public JnlpProtocolHandler<? extends JnlpConnectionState> create(JnlpClientDatabase db,


### PR DESCRIPTION
The protocol is deprecated, I would like to explicitly advice against using its classes internally and externally.

@reviewbybees @rysteboe @akshayabd 