### PR TITLE
[JENKINS-51551] Allow CommandTransport and its sub-classes to be sub-typed from outside

### DIFF
--- a/src/main/java/hudson/remoting/CommandTransport.java
+++ b/src/main/java/hudson/remoting/CommandTransport.java
@@ -140,7 +140,7 @@ public abstract class CommandTransport {
      *      Informational flag that indicates that this is the last
      *      call of the {@link #write(Command, boolean)}.
      */
-    protected abstract void write(Command cmd, boolean last) throws IOException;
+    public abstract void write(Command cmd, boolean last) throws IOException;
 
     /**
      * Called to close the write side of the transport, allowing the underlying transport

--- a/src/main/java/hudson/remoting/CommandTransport.java
+++ b/src/main/java/hudson/remoting/CommandTransport.java
@@ -49,17 +49,15 @@ import javax.annotation.CheckForNull;
  * @since 2.13
  */
 public abstract class CommandTransport {
-    /**
-     * Package private so as not to allow direct subtyping (just yet.)
-     */
-    /*package*/ CommandTransport() {
+
+    protected CommandTransport() {
     }
 
     /**
      * SPI implemented by {@link Channel} so that the transport can pass the received command
      * to {@link Channel} for processing.
      */
-    static interface CommandReceiver {
+    protected static interface CommandReceiver {
         /**
          * Notifies the channel that a new {@link Command} was received from the other side.
          * 
@@ -142,7 +140,7 @@ public abstract class CommandTransport {
      *      Informational flag that indicates that this is the last
      *      call of the {@link #write(Command, boolean)}.
      */
-    abstract void write(Command cmd, boolean last) throws IOException;
+    protected abstract void write(Command cmd, boolean last) throws IOException;
 
     /**
      * Called to close the write side of the transport, allowing the underlying transport

--- a/src/main/java/hudson/remoting/JarCache.java
+++ b/src/main/java/hudson/remoting/JarCache.java
@@ -24,7 +24,7 @@ public abstract class JarCache {
     /**
      * Default JAR cache location for disabled workspace Manager.
      */
-    /*package*/ static final File DEFAULT_NOWS_JAR_CACHE_LOCATION = 
+    public static final File DEFAULT_NOWS_JAR_CACHE_LOCATION =
         new File(System.getProperty("user.home"),".jenkins/cache/jars");
 
     //TODO: replace by checked exception

--- a/src/main/java/hudson/remoting/SynchronousCommandTransport.java
+++ b/src/main/java/hudson/remoting/SynchronousCommandTransport.java
@@ -31,7 +31,7 @@ public abstract class SynchronousCommandTransport extends CommandTransport {
     /**
      * Called by {@link Channel} to read the next command to arrive from the stream.
      */
-    protected abstract Command read() throws IOException, ClassNotFoundException, InterruptedException;
+    public abstract Command read() throws IOException, ClassNotFoundException, InterruptedException;
 
     @Override
     public void setup(Channel channel, CommandReceiver receiver) {

--- a/src/main/java/hudson/remoting/SynchronousCommandTransport.java
+++ b/src/main/java/hudson/remoting/SynchronousCommandTransport.java
@@ -31,7 +31,7 @@ public abstract class SynchronousCommandTransport extends CommandTransport {
     /**
      * Called by {@link Channel} to read the next command to arrive from the stream.
      */
-    abstract Command read() throws IOException, ClassNotFoundException, InterruptedException;
+    protected abstract Command read() throws IOException, ClassNotFoundException, InterruptedException;
 
     @Override
     public void setup(Channel channel, CommandReceiver receiver) {


### PR DESCRIPTION
JIRA task: https://issues.jenkins-ci.org/browse/JENKINS-51551

While working on the design for [JENKINS-51413](https://issues.jenkins-ci.org/browse/JENKINS-51413), I need to implement a new command transport to support Kafka communication. However, `CommandTransport` and `SynchronousCommandTransport` are not allowed to be sub-typed outside of the package because some of the fields, methods were made package-private. The proposed solution to this is to change them to protected access level.

@jenkinsci/code-reviewers @oleg-nenashev @jeffret-b @dwnusbaum @Supun94 