### PR TITLE
[JENKINS-48133] - ChannelClosedException and ChannelStateException now record channel name and info when possible.

### DIFF
--- a/src/main/java/hudson/remoting/Callable.java
+++ b/src/main/java/hudson/remoting/Callable.java
@@ -63,7 +63,7 @@ public interface Callable<V,T extends Throwable> extends Serializable, RoleSensi
             // and leaks in ExportTable.
             //TODO: maybe there is a way to actually diagnose this case?
             final Thread t = Thread.currentThread();
-            throw new ChannelStateException("The calling thread " + t + " has no associated channel. "
+            throw new ChannelStateException(null, "The calling thread " + t + " has no associated channel. "
                     + "The current object " + this + " is " + SerializableOnlyOverRemoting.class +
                     ", but it is likely being serialized/deserialized without the channel");
         }
@@ -85,7 +85,7 @@ public interface Callable<V,T extends Throwable> extends Serializable, RoleSensi
     default Channel getOpenChannelOrFail() throws ChannelStateException {
         final Channel ch = getChannelOrFail();
         if (ch.isClosingOrClosed()) {
-            throw new ChannelClosedException("The associated channel " + ch + " is closing down or has closed down", ch.getCloseRequestCause());
+            throw new ChannelClosedException(ch, "The associated channel " + ch + " is closing down or has closed down", ch.getCloseRequestCause());
         }
         return ch;
     }

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -669,7 +669,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT", justification = "The method is synchronized, no other usages. See https://sourceforge.net/p/findbugs/bugs/1032/")
     /*package*/ synchronized void send(Command cmd) throws IOException {
         if(outClosed!=null)
-            throw new ChannelClosedException(outClosed);
+            throw new ChannelClosedException(this, outClosed);
         if(logger.isLoggable(Level.FINE))
             logger.fine("Send "+cmd);
 

--- a/src/main/java/hudson/remoting/ChannelClosedException.java
+++ b/src/main/java/hudson/remoting/ChannelClosedException.java
@@ -19,11 +19,25 @@ public class ChannelClosedException extends ChannelStateException {
      */
     @Deprecated
     public ChannelClosedException() {
-        super("channel is already closed");
+        this(null, "channel is already closed", null);
     }
 
+    /**
+     * @deprecated Use {@link #ChannelClosedException(Channel, Throwable)}
+     */
+    @Deprecated
     public ChannelClosedException(Throwable cause) {
-        super("channel is already closed", cause);
+        this((Channel) null, cause);
+    }
+
+    /**
+     * Constructor.
+     * @param channel Reference to the channel. {@code null} if the channel is unknown.
+     * @param cause Cause
+     * @since TODO
+     */
+    public ChannelClosedException(@CheckForNull Channel channel, @CheckForNull Throwable cause) {
+        super(channel, "channel is already closed", cause);
     }
     
     /**
@@ -33,8 +47,23 @@ public class ChannelClosedException extends ChannelStateException {
      * @param cause Cause of the channel close/termination. 
      *              May be {@code null} if it cannot be determined when the exception is constructed.
      * @since 3.11
+     * @deprecated Use {@link #ChannelClosedException(Channel, String, Throwable)}
      */
+    @Deprecated
     public ChannelClosedException(@Nonnull String message, @CheckForNull Throwable cause) {
-        super(message, cause);
+        this(null, message, cause);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param channel Reference to the channel. {@code null} if the channel is unknown.
+     * @param message Message
+     * @param cause Cause of the channel close/termination.
+     *              May be {@code null} if it cannot be determined when the exception is constructed.
+     * @since TODO
+     */
+    public ChannelClosedException(@CheckForNull Channel channel, @Nonnull String message, @CheckForNull Throwable cause) {
+        super(channel, message, cause);
     }
 }

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -117,7 +117,7 @@ abstract class Request<RSP extends Serializable,EXC extends Throwable> extends C
         final Throwable senderCloseCause = channel.getSenderCloseCause();
         if (senderCloseCause != null) {
             // Sender is closed, we won't be able to send anything
-            throw new ChannelClosedException(senderCloseCause);
+            throw new ChannelClosedException(channel, senderCloseCause);
         }
     }
     

--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/ChannelApplicationLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/ChannelApplicationLayer.java
@@ -291,15 +291,17 @@ public class ChannelApplicationLayer extends ApplicationLayer<Future<Channel>> {
          */
         @Override
         protected void write(ByteBuffer header, ByteBuffer data) throws IOException {
+            //TODO: Any way to get channel information here
             if (isWriteOpen()) {
                 try {
                     ChannelApplicationLayer.this.write(header);
                     ChannelApplicationLayer.this.write(data);
                 } catch (ClosedChannelException e) {
-                    throw new ChannelClosedException(e);
+                    // Probably it should be another exception type at all
+                    throw new ChannelClosedException(null, "Protocol stack cannot write data anymore. ChannelApplicationLayer reports that the NIO Channel is closed", e);
                 }
             } else {
-                throw new ChannelClosedException(new ClosedChannelException());
+                throw new ChannelClosedException(null, "Protocol stack cannot write data anymore. It is not open for write", null);
             }
         }
 


### PR DESCRIPTION
ChannelStateException has not been released yet, so the API compatibility is not broken.

https://issues.jenkins-ci.org/browse/JENKINS-48133

@reviewbybees
