### PR TITLE
Suppress some irrelevant stack traces

### DIFF
--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -383,7 +383,11 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
                 } catch (IOException e) {
                     // communication error.
                     // this means the caller will block forever
-                    logger.log(Level.WARNING, "Failed to send back a reply to the request " + this, e);
+                    if (e instanceof ChannelClosedException) {
+                        logger.log(Level.INFO, "Failed to send back a reply to the request {0}: {1}", new Object[] {this, e});
+                    } else {
+                        logger.log(Level.WARNING, "Failed to send back a reply to the request " + this, e);
+                    }
                 } finally {
                     channel.executingCalls.remove(id);
                     Thread.currentThread().setName(oldThreadName);

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -383,7 +383,7 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
                 } catch (IOException e) {
                     // communication error.
                     // this means the caller will block forever
-                    if (e instanceof ChannelClosedException) {
+                    if (e instanceof ChannelClosedException && !logger.isLoggable(Level.FINE)) {
                         logger.log(Level.INFO, "Failed to send back a reply to the request {0}: {1}", new Object[] {this, e});
                     } else {
                         logger.log(Level.WARNING, "Failed to send back a reply to the request " + this, e);

--- a/src/main/java/org/jenkinsci/remoting/protocol/IOHub.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/IOHub.java
@@ -423,7 +423,13 @@ public class IOHub implements Executor, Closeable, Runnable, ByteBufferPool {
     }
 
     private String getThreadNameBase(String executorThreadName) {
-        return "IOHub#" + _id + ": Selector[keys:" + selector.keys().size() + ", gen:" + gen + "] / " + executorThreadName;
+        int keySize;
+        try {
+            keySize = selector.keys().size();
+        } catch (ClosedSelectorException x) {
+            keySize = -1; // possibly a race condition, ignore
+        }
+        return "IOHub#" + _id + ": Selector[keys:" + keySize + ", gen:" + gen + "] / " + executorThreadName;
     }
 
     /**


### PR DESCRIPTION
Noticed a bunch of stack traces during `io.jenkins.plugins.artifact_manager_jclouds.NetworkTest#unrecoverableExceptionArchiving` (https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/41) for example, but really these have been irritating me for a long time (years?):

```
WARNING	hudson.remoting.Request$2#run: Failed to send back a reply to the request hudson.remoting.Request$2@…
Command Close created at
	at hudson.remoting.Command.<init>(Command.java:65)
	at hudson.remoting.Channel$CloseCommand.<init>(Channel.java:1265)
	at hudson.remoting.Channel$CloseCommand.<init>(Channel.java:1263)
	at hudson.remoting.Channel.close(Channel.java:1436)
	at hudson.remoting.Channel.close(Channel.java:1403)
	at hudson.remoting.Channel$CloseCommand.execute(Channel.java:1270)
Caused: hudson.remoting.Channel$OrderlyShutdown
	at hudson.remoting.Channel$CloseCommand.execute(Channel.java:1271)
	at hudson.remoting.Channel$1.handle(Channel.java:565)
	at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:87)
Caused: hudson.remoting.ChannelClosedException: Channel "hudson.remoting.Channel@…:remote": channel is already closed
	at hudson.remoting.Channel.send(Channel.java:717)
	at hudson.remoting.Request$2.run(Request.java:382)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
	at org.jenkinsci.remoting.CallableDecorator.call(CallableDecorator.java:19)
	at hudson.remoting.CallableDecoratorList$1.call(CallableDecoratorList.java:21)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:71)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
INFO	jenkins.model.Jenkins#cleanUp: Stopping Jenkins
WARNING	h.u.ExceptionCatchingThreadFactory#uncaughtException: Thread Computer.threadPoolForRemoting [#9] terminated unexpectedly
java.nio.channels.ClosedSelectorException
	at sun.nio.ch.SelectorImpl.keys(SelectorImpl.java:68)
	at org.jenkinsci.remoting.protocol.IOHub.getThreadNameBase(IOHub.java:426)
	at org.jenkinsci.remoting.protocol.IOHub.access$200(IOHub.java:69)
	at org.jenkinsci.remoting.protocol.IOHub$IOHubSelectorWatcher.run(IOHub.java:536)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:59)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

Should now be reduced to:

```
INFO	hudson.remoting.Request$2#run: Failed to send back a reply to the request hudson.remoting.Request$2@…: hudson.remoting.ChannelClosedException: Channel "hudson.remoting.Channel@…:remote": channel is already closed
INFO	jenkins.model.Jenkins#cleanUp: Stopping Jenkins
```

See also [JENKINS-31652](https://issues.jenkins-ci.org/browse/JENKINS-31652), a different case.