### PR TITLE
[JENKINS-51378] Simplify NetworkLayerTest, removing duplication.

### DIFF
--- a/src/test/java/org/jenkinsci/remoting/protocol/IOBufferMatcher.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/IOBufferMatcher.java
@@ -284,7 +284,4 @@ public abstract class IOBufferMatcher {
         }
     }
 
-    public void closeRead() throws IOException {
-        //innerClose(null);
-    }
 }

--- a/src/test/java/org/jenkinsci/remoting/protocol/IOBufferMatcherLayer.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/IOBufferMatcherLayer.java
@@ -52,11 +52,6 @@ public class IOBufferMatcherLayer extends ApplicationLayer<IOBufferMatcher> {
                 super.close();
             }
 
-            @Override
-            public void closeRead() throws IOException {
-                doCloseRead();
-                super.closeRead();
-            }
         };
     }
 

--- a/src/test/java/org/jenkinsci/remoting/protocol/impl/NetworkLayerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/impl/NetworkLayerTest.java
@@ -87,6 +87,7 @@ public class NetworkLayerTest {
                         .on(clientFactory.create(hub, serverToClient.source(), clientToServer.sink()))
                         .build(new IOBufferMatcherLayer());
 
+
         ProtocolStack<IOBufferMatcher> server =
                 ProtocolStack
                         .on(serverFactory.create(hub, clientToServer.source(), serverToClient.sink()))
@@ -99,7 +100,8 @@ public class NetworkLayerTest {
         server.get().send(data);
         client.get().awaitByteContent(is(expected));
         assertThat(client.get().asByteArray(), is(expected));
-        server.get().close(null);
+        server.get().close();
+        client.get().awaitClose();
     }
 
 }

--- a/src/test/java/org/jenkinsci/remoting/protocol/impl/NetworkLayerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/impl/NetworkLayerTest.java
@@ -25,30 +25,20 @@ package org.jenkinsci.remoting.protocol.impl;
 
 import java.nio.ByteBuffer;
 import java.nio.channels.Pipe;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.remoting.protocol.IOBufferMatcher;
 import org.jenkinsci.remoting.protocol.IOBufferMatcherLayer;
-import org.jenkinsci.remoting.protocol.IOHubRule;
+import org.jenkinsci.remoting.protocol.IOHub;
 import org.jenkinsci.remoting.protocol.NetworkLayerFactory;
 import org.jenkinsci.remoting.protocol.ProtocolStack;
-import org.jenkinsci.remoting.protocol.Repeat;
-import org.jenkinsci.remoting.protocol.RepeatRule;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.experimental.theories.DataPoint;
-import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestName;
-import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
 import static org.hamcrest.Matchers.is;
