### PR TITLE
[JENKINS-37566] - Stop nullifying channel in ProxyOutputStream#finalize()

### DIFF
--- a/src/main/java/hudson/remoting/ProxyOutputStream.java
+++ b/src/main/java/hudson/remoting/ProxyOutputStream.java
@@ -181,7 +181,7 @@ final class ProxyOutputStream extends OutputStream implements ErrorPropagatingOu
         super.finalize();
         // if we haven't done so, release the exported object on the remote side.
         // if the object is auto-unexported, the export entry could have already been removed.
-        if(channel!=null) {
+        if(channel != null && oid != -1) {
             channel.send(new Unexport(channel.newIoId(),oid));
             oid = -1;
         }

--- a/src/main/java/hudson/remoting/ProxyOutputStream.java
+++ b/src/main/java/hudson/remoting/ProxyOutputStream.java
@@ -183,7 +183,6 @@ final class ProxyOutputStream extends OutputStream implements ErrorPropagatingOu
         // if the object is auto-unexported, the export entry could have already been removed.
         if(channel!=null) {
             channel.send(new Unexport(channel.newIoId(),oid));
-            channel = null;
             oid = -1;
         }
     }


### PR DESCRIPTION
Just YAGNI, it does not help garbage collector much and actually makes it more complicated due to breaking the object chain.

@reviewbybees
