### PR TITLE
[JENKINS-49027] Better report JEP-200 violations in Remoting

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -47,7 +47,6 @@ import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.Locale;
@@ -910,13 +909,11 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 
         // re-wrap the exception so that we can capture the stack trace of the caller.
         } catch (ClassNotFoundException e) {
-            IOException x = new IOException("Remote call on "+name+" failed");
-            x.initCause(e);
-            throw x;
+            throw new IOException("Remote call on " + name + " failed", e);
         } catch (Error e) {
-            IOException x = new IOException("Remote call on "+name+" failed");
-            x.initCause(e);
-            throw x;
+            throw new IOException("Remote call on " + name + " failed", e);
+        } catch (SecurityException e) {
+            throw new IOException("Failed to deserialize response to " + request + ": " + e, e);
         } finally {
             // since this is synchronous operation, when the round trip is over
             // we assume all the exported objects are out of scope.

--- a/src/main/java/hudson/remoting/ClassFilter.java
+++ b/src/main/java/hudson/remoting/ClassFilter.java
@@ -60,8 +60,9 @@ public abstract class ClassFilter {
      * @throws SecurityException if it is blacklisted
      */
 	public final String check(String name) {
-		if (isBlacklisted(name))
-			throw new SecurityException("Rejected: " +name);
+        if (isBlacklisted(name)) {
+            throw new SecurityException("Rejected: " + name + "; see https://jenkins.io/redirect/class-filter/");
+        }
 		return name;
 	}
 
@@ -71,8 +72,9 @@ public abstract class ClassFilter {
      * @throws SecurityException if it is blacklisted
      */
 	public final Class check(Class c) {
-		if (isBlacklisted(c))
-			throw new SecurityException("Rejected: " +c.getName());
+        if (isBlacklisted(c)) {
+            throw new SecurityException("Rejected: " + c.getName() + "; see https://jenkins.io/redirect/class-filter/");
+        }
 		return c;
 	}
 

--- a/src/test/java/hudson/remoting/ChannelFilterTest.java
+++ b/src/test/java/hudson/remoting/ChannelFilterTest.java
@@ -62,9 +62,18 @@ public class ChannelFilterTest extends RmiTestBase {
         try {
             channel.call(new ReverseGunImporter());
             fail("should have failed");
-        } catch (SecurityException e) {
-            assertEquals("Rejecting "+GunImporter.class.getName(),e.getMessage());
+        } catch (Exception e) {
+            assertEquals("Rejecting "+GunImporter.class.getName(), findSecurityException(e).getMessage());
 //            e.printStackTrace();
+        }
+    }
+    private static SecurityException findSecurityException(Throwable x) {
+        if (x instanceof SecurityException) {
+            return (SecurityException) x;
+        } else if (x == null) {
+            throw new AssertionError("no SecurityException detected");
+        } else {
+            return findSecurityException(x.getCause());
         }
     }
 


### PR DESCRIPTION
Partial improvement for [JENKINS-49027](https://issues.jenkins-ci.org/browse/JENKINS-49027). For example, update https://github.com/jenkinsci/pipeline-aws-plugin/pull/37 to use a snapshot of `remoting` and comment out the whitelist entry. Without this change, you get

```
java.lang.SecurityException: Rejected: java.lang.String$CaseInsensitiveComparator
	at hudson.remoting.ClassFilter.check(ClassFilter.java:75)
	at hudson.remoting.MultiClassLoaderSerializer$Input.resolveClass(MultiClassLoaderSerializer.java:129)
	at java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:1863)
	at java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1746)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2037)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1568)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2282)
	at java.io.ObjectInputStream.defaultReadObject(ObjectInputStream.java:558)
	at java.util.TreeMap.readObject(TreeMap.java:2449)
	at sun.reflect.GeneratedMethodAccessor3.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.io.ObjectStreamClass.invokeReadObject(ObjectStreamClass.java:1158)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2173)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2064)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1568)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2282)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2206)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2064)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1568)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:428)
	at hudson.remoting.UserRequest.deserialize(UserRequest.java:277)
	at hudson.remoting.UserResponse.retrieve(UserRequest.java:310)
	at hudson.remoting.Channel.call(Channel.java:909)
	at hudson.FilePath.act(FilePath.java:998)
	at hudson.FilePath.act(FilePath.java:987)
	at de.taimos.pipeline.aws.S3UploadStep$Execution$1.run(S3UploadStep.java:261)
```

which is pretty opaque. With it, you get

```
java.lang.SecurityException: Rejected: java.lang.String$CaseInsensitiveComparator; see https://jenkins.io/redirect/class-filter/
	at hudson.remoting.ClassFilter.check(ClassFilter.java:76)
	at hudson.remoting.MultiClassLoaderSerializer$Input.resolveClass(MultiClassLoaderSerializer.java:129)
	at java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:1863)
	at java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1746)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2037)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1568)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2282)
	at java.io.ObjectInputStream.defaultReadObject(ObjectInputStream.java:558)
	at java.util.TreeMap.readObject(TreeMap.java:2449)
	at sun.reflect.GeneratedMethodAccessor3.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.io.ObjectStreamClass.invokeReadObject(ObjectStreamClass.java:1158)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2173)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2064)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1568)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2282)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2206)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2064)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1568)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:428)
	at hudson.remoting.UserRequest.deserialize(UserRequest.java:277)
	at hudson.remoting.UserResponse.retrieve(UserRequest.java:310)
	at hudson.remoting.Channel.call(Channel.java:908)
Caused: java.io.IOException: Failed to deserialize response to UserRequest:hudson.FilePath$FileCallableWrapper@61b60c71
	at hudson.remoting.Channel.call(Channel.java:916)
	at hudson.FilePath.act(FilePath.java:998)
Caused: java.io.IOException: remote file operation failed: …/workspace/p/x at hudson.remoting.Channel@45b84a70:slave0
	at hudson.FilePath.act(FilePath.java:1005)
	at hudson.FilePath.act(FilePath.java:987)
	at de.taimos.pipeline.aws.S3UploadStep$Execution$1.run(S3UploadStep.java:261)
```

which is somewhat better: the problem has been upgraded to a checked exception that code is likely to check; the JEP-200 permalink is visible; and you can see the `Callable.toString` (though in this case https://github.com/jenkinsci/jenkins/pull/3071 would be necessary to make that point you to the actual plugin `MasterToSlaveFileCallable`).

I am also looking into whether we can get details on the actual field causing the problem, but I think this is mergeable as it stands.

@reviewbybees