### PR TITLE
[JENKINS-37566] - FindBugs: Channel#waitForProperty() should use wait() with a timeout.

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1465,8 +1465,8 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 
         while (true) {
             synchronized(this) {
-                // Now we wait till setProperty() notifies us
-                wait();
+                // Now we wait till setProperty() notifies us (in a cycle)
+                wait(1000);
             }
             Object v = properties.get(key);
             if (v != null) return v;


### PR DESCRIPTION
In the worst case it will cause looping within the loop, but it should be fine in the case of the current implementation. It also prevents the infinite lock when the channel closes and does not send notifyAll() properly.

@reviewbybees
