### PR TITLE
[JENKINS-50237] When returning an exception to a UserRequest, always include a ProxyException

### DIFF
--- a/src/main/java/hudson/remoting/Capability.java
+++ b/src/main/java/hudson/remoting/Capability.java
@@ -36,7 +36,7 @@ public final class Capability implements Serializable {
     }
 
     public Capability() {
-        this(MASK_MULTI_CLASSLOADER|MASK_PIPE_THROTTLING|MASK_MIMIC_EXCEPTION|MASK_PREFETCH|GREEDY_REMOTE_INPUTSTREAM| MASK_PROXY_WRITER_2_35|MASK_CHUNKED_ENCODING);
+        this(MASK_MULTI_CLASSLOADER | MASK_PIPE_THROTTLING | MASK_MIMIC_EXCEPTION | MASK_PREFETCH | GREEDY_REMOTE_INPUTSTREAM | MASK_PROXY_WRITER_2_35 | MASK_CHUNKED_ENCODING | PROXY_EXCEPTION_FALLBACK);
     }
 
     /**
@@ -109,6 +109,15 @@ public final class Capability implements Serializable {
      */
     public boolean supportsProxyWriter2_35() {
         return (mask & MASK_PROXY_WRITER_2_35) != 0;
+    }
+
+    /**
+     * Supports {@link ProxyException} as a fallback when failing to deserialize {@link UserRequest} exceptions.
+     * @since 3.19
+     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-50237">JENKINS-50237</a>
+     */
+    public boolean supportsProxyExceptionFallback() {
+        return (mask & PROXY_EXCEPTION_FALLBACK) != 0;
     }
 
     //TODO: ideally preamble handling needs to be reworked in order to avoid FB suppression
@@ -233,6 +242,8 @@ public final class Capability implements Serializable {
      */
     private static final long MASK_CHUNKED_ENCODING = 1L << 7;
 
+    private static final long PROXY_EXCEPTION_FALLBACK = 1L << 8;
+
     static final byte[] PREAMBLE = "<===[JENKINS REMOTING CAPACITY]===>".getBytes(StandardCharsets.UTF_8);
 
     public static final Capability NONE = new Capability(0);
@@ -295,6 +306,14 @@ public final class Capability implements Serializable {
                 sb.append(", ");
             }
             sb.append("Chunked encoding");
+        }
+        if ((mask & PROXY_EXCEPTION_FALLBACK) != 0) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append("ProxyException fallback");
         }
         sb.append('}');
         return sb.toString();

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -951,7 +951,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         UserRequest<V,T> request=null;
         try {
             request = new UserRequest<V, T>(this, callable);
-            UserResponse<V,T> r = request.call(this);
+            UserRequest.ResponseToUserRequest<V, T> r = request.call(this);
             return r.retrieve(this, UserRequest.getClassLoader(callable));
 
         // re-wrap the exception so that we can capture the stack trace of the caller.
@@ -982,9 +982,10 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
                     + "The channel is closing down or has closed down", getCloseRequestCause());
         }
         
