### PR TITLE
[JENKINS-37566] - Suppress issue with non-serializable inner classes in NioChannelHub

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
@@ -535,6 +535,10 @@ public class NioChannelHub implements Runnable, Closeable {
         private Object readResolve() throws ObjectStreamException {
             throw new NotSerializableException("The class should not be serialized over Remoting");
         }
+        
+        private Object writeReplace() throws ObjectStreamException {
+            throw new NotSerializableException("The class should not be serialized over Remoting");
+        }
 
         @Override
         public void checkRoles(RoleChecker checker) throws SecurityException {

--- a/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
@@ -525,10 +525,9 @@ public class NioChannelHub implements Runnable, Closeable {
             }
             try {
                 return task.call();
+            } catch (IOException ex) {
+                throw ex;
             } catch (Exception ex) {
-                if (ex instanceof IOException) {
-                    throw (IOException)ex;
-                }
                 throw new IOException(ex);
             }
         }


### PR DESCRIPTION
The wrapper may decrease the performance a bit, but NioChannelHub is not being used in JNLP4 anyway. Ideally submissions should not use the selector tasks queue in such lame way, but it’s risky to change it to another executor service.

@reviewbybees @rysteboe 
