### PR TITLE
[JENKINS-52204] - Skip port availability check when -tunnel option is set

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -135,8 +135,9 @@ public class Engine extends Thread {
 	private String proxyCredentials = System.getProperty("proxyCredentials");
 
     /**
-     * See Main#tunnel in the jnlp-agent module for the details.
+     * See {@link hudson.remoting.jnlp.Main#tunnel} for the documentation.
      */
+    @CheckForNull
     private String tunnel;
 
     private boolean disableHttpsCertValidation;
@@ -305,7 +306,11 @@ public class Engine extends Thread {
         return hudsonUrl;
     }
 
-    public void setTunnel(String tunnel) {
+    /**
+     * If set, connect to the specified host and port instead of connecting directly to Jenkins.
+     * @param tunnel Value. {@code null} to disable tunneling
+     */
+    public void setTunnel(@CheckForNull String tunnel) {
         this.tunnel = tunnel;
     }
 

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -69,7 +69,7 @@ public class Main {
 
     @Option(name="-tunnel",metaVar="HOST:PORT",
             usage="Connect to the specified host and port, instead of connecting directly to Jenkins. " +
-                  "Useful when connection to Hudson needs to be tunneled. Can be also HOST: or :PORT, " +
+                  "Useful when connection to Jenkins needs to be tunneled. Can be also HOST: or :PORT, " +
                   "in which case the missing portion will be auto-configured like the default behavior")
     public String tunnel;
 

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -135,11 +135,12 @@ public class JnlpAgentEndpointResolver {
         this.proxyCredentials = user + ":" + pass;
     }
 
+    @CheckForNull
     public String getTunnel() {
         return tunnel;
     }
 
-    public void setTunnel(String tunnel) {
+    public void setTunnel(@CheckForNull String tunnel) {
         this.tunnel = tunnel;
     }
 

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -281,10 +281,17 @@ public class JnlpAgentEndpointResolver {
                     firstError = chain(firstError, new IOException(jenkinsUrl + " is publishing an invalid port"));
                     continue;
                 }
-                if (!isPortVisible(host, port, 5000)) {
-                    firstError = chain(firstError, new IOException(jenkinsUrl + " provided port:" + port
-                            + " is not reachable"));
-                    continue;
+                if (tunnel == null) {
+                    if (!isPortVisible(host, port, 5000)) {
+                        firstError = chain(firstError, new IOException(jenkinsUrl + " provided port:" + port
+                                + " is not reachable"));
+                        continue;
+                    } else {
+                        LOGGER.log(Level.FINE, "TCP Agent Listener Port availability check passed");
+                    }
+                } else {
+                    LOGGER.log(Level.INFO, "Remoting TCP connection tunneling is enabled. " +
+                            "Skipping the TCP Agent Listener Port availability check");
                 }
                 // sort the URLs so that the winner is the one we try first next time
                 final String winningJenkinsUrl = jenkinsUrl;
@@ -307,6 +314,8 @@ public class JnlpAgentEndpointResolver {
                     if (tokens[0].length() > 0) host = tokens[0];
                     if (tokens[1].length() > 0) port = Integer.parseInt(tokens[1]);
                 }
+
+                //TODO: all the checks above do not make much sense if tunneling is enabled (JENKINS-52246)
                 
                 return new JnlpAgentEndpoint(host, port, identity, agentProtocolNames, selectedJenkinsURL);
             } finally {


### PR DESCRIPTION
This is a fix for the [JENKINS-52204](https://issues.jenkins-ci.org/browse/JENKINS-52204) regression in Remoting 3.22 and Jenkins 2.129. When `-tunnel` option is set, Jenkins may be connecting to different host. So it does not make much sense to verify port availability in that case.

The issue comes from #275 . Although I believe that the current `-tunnel` behavior is rather obsolete and should be reworked/removed ([JENKINS-52246](https://issues.jenkins-ci.org/browse/JENKINS-52246)), I propose to just disable the check and restore compatibility for now

CC @denami @jeffret-b @dwnusbaum 