### PR TITLE
Disable recordCreateAt from RemoteClassLoader

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -537,7 +537,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 
         if(internalExport(IChannel.class, this, false)!=1)
             throw new AssertionError(); // export number 1 is reserved for the channel itself
-        remoteChannel = RemoteInvocationHandler.wrap(this,1,IChannel.class,true,false,false);
+        remoteChannel = RemoteInvocationHandler.wrap(this, 1, IChannel.class, true, false, false, true);
 
         this.remoteCapability = transport.getRemoteCapability();
         this.pipeWriter = new PipeWriter(createPipeWriterExecutor());
@@ -727,7 +727,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      */
     @Override
     public <T> T export(Class<T> type, T instance) {
-        return export(type, instance, true, true);
+        return export(type, instance, true, true, true);
     }
 
     /**
@@ -740,11 +740,12 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *      used by {@link RemoteClassLoader}.
      *
      *      To create proxies for objects inside remoting, pass in false. 
+     * @param recordCreatedAt as in {@link Command#Command(boolean)}
      * @return Reference to the exported instance wrapped by {@link RemoteInvocationHandler}. 
      *      {@code null} if the input instance is {@code null}.     
      */
     @Nullable
-    /*package*/ <T> T export(Class<T> type, @CheckForNull T instance, boolean userProxy, boolean userScope) {
+    /*package*/ <T> T export(Class<T> type, @CheckForNull T instance, boolean userProxy, boolean userScope, boolean recordCreatedAt) {
         if(instance==null) {
             return null;
         }
@@ -763,7 +764,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         // either local side will auto-unexport, or the remote side will unexport when it's GC-ed
         boolean autoUnexportByCaller = exportedObjects.isRecording();
         final int id = internalExport(type, instance, autoUnexportByCaller);
-        return RemoteInvocationHandler.wrap(null, id, type, userProxy, autoUnexportByCaller, userScope);
+        return RemoteInvocationHandler.wrap(null, id, type, userProxy, autoUnexportByCaller, userScope, recordCreatedAt);
     }
 
     /*package*/ <T> int internalExport(Class<T> clazz, T instance) {

--- a/src/main/java/hudson/remoting/ImportedClassLoaderTable.java
+++ b/src/main/java/hudson/remoting/ImportedClassLoaderTable.java
@@ -51,7 +51,7 @@ final class ImportedClassLoaderTable {
      */
     @Nonnull
     public synchronized ClassLoader get(int oid) {
-        return get(RemoteInvocationHandler.wrap(channel,oid,IClassLoader.class,false,false,false));
+        return get(RemoteInvocationHandler.wrap(channel, oid, IClassLoader.class, false, false, false, false));
     }
 
     /**

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -759,7 +759,7 @@ final class RemoteClassLoader extends URLClassLoader {
         // Remote classloader operates in the System scope (JENKINS-45294).
         // It's probably YOLO, but otherwise the termination calls may be unable
         // to execute correctly.
-        return local.export(IClassLoader.class, new ClassLoaderProxy(cl,local), false, false);
+        return local.export(IClassLoader.class, new ClassLoaderProxy(cl,local), false, false, false);
     }
 
     public static void pin(ClassLoader cl, Channel local) {

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -103,8 +103,13 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
     @Deprecated
     /*package*/ volatile transient Future<?> lastIo;
 
-    @SuppressFBWarnings(value="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification="That is why we synchronize on the class.")
     Request() {
+        this(true);
+    }
+
+    @SuppressFBWarnings(value="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification="That is why we synchronize on the class.")
+    Request(boolean recordCreatedAt) {
+        super(recordCreatedAt);
         synchronized(Request.class) {
             id = nextId++;
         }

--- a/src/test/java/hudson/remoting/ChannelTest.java
+++ b/src/test/java/hudson/remoting/ChannelTest.java
@@ -287,7 +287,7 @@ public class ChannelTest extends RmiTestBase {
         @Override
         public TInterface call() throws Exception {
             // UserProxy is used only for the user space, otherwise it will be wrapped into UserRequest
-            return Channel.current().export(clazz, object, userSpace, userSpace);
+            return Channel.current().export(clazz, object, userSpace, userSpace, true);
         }
 
         @Override

--- a/src/test/java/hudson/remoting/PipeWriterTest.java
+++ b/src/test/java/hudson/remoting/PipeWriterTest.java
@@ -24,7 +24,7 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
     protected void setUp() throws Exception {
         super.setUp();
         // Checker operates using the user-space RMI
-        checker = channel.export(PipeWriterTestChecker.class, this, false, true);
+        checker = channel.export(PipeWriterTestChecker.class, this, false, true, true);
     }
 
     /**


### PR DESCRIPTION
While trying to diagnose poor performance of a plugin which did heavy remote class loading in a dev build, I saw agent thread dumps such as

```
"pool-…-thread-… for channel id=… / waiting for channel id=…" … RUNNABLE
	at java.lang.Throwable.getStackTraceElement(Native Method)
	at java.lang.Throwable.getOurStackTrace(Throwable.java:827)
	-  locked hudson.remoting.Command$Source@…
	at java.lang.Throwable.writeObject(Throwable.java:979)
	-  locked hudson.remoting.Command$Source@…
	at sun.reflect.GeneratedMethodAccessor3.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.io.ObjectStreamClass.invokeWriteObject(ObjectStreamClass.java:1128)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1496)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
	at hudson.remoting.Command.writeTo(Command.java:106)
	at hudson.remoting.AbstractSynchronousByteArrayCommandTransport.write(AbstractSynchronousByteArrayCommandTransport.java:46)
	at hudson.remoting.Channel.send(Channel.java:719)
	-  locked hudson.remoting.Channel@…
	at hudson.remoting.Request.call(Request.java:155)
	-  locked hudson.remoting.RemoteInvocationHandler$RPCRequest@…
	-  locked hudson.remoting.Channel@…
	at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:281)
	at com.sun.proxy.$Proxy5.fetch3(Unknown Source)
	at hudson.remoting.RemoteClassLoader.findClass(RemoteClassLoader.java:209)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	-  locked hudson.remoting.RemoteClassLoader@…
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at …
```

While it might theoretically be interesting to diagnose where these commands are being created from, there are a lot of these little calls, and the overhead of constructing a stack trace and passing it through the channel each time seems excessive.

@reviewbybees