### PR TITLE
[JENKINS-48309] - Prevent TimeoutException in AsyncFutureImpl in the case of spurious wakeups

### DIFF
--- a/src/main/java/hudson/remoting/AsyncFutureImpl.java
+++ b/src/main/java/hudson/remoting/AsyncFutureImpl.java
@@ -89,8 +89,7 @@ public class AsyncFutureImpl<V> implements Future<V> {
                 break;
             }
 
-            long timeToWaitMs = Math.max(1, timeToWait / 1000000);
-            wait(timeToWaitMs);
+            wait(timeToWait / 1000000, (int)(timeToWait % 1000000));
         }
 
         if(!completed)

--- a/src/main/java/hudson/remoting/AsyncFutureImpl.java
+++ b/src/main/java/hudson/remoting/AsyncFutureImpl.java
@@ -24,6 +24,7 @@
 package hudson.remoting;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnegative;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -80,12 +81,12 @@ public class AsyncFutureImpl<V> implements Future<V> {
     }
 
     @CheckForNull
-    public synchronized V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    public synchronized V get(@Nonnegative long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         // The accuracy of wait(long) operation is milliseconds anyway, but ok.
         long endWaitTime = System.nanoTime() + unit.toNanos(timeout);
         while (!completed) {
             long timeToWait = endWaitTime - System.nanoTime();
-            if (timeout < 0) {
+            if (timeToWait < 0) {
                 break;
             }
 


### PR DESCRIPTION
**TL;DR**: A large part of Jenkins’ get-with-timeout logic is a subject for improper exit before the timeout.



It happens, because "wait(timeout)" is not in the loop. Object#wait(long) is explicit about that: "A thread can also wake up without being notified, interrupted, or timing out, a so-called spurious wakeup. While this will rarely occur in practice, applications must guard against it by testing for the condition that should have caused the thread to be awakened, and continuing to wait if the condition is not satisfied. In other words, waits should always occur in loops..."

https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-

Impact:

* AsyncFutureImpl is being used explicitly in JarCacheSupport. Jar resolution with a timeout may fail due to the issue
* The class is overridden in Jenkins Core's public API, e.g. hudson.model.queue.FutureImpl. It's hard to estimate risks in the core, but it looks bad.

https://issues.jenkins-ci.org/browse/JENKINS-48309

@reviewbybees @rysteboe @jglick 