@@ -57,16 +47,10 @@ import static org.junit.Assert.assertThat;
 @RunWith(Theories.class)
 public class NetworkLayerTest {
 
-    @Rule
-    public TestName name = new TestName();
-    private IOHubRule selector = new IOHubRule();
-    @Rule
-    public RuleChain chain = RuleChain.outerRule(selector)
-            .around(new RepeatRule())
-            .around(new Timeout(10, TimeUnit.MINUTES));
-
     private Pipe clientToServer;
     private Pipe serverToClient;
+    private ExecutorService executorService;
+    private IOHub hub;
 
     @DataPoint("blocking I/O")
     public static NetworkLayerFactory blocking() {
@@ -78,35 +62,18 @@ public class NetworkLayerTest {
         return new NetworkLayerFactory.NIO();
     }
 
-    @DataPoints
-    public static BatchSendBufferingFilterLayer[] batchSizes() {
-        List<BatchSendBufferingFilterLayer> result = new ArrayList<BatchSendBufferingFilterLayer>();
-        if (Boolean.getBoolean("fullTests")) {
-            int length = 16;
-            while (length < 65536) {
-                result.add(new BatchSendBufferingFilterLayer(length));
-                if (length < 16) {
-                    length = length * 2;
-                } else {
-                    length = length * 3 / 2;
-                }
-            }
-        } else {
-            result.add(new BatchSendBufferingFilterLayer(16));
-            result.add(new BatchSendBufferingFilterLayer(4096));
-            result.add(new BatchSendBufferingFilterLayer(65536));
-        }
-        return result.toArray(new BatchSendBufferingFilterLayer[result.size()]);
-    }
-
     @Before
-    public void setUpPipe() throws Exception {
+    public void setUp() throws Exception {
         clientToServer = Pipe.open();
         serverToClient = Pipe.open();
+        executorService = Executors.newFixedThreadPool(8);
+        hub = IOHub.create(executorService);
     }
 
     @After
-    public void tearDownPipe() throws Exception {
+    public void tearDown() throws Exception {
+        hub.close();
+        executorService.shutdownNow();
         IOUtils.closeQuietly(clientToServer.sink());
         IOUtils.closeQuietly(clientToServer.source());
         IOUtils.closeQuietly(serverToClient.sink());
@@ -114,16 +81,15 @@ public class NetworkLayerTest {
     }
 
     @Theory
-    public void smokes(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory) throws Exception {
+    public void doBasicSendReceive(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory) throws Exception {
         ProtocolStack<IOBufferMatcher> client =
                 ProtocolStack
-                        .on(clientFactory.create(selector.hub(), serverToClient.source(), clientToServer.sink()))
+                        .on(clientFactory.create(hub, serverToClient.source(), clientToServer.sink()))
                         .build(new IOBufferMatcherLayer());
-
 
         ProtocolStack<IOBufferMatcher> server =
                 ProtocolStack
-                        .on(serverFactory.create(selector.hub(), clientToServer.source(), serverToClient.sink()))
+                        .on(serverFactory.create(hub, clientToServer.source(), serverToClient.sink()))
                         .build(new IOBufferMatcherLayer());
 
         byte[] expected = "Here is some sample data".getBytes("UTF-8");
@@ -133,219 +99,7 @@ public class NetworkLayerTest {
         server.get().send(data);
         client.get().awaitByteContent(is(expected));
         assertThat(client.get().asByteArray(), is(expected));
-        server.get().close();
-        client.get().awaitClose();
-    }
-
-    @Theory
-    public void doCloseRecv(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory) throws Exception {
-        Logger.getAnonymousLogger().log(Level.INFO, "serverFactory: {0} clientFactory: {1}",
-                new Object[]{serverFactory.getClass().getSimpleName(), clientFactory.getClass().getSimpleName()});
-        ProtocolStack<IOBufferMatcher> client =
-                ProtocolStack
-                        .on(clientFactory.create(selector.hub(), serverToClient.source(), clientToServer.sink()))
-                        .build(new IOBufferMatcherLayer());
-
-
-        ProtocolStack<IOBufferMatcher> server =
-                ProtocolStack
-                        .on(serverFactory.create(selector.hub(), clientToServer.source(), serverToClient.sink()))
-                        .build(new IOBufferMatcherLayer());
-
-        byte[] expected = "Here is some sample data".getBytes("UTF-8");
-        ByteBuffer data = ByteBuffer.allocate(expected.length);
-        data.put(expected);
-        data.flip();
-        server.get().send(data);
-        client.get().awaitByteContent(is(expected));
-        assertThat(client.get().asByteArray(), is(expected));
-        server.get().closeRead();
-        client.get().awaitClose();
-    }
-
-    @Theory
-    @Repeat(value = 1024, stopAfter = 1)
-    public void concurrentStress_1_1(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory)
-            throws Exception {
-        concurrentStress(serverFactory, clientFactory, 1, 1);
-    }
-
-    @Theory
-    @Repeat(value = 1024, stopAfter = 1)
-    public void concurrentStress_64_1(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory)
-            throws Exception {
-        concurrentStress(serverFactory, clientFactory, 64, 1);
-    }
-
-    @Theory
-    @Repeat(value = 1024, stopAfter = 1)
-    public void concurrentStress_1_64(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory)
-            throws Exception {
-        concurrentStress(serverFactory, clientFactory, 1, 64);
-    }
-
-    @Theory
-    @Repeat(value = 1024, stopAfter = 1)
-    public void concurrentStress_1k_1k(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory)
-            throws Exception {
-        concurrentStress(serverFactory, clientFactory, 1024, 1024);
-    }
-
-    @Theory
-    @Repeat(value = 1024, stopAfter = 1)
-    public void concurrentStress_1k_64k(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory)
-            throws Exception {
-        concurrentStress(serverFactory, clientFactory, 1024, 65536);
-    }
-
-    @Theory
-    @Repeat(value = 1024, stopAfter = 1)
-    public void concurrentStress_64k_1k(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory)
-            throws Exception {
-        concurrentStress(serverFactory, clientFactory, 65536, 1024);
-    }
-
-    @Theory
-    @Repeat(value = 1024, stopAfter = 1)
-    public void concurrentStress_64k_64k(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory)
-            throws Exception {
-        concurrentStress(serverFactory, clientFactory, 65536, 65536);
-    }
-
-    @Theory
-    @Repeat(value = 16, stopAfter = 1)
-    public void concurrentStress_1m_2m(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory)
-            throws Exception {
-        concurrentStress(serverFactory, clientFactory, 1024 * 1024, 2048 * 1024);
-    }
-
-    @Theory
-    @Repeat(value = 16, stopAfter = 1)
-    public void concurrentStress_2m_1m(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory)
-            throws Exception {
-        concurrentStress(serverFactory, clientFactory, 2048 * 1024, 1024 * 1024);
-    }
-
-    private void concurrentStress(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory, int serverLimit,
-                                  int clientLimit)
-            throws java.io.IOException, InterruptedException, java.util.concurrent.ExecutionException {
-        Logger.getLogger(name.getMethodName()).log(
-                Level.INFO, "Starting test with server {0} client {1}",
-                new Object[]{serverFactory.getClass().getSimpleName(), clientFactory.getClass().getSimpleName()});
-        ProtocolStack<IOBufferMatcher> clientStack =
-                ProtocolStack
-                        .on(clientFactory.create(selector.hub(), serverToClient.source(), clientToServer.sink()))
-                        .build(new IOBufferMatcherLayer());
-
-
-        ProtocolStack<IOBufferMatcher> serverStack =
-                ProtocolStack
-                        .on(serverFactory.create(selector.hub(), clientToServer.source(), serverToClient.sink()))
-                        .build(new IOBufferMatcherLayer());
-
-        final IOBufferMatcher client = clientStack.get();
-        final IOBufferMatcher server = serverStack.get();
-        Future<Void> clientWork = selector.executorService().submit(new SequentialSender(client, clientLimit, 11));
-        Future<Void> serverWork = selector.executorService().submit(new SequentialSender(server, serverLimit, 13));
-
-        clientWork.get();
-        serverWork.get();
-
-        client.awaitByteContent(SequentialSender.matcher(serverLimit));
-        server.awaitByteContent(SequentialSender.matcher(clientLimit));
-
-        client.close();
-        server.close();
-
-        client.awaitClose();
-        server.awaitClose();
-
-        assertThat(client.asByteArray(), SequentialSender.matcher(serverLimit));
-        assertThat(server.asByteArray(), SequentialSender.matcher(clientLimit));
-    }
-
-    @Theory
-    public void sendingBiggerAndBiggerBatches(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory,
-                                              BatchSendBufferingFilterLayer batch)
-            throws java.io.IOException, InterruptedException, java.util.concurrent.ExecutionException {
-        Logger.getLogger(name.getMethodName()).log(
-                Level.INFO, "Starting test with server {0} client {1} batch {2}", new Object[]{
-                        serverFactory.getClass().getSimpleName(),
-                        clientFactory.getClass().getSimpleName(),
-                        batch
-                });
-        ProtocolStack<IOBufferMatcher> clientStack =
-                ProtocolStack
-                        .on(clientFactory.create(selector.hub(), serverToClient.source(), clientToServer.sink()))
-                        .build(new IOBufferMatcherLayer());
-
-
-        ProtocolStack<IOBufferMatcher> serverStack =
-                ProtocolStack
-                        .on(serverFactory.create(selector.hub(), clientToServer.source(), serverToClient.sink()))
-                        .filter(batch)
-                        .build(new IOBufferMatcherLayer());
-
-        final IOBufferMatcher client = clientStack.get();
-        final IOBufferMatcher server = serverStack.get();
-        Future<Void> serverWork = selector.executorService().submit(new SequentialSender(server, 65536 * 4, 13));
-
-        serverWork.get();
-        batch.flush();
-
-        client.awaitByteContent(SequentialSender.matcher(65536 * 4), 5, TimeUnit.SECONDS);
-
-        client.awaitByteContent(SequentialSender.matcher(65536 * 4));
-
-        client.close();
-        server.close();
-
-        client.awaitClose();
-        server.awaitClose();
-
-        assertThat(client.asByteArray(), SequentialSender.matcher(65536 * 4));
-    }
-
-    @Theory
-    public void bidiSendingBiggerAndBiggerBatches(NetworkLayerFactory serverFactory, NetworkLayerFactory clientFactory,
-                                                  BatchSendBufferingFilterLayer batch)
-            throws java.io.IOException, InterruptedException, java.util.concurrent.ExecutionException {
-        Logger.getLogger(name.getMethodName()).log(
-                Level.INFO, "Starting test with server {0} client {1} batch {2}", new Object[]{
-                        serverFactory.getClass().getSimpleName(),
-                        clientFactory.getClass().getSimpleName(),
-                        batch
-                });
-        BatchSendBufferingFilterLayer clientBatch = batch.clone();
-        ProtocolStack<IOBufferMatcher> clientStack =
-                ProtocolStack
-                        .on(clientFactory.create(selector.hub(), serverToClient.source(), clientToServer.sink()))
-                        .filter(new NoOpFilterLayer())
-                        .filter(clientBatch)
-                        .filter(new NoOpFilterLayer())
-                        .build(new IOBufferMatcherLayer());
-
-
-        ProtocolStack<IOBufferMatcher> serverStack =
-                ProtocolStack
-                        .on(serverFactory.create(selector.hub(), clientToServer.source(), serverToClient.sink()))
-                        .filter(new NoOpFilterLayer())
-                        .filter(batch)
-                        .filter(new NoOpFilterLayer())
-                        .build(new IOBufferMatcherLayer());
-
-        final IOBufferMatcher client = clientStack.get();
-        final IOBufferMatcher server = serverStack.get();
-        Future<Void> clientWork = selector.executorService().submit(new SequentialSender(client, 65536 * 4, 11));
-        Future<Void> serverWork = selector.executorService().submit(new SequentialSender(server, 65536 * 4, 13));
-
-        clientWork.get();
-        serverWork.get();
-        clientBatch.flush();
-        batch.flush();
-
-        client.awaitByteContent(SequentialSender.matcher(65536 * 4));
-        server.awaitByteContent(SequentialSender.matcher(65536 * 4));
+        server.get().close(null);
     }
 
 }


### PR DESCRIPTION
This test has been doing essentially the same thing over and over in a very repetitive way. Some slight, but pretty meaningless variations. And a whole bunch of absolute repetitions.

It kind of halfway used theories to reduce duplication, though it still used traditional duplication structures. And the theories mostly ended up just doing the same thing, as far as the Remoting specific code was concerned.

Ultimately, these repetitions were testing whether Java and the JVM works properly. Oddly and unfortunately, the answer is no, in this case. There are indications that issues exist, on certain platforms, in some extreme scenarios. Key among the scenarios is a very rapid creation and teardown of channels, file descriptors, or possibly most significantly pipes. This seems to particularly apply to the Mac OS. Linux can also show it, though in possibly a somewhat different way. This primarily involves nio. These situations can result in hangs in native calls from Java core APIs, post prominently preClose0(). Rather than testing variations in the Remoting library, all of these JVM issues are what these tests have been stressing, and hitting some of these key characteristics.

These hangs have existed since this test was first created. They're sporadic, though they're more likely to appear in some situations than others. As a result, it leads to the impression that these tests have worked correctly at some times, when it's just been a matter of not hitting the causes in exactly the right way.

There are not any indications that these highly repetitive tests hit conditions that are actually important to any user. This rapid-fire creation and teardown operations are not part of regular operation. These test issues have existed for some time, since the tests were first introduced, and are not known to be related to any customer-observed issued.

@reviewbybees 