### PR TITLE
[FIXED JENKINS-37566] - Enforce FindBugs by default and add it to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,8 +43,10 @@ for (int i = 0; i < platforms.size(); ++i) {
                     /* Archive the test results */
                     junit '**/target/surefire-reports/TEST-*.xml'
 
-                    /* Archive the build artifacts */
-                    archiveArtifacts artifacts: 'target/**/*.jar'
+                    if (label == 'linux') {
+                      archiveArtifacts artifacts: 'target/**/*.jar'
+                      findbugs '**/target/findbugsXml.xml'
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ for (int i = 0; i < platforms.size(); ++i) {
 
                     if (label == 'linux') {
                       archiveArtifacts artifacts: 'target/**/*.jar'
-                      findbugs '**/target/findbugsXml.xml'
+                      findbugs pattern: '**/target/findbugsXml.xml'
                     }
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ THE SOFTWARE.
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <findbugs.failOnError>false</findbugs.failOnError>
+    <findbugs.failOnError>true</findbugs.failOnError>
     <!-- TODO: Required to override by a version with certchain support (MJARSIGNER-53) on @oleg-nenashev's machine. Remove once it's in upstream -->
     <maven-jarsigner-plugin.version>1.4</maven-jarsigner-plugin.version>
   </properties>


### PR DESCRIPTION
Jenkins Remoting is now FindBugs-clean.

![full](https://user-images.githubusercontent.com/3000480/33705620-17673fa4-db42-11e7-8451-62a65b35d76b.png)

@reviewbybees @rysteboe + @rtyler since I have patched the Jenkinsfile