### PR TITLE
[JENKINS-37566] - FindBugs: Suppress serialization warning for UserRequest#classLoaderProxy.

### DIFF
--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -712,7 +712,17 @@ final class RemoteClassLoader extends URLClassLoader {
         ResourceFile[] getResources2(String name) throws IOException;
     }
 
-    public static IClassLoader export(@Nonnull ClassLoader cl, Channel local) {
+    /**
+     * Exports classloader over the channel.
+     *
+     * If the classloader is an instance of {@link RemoteClassLoader}, this classloader will be unwrapped and reused.
+     * Otherwise, a classloader object will be exported
+     *
+     * @param cl Classloader to be exported
+     * @param local Channel
+     * @return Exported reference. This reference is always {@link Serializable} though interface is not explict about that
+     */
+    public static IClassLoader export(@Nonnull ClassLoader cl, @Nonnull Channel local) {
         if (cl instanceof RemoteClassLoader) {
             // check if this is a remote classloader from the channel
             final RemoteClassLoader rcl = (RemoteClassLoader) cl;

--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -57,6 +57,7 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<
     private final byte[] request;
     
     @Nonnull
+    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "RemoteClassLoader.export() always returns a serializable instance, but we cannot check it statically due to the java.lang.reflect.Proxy")
     private final IClassLoader classLoaderProxy;
     private final String toString;
     /**
@@ -101,6 +102,8 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<
             exports.stopRecording();
         }
 
+        // TODO: We know that the classloader is always serializable, but there is no way to express it here in a compatible way \
+        // (as well as to call instance off or whatever)
         this.classLoaderProxy = RemoteClassLoader.export(cl, local);
     }
 


### PR DESCRIPTION
The field is actually always serializable, but we cannot confirm it statically due to the reflection code.
I decided to just suppress it for now and to document the method.

@reviewbybees @rysteboe 
