### PR TITLE
[JENKINS-51841] - Offer a method for standardized command deserialization from the channel

### DIFF
--- a/src/main/java/hudson/remoting/AbstractByteArrayCommandTransport.java
+++ b/src/main/java/hudson/remoting/AbstractByteArrayCommandTransport.java
@@ -60,10 +60,7 @@ public abstract class AbstractByteArrayCommandTransport extends CommandTransport
         setup(new ByteArrayReceiver() {
             public void handle(byte[] payload) {
                 try {
-                    Command cmd = Command.readFrom(channel, new ObjectInputStreamEx(
-                            new ByteArrayInputStream(payload),channel.baseClassLoader,channel.classFilter));
-                    receiver.handle(cmd);
-                    channel.notifyRead(cmd, payload.length);
+                    Command cmd = Command.readFrom(channel, payload);
                 } catch (IOException | ClassNotFoundException e) {
                     LOGGER.log(Level.WARNING, "Failed to construct Command in channel " + channel.getName(), e);
                 }

--- a/src/main/java/hudson/remoting/AbstractByteArrayCommandTransport.java
+++ b/src/main/java/hudson/remoting/AbstractByteArrayCommandTransport.java
@@ -61,6 +61,7 @@ public abstract class AbstractByteArrayCommandTransport extends CommandTransport
             public void handle(byte[] payload) {
                 try {
                     Command cmd = Command.readFrom(channel, payload);
+                    receiver.handle(cmd);
                 } catch (IOException | ClassNotFoundException e) {
                     LOGGER.log(Level.WARNING, "Failed to construct Command in channel " + channel.getName(), e);
                 }

--- a/src/main/java/hudson/remoting/AbstractByteBufferCommandTransport.java
+++ b/src/main/java/hudson/remoting/AbstractByteBufferCommandTransport.java
@@ -199,10 +199,8 @@ public abstract class AbstractByteBufferCommandTransport extends CommandTranspor
         try {
             FastByteBufferQueueInputStream is = new FastByteBufferQueueInputStream(receiveQueue, readCommandSizes[0]);
             try {
-                ObjectInputStreamEx ois = new ObjectInputStreamEx(is, channel.baseClassLoader, channel.classFilter);
-                Command cmd = Command.readFrom(channel, ois);
+                Command cmd = Command.readFrom(channel, is, readCommandSizes[0]);
                 receiver.handle(cmd);
-                channel.notifyRead(cmd, readCommandSizes[0]);
             } catch (IOException | ClassNotFoundException e) {
                 LOGGER.log(Level.WARNING, "Failed to construct Command in channel " + channel.getName(), e);
             } finally {

--- a/src/main/java/hudson/remoting/AbstractSynchronousByteArrayCommandTransport.java
+++ b/src/main/java/hudson/remoting/AbstractSynchronousByteArrayCommandTransport.java
@@ -33,11 +33,7 @@ public abstract class AbstractSynchronousByteArrayCommandTransport extends Synch
     @Override
     public Command read() throws IOException, ClassNotFoundException {
         byte[] block = readBlock(channel);
-        Command cmd = Command.readFrom(channel, new ObjectInputStreamEx(
-                new ByteArrayInputStream(block),
-                channel.baseClassLoader,channel.classFilter));
-        channel.notifyRead(cmd, block.length);
-        return cmd;
+        return Command.readFrom(channel, block);
     }
 
     @Override

--- a/src/main/java/hudson/remoting/ClassicCommandTransport.java
+++ b/src/main/java/hudson/remoting/ClassicCommandTransport.java
@@ -68,7 +68,7 @@ import java.io.StreamCorruptedException;
 
     public final Command read() throws IOException, ClassNotFoundException {
         try {
-            Command cmd = Command.readFrom(channel, ois);
+            Command cmd = Command.readFromObjectStream(channel, ois);
             // TODO notifyRead using CountingInputStream
             if (rawIn!=null)
                 rawIn.clear();

--- a/src/main/java/hudson/remoting/Command.java
+++ b/src/main/java/hudson/remoting/Command.java
@@ -119,6 +119,7 @@ public abstract class Command implements Serializable {
      * @return Read command
      * @throws IOException Read exception
      * @throws ClassNotFoundException Deserialization error: class not found
+     * @since TODO
      */
     public static Command readFrom(@Nonnull Channel channel, @Nonnull byte[] payload)
             throws IOException, ClassNotFoundException {

--- a/src/main/java/hudson/remoting/CommandTransport.java
+++ b/src/main/java/hudson/remoting/CommandTransport.java
@@ -43,7 +43,8 @@ import javax.annotation.CheckForNull;
  * {@link Command} objects need to be serialized and deseralized in a specific environment
  * so that {@link Command}s can access {@link Channel} that's using it. Because of this,
  * a transport needs to use {@link Command#writeTo(Channel, ObjectOutputStream)} and
- * {@link Command#readFrom(Channel, ObjectInputStream)}.
+ * {@link Command#readFromObjectStream(Channel, ObjectInputStream)} or
+ * {@link Command#readFrom(Channel, byte[])}.
  *
  * @author Kohsuke Kawaguchi
  * @since 2.13
@@ -69,8 +70,8 @@ public abstract class CommandTransport {
          * concurrently.
          * 
          * @param cmd
-         *      The command received. This object must be read from {@link ObjectInputStream} via
-         *      {@link Command#readFrom(Channel, ObjectInputStream)}
+         *      The command received. This object must be read from the payload
+         *      using {@link Command#readFrom(Channel, byte[])}.
          */
         void handle(Command cmd);
         


### PR DESCRIPTION
Remoting Kafka Plugin implements its own Command Transport, which creates Command Instances. Proper deserialization of Commands requires setting proper classloader and a local channel instances.

There is a Command#readFrom() method which does it, but it's package-private. Also, a construction of the ObjectInputStreamEx requires package-private Channel fields.

I propose to create a public Channel#readFrom(Channel, byte[] payload) method so that it can be used externally

- [x] - Offer a new method
- [x] - Refactor existing logic to use the new method

Reference implementation: https://github.com/pvtuan10/remoting-kafka-plugin/pull/1

@pvtuan10 