-        final Future<UserResponse<V,T>> f = new UserRequest<V,T>(this, callable).callAsync(this);
-        return new FutureAdapter<V,UserResponse<V,T>>(f) {
-            protected V adapt(UserResponse<V,T> r) throws ExecutionException {
+        final Future<UserRequest.ResponseToUserRequest<V, T>> f = new UserRequest<V, T>(this, callable).callAsync(this);
+        return new FutureAdapter<V, UserRequest.ResponseToUserRequest<V, T>>(f) {
+            @Override
+            protected V adapt(UserRequest.ResponseToUserRequest<V, T> r) throws ExecutionException {
                 try {
                     return r.retrieve(Channel.this, UserRequest.getClassLoader(callable));
                 } catch (Throwable t) {// really means catch(T t)

--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -354,6 +354,7 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserRequest.R
                 if (t == null) {
                     t = (Throwable) deserialize(channel, proxyResponse, cl);
                 }
+                channel.attachCallSiteStackTrace(t);
                 throw (EXC) t;
             } finally {
                 Channel.setCurrent(old);

--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -51,7 +51,7 @@ import org.jenkinsci.remoting.util.AnonymousClassWarnings;
  *
  * @author Kohsuke Kawaguchi
  */
-final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<RSP,EXC>,EXC> {
+final class UserRequest<RSP,EXC extends Throwable> extends Request<UserRequest.ResponseToUserRequest<RSP,EXC>,EXC> {
 
     private static final Logger LOGGER = Logger.getLogger(UserRequest.class.getName());
 
@@ -147,7 +147,8 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<
     }
 
     private static boolean workaroundDone = false;
-    protected UserResponse<RSP,EXC> perform(Channel channel) throws EXC {
+    @Override
+    protected ResponseToUserRequest<RSP,EXC> perform(Channel channel) throws EXC {
         try {
             ClassLoader cl = channel.importedClassLoaders.get(classLoaderProxy);
 
@@ -219,10 +220,22 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<
                 Channel.setCurrent(oldc);
             }
 
-            return new UserResponse<RSP,EXC>(serialize(r,channel),false);
+            byte[] response = serialize(r,channel);
+            return channel.remoteCapability.supportsProxyExceptionFallback() ? new NormalResponse<>(response) : new UserResponse<>(response,false);
         } catch (Throwable e) {
             // propagate this to the calling process
             try {
+                if (channel.remoteCapability.supportsProxyExceptionFallback()) {
+                    byte[] rawResponse = null;
+                    try {
+                        rawResponse = _serialize(e, channel);
+                    } catch (NotSerializableException x) {
+                        // OK
+                    }
+                    byte[] proxyResponse = serialize(new ProxyException(e), channel);
+                    return new ExceptionResponse<>(rawResponse, proxyResponse);
+                }
+                // Remote side is old, so need to use less robust variant:
                 byte[] response;
                 try {
                     response = _serialize(e, channel);
@@ -291,9 +304,70 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserResponse<
     }
 
     private static final long serialVersionUID = 1L;
+
+    interface ResponseToUserRequest<RSP,EXC extends Throwable> extends Serializable {
+        /**
+         * Deserializes the response byte stream into an object.
+         */
+        RSP retrieve(Channel channel, ClassLoader cl) throws IOException, ClassNotFoundException, EXC;
+    }
+
+    private static final class NormalResponse<RSP, EXC extends Throwable> implements ResponseToUserRequest<RSP, EXC> {
+        private static final long serialVersionUID = 1L;
+        private final byte[] response;
+        NormalResponse(byte[] response) {
+            this.response = response;
+        }
+        @SuppressWarnings("unchecked")
+        @Override
+        public RSP retrieve(Channel channel, ClassLoader cl) throws IOException, ClassNotFoundException, EXC {
+            Channel old = Channel.setCurrent(channel);
+            try {
+                return (RSP) deserialize(channel, response, cl);
+            } finally {
+                Channel.setCurrent(old);
+            }
+        }
+    }
+
+    private static final class ExceptionResponse<RSP, EXC extends Throwable> implements ResponseToUserRequest<RSP, EXC> {
+        private static final long serialVersionUID = 1L;
+        private @CheckForNull final byte[] rawResponse;
+        private final byte[] proxyResponse;
+        ExceptionResponse(@CheckForNull byte[] rawResponse, byte[] proxyResponse) {
+            this.rawResponse = rawResponse;
+            this.proxyResponse = proxyResponse;
+        }
+        @SuppressWarnings("unchecked")
+        @Override
+        public RSP retrieve(Channel channel, ClassLoader cl) throws IOException, ClassNotFoundException, EXC {
+            Channel old = Channel.setCurrent(channel);
+            try {
+                Throwable t = null;
+                if (rawResponse != null) {
+                    try {
+                        t = (Throwable) deserialize(channel, rawResponse, cl);
+                    } catch (Exception x) {
+                        LOGGER.log(Level.FINE, "could not deserialize exception response", x);
+                    }
+                }
+                if (t == null) {
+                    t = (Throwable) deserialize(channel, proxyResponse, cl);
+                }
+                throw (EXC) t;
+            } finally {
+                Channel.setCurrent(old);
+            }
+        }
+    }
+
 }
 
-final class UserResponse<RSP,EXC extends Throwable> implements Serializable {
+/**
+ * @deprecated Used only when we lack {@link Capability#supportsProxyExceptionFallback}.
+ */
+@Deprecated
+final class UserResponse<RSP,EXC extends Throwable> implements UserRequest.ResponseToUserRequest<RSP, EXC> {
     private final byte[] response;
     private final boolean isException;
 


### PR DESCRIPTION
[JENKINS-50237](https://issues.jenkins-ci.org/browse/JENKINS-50237)

Inspired by https://github.com/jenkinsci/workflow-api-plugin/pull/64, but more complicated in this case since

* we prefer to retain the original exception type when possible
* we cannot be sure that the remote side is running a similarly updated Remoting

@reviewbybees @jenkinsci/code-reviewers