### PR TITLE
[JENKINS-50965] Fix log message

### DIFF
--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -178,7 +178,7 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserRequest.R
                 final Logger logger = Logger.getLogger(RemoteClassLoader.class.getName());
                 if( logger.isLoggable(logLevel) )
                 {
-                    logger.log(logLevel, "%s class '%s' using classloader: %s", new String[]{ eventMsg, clazz, cl.toString()} );
+                    logger.log(logLevel, "{0} class ''{1}'' using classloader: {2}", new Object[]{ eventMsg, clazz, cl.toString()} );
                 }
             }
 


### PR DESCRIPTION
Current code logs `INFO: %s class '%s' using classloader: %s` if system property `hudson.remoting.RemoteClassLoader.force` is set.  This is ugly and unhelpful.
The code (introduced in #82) should be using `java.text.MessageFormat.format` syntax but is (mistakenly) using `String.format` syntax instead.

I've checked the (new) log format locally (manually, as there's no unit-test for this code) and confirmed that the new format strong would log a message of the form `INFO: Loaded class 'com.foo.Bar' using classloader: com.foo.SomeClassLoader`.