### PR TITLE
[JENKINS-37566] - Cleanup issues in Command#createdAt handling

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -743,7 +743,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         return exportedObjects.type(oid);
     }
 
-    /*package*/ void unexport(int id, Throwable cause) {
+    /*package*/ void unexport(int id, @CheckForNull Throwable cause) {
         unexport(id, cause, true);
     }
     
@@ -753,7 +753,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * @param cause Stacktrace pf the object creation call
      * @param severeErrorIfMissing Consider missing object as {@code SEVERE} error. {@code FINE} otherwise
      */
-    /*package*/ void unexport(int id, Throwable cause, boolean severeErrorIfMissing) {
+    /*package*/ void unexport(int id, @CheckForNull Throwable cause, boolean severeErrorIfMissing) {
         exportedObjects.unexportByOid(id, cause, severeErrorIfMissing);
     }
 
@@ -1244,9 +1244,8 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * where the termination was initiated as a nested exception.
      */
     private static final class OrderlyShutdown extends IOException {
-        private OrderlyShutdown(Throwable cause) {
-            super(cause.getMessage());
-            initCause(cause);
+        private OrderlyShutdown(@CheckForNull  Throwable cause) {
+            super(cause);
         }
         private static final long serialVersionUID = 1L;
     }

--- a/src/main/java/hudson/remoting/Command.java
+++ b/src/main/java/hudson/remoting/Command.java
@@ -45,8 +45,10 @@ import javax.annotation.CheckForNull;
 abstract class Command implements Serializable {
     /**
      * This exception captures the stack trace of where the Command object is created.
-     * This is useful for diagnosing the error when command fails to execute on the remote peer. 
+     * This is useful for diagnosing the error when command fails to execute on the remote peer.
+     * {@code null} if the cause is not recorded.
      */
+    @CheckForNull
     public final Exception createdAt;
 
 
@@ -81,6 +83,17 @@ abstract class Command implements Serializable {
      * @throws ExecutionException Execution error
      */
     protected abstract void execute(Channel channel) throws ExecutionException;
+
+    /**
+     * Chains the {@link #createdAt} cause.
+     * It will happen if and only if cause recording is enabled.
+     * @param initCause Original Cause. {@code null} causes will be ignored
+     */
+    protected final void chainCause(@CheckForNull Throwable initCause) {
+        if (createdAt != null && initCause != null) {
+            createdAt.initCause(initCause);
+        }
+    }
       
     void writeTo(Channel channel, ObjectOutputStream oos) throws IOException {
         Channel old = Channel.setCurrent(channel);

--- a/src/main/java/hudson/remoting/PipeWindow.java
+++ b/src/main/java/hudson/remoting/PipeWindow.java
@@ -24,6 +24,9 @@
 package hudson.remoting;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.logging.Logger;
@@ -49,6 +52,12 @@ import static java.util.logging.Level.*;
  * @author Kohsuke Kawaguchi
  */
 abstract class PipeWindow {
+
+    /**
+     * Cause of death.
+     * If not {@code null}, new commands will not be executed.
+     */
+    @CheckForNull
     protected volatile Throwable dead;
 
     /**
@@ -95,19 +104,23 @@ abstract class PipeWindow {
 
     /**
      * Indicates that the remote end has died and all the further send attempt should fail.
+     * @param cause Death cause. If {@code null}, the death will be still considered as dead, but there will be no cause recorded..
      */
-    void dead(Throwable cause) {
-        this.dead = cause;
+    void dead(@CheckForNull Throwable cause) {
+        // We need to record
+        this.dead = cause != null ? cause : new RemotingSystemException("Unknown cause", null) ;
     }
 
     /**
      * If we already know that the remote end had developed a problem, throw an exception.
      * Otherwise no-op.
+     * @throws IOException Pipe is already closed
      */
     protected void checkDeath() throws IOException {
-        if (dead!=null)
+        if (dead != null) {
             // the remote end failed to write.
-            throw (IOException)new IOException("Pipe is already closed").initCause(dead);
+            throw new IOException("Pipe is already closed", dead);
+        }
     }
 
 

--- a/src/main/java/hudson/remoting/ProxyOutputStream.java
+++ b/src/main/java/hudson/remoting/ProxyOutputStream.java
@@ -443,7 +443,7 @@ final class ProxyOutputStream extends OutputStream implements ErrorPropagatingOu
         @Override
         protected void execute(Channel channel) {
             PipeWindow w = channel.getPipeWindow(oid);
-            w.dead(createdAt.getCause());
+            w.dead(createdAt != null ? createdAt.getCause() : null);
         }
 
         public String toString() {

--- a/src/main/java/hudson/remoting/ProxyWriter.java
+++ b/src/main/java/hudson/remoting/ProxyWriter.java
@@ -474,7 +474,7 @@ final class ProxyWriter extends Writer {
         @Override
         protected void execute(Channel channel) {
             PipeWindow w = channel.getPipeWindow(oid);
-            w.dead(createdAt.getCause());
+            w.dead(createdAt != null ? createdAt.getCause() : null);
         }
 
         public String toString() {

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -364,8 +364,9 @@ abstract class Request<RSP extends Serializable,EXC extends Throwable> extends C
                     } finally {
                         CURRENT.set(null);
                     }
-                    if(chainCause)
-                        rsp.createdAt.initCause(createdAt);
+                    if(chainCause) {
+                        rsp.chainCause(createdAt);
+                    }
 
                     channel.send(rsp);
                 } catch (IOException e) {

--- a/src/main/java/hudson/remoting/UnexportCommand.java
+++ b/src/main/java/hudson/remoting/UnexportCommand.java
@@ -23,6 +23,8 @@
  */
 package hudson.remoting;
 
+import javax.annotation.CheckForNull;
+
 /**
  * {@link Command} that unexports an object.
  * @author Kohsuke Kawaguchi
@@ -30,11 +32,15 @@ package hudson.remoting;
 public class UnexportCommand extends Command {
     private final int oid;
 
-    UnexportCommand(int oid, Throwable cause) {
+    UnexportCommand(int oid, @CheckForNull Throwable cause) {
         this.oid = oid;
-        this.createdAt.initCause(cause);
+        chainCause(cause);
     }
 
+    /**
+     * @deprecated Use {@link #UnexportCommand(int, Throwable)}
+     */
+    @Deprecated
     public UnexportCommand(int oid) {
         this(oid,null);
     }


### PR DESCRIPTION
I noticed that `Command#createdAt` is being handled incorrectly in some cases, so I annotated the related methods and fixed FindBugs issues.

https://issues.jenkins-ci.org/browse/JENKINS-37566

@reviewbybees