### PR TITLE
Remoting POM.xml had no pluginRepositories defined

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ THE SOFTWARE.
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -85,6 +85,12 @@ THE SOFTWARE.
       </snapshots>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Noticed it in https://github.com/jenkinsci/remoting/pull/265

https://ci.jenkins.io/blue/organizations/jenkins/Core%2Fremoting/detail/PR-265/10/pipeline/ for Windows build

@reviewbybees 