### PR TITLE
[JENKINS-49618] - Display Remoting version in the agent log when starting up the agent

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -232,6 +232,7 @@ public class Engine extends Thread {
      *               This method can be used for testing startup logic.
      */
     /*package*/ void startEngine(boolean dryRun) throws IOException {
+        LOGGER.log(Level.INFO, "Using Remoting version: {0}", Launcher.VERSION);
         @CheckForNull File jarCacheDirectory = null;
         
         // Prepare the working directory if required


### PR DESCRIPTION
This PR is to solve newbie-friendly issue in https://issues.jenkins-ci.org/browse/JENKINS-49618.