### PR TITLE
[JENKINS-37566] - FindBugs: Prevent the unconditional wait warning in Channel#waitForProperty()

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1463,17 +1463,18 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
             throw new IllegalStateException("Channel was already closed", outClosed);
 
         while (true) {
+            // Now we wait till setProperty() notifies us (in a cycle)
             synchronized(this) {
-                // Now we wait till setProperty() notifies us (in a cycle)
-                wait(1000);
+                if (isInClosed()) {
+                    throw new IllegalStateException("Channel was already closed", inClosed);
+                } else if (isOutClosed()) {
+                    throw new IllegalStateException("Channel was already closed", outClosed);
+                } else {
+                    wait(1000);
+                }
             }
             Object v = properties.get(key);
             if (v != null) return v;
-
-            if (isInClosed())
-                throw new IllegalStateException("Channel was already closed", inClosed);
-            if (isOutClosed())
-                throw new IllegalStateException("Channel was already closed", outClosed);
         }
     }
 


### PR DESCRIPTION
Just rebalances the code a bit, which may helpful if waitForProperty() waits for the channel lock too long and it gets closed.

@reviewbybees @rysteboe 
