### PR TITLE
Add pom configuration to gpg plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -498,6 +498,12 @@ THE SOFTWARE.
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Allow it to run in unattended mode on MacOS with GPG.
Without this addition, it gives an error that looks like this:
gpg: signing failed: Inappropriate ioctl for device
gpg: signing failed: Inappropriate ioctl for device

This is kind of a weird, complicated situation. 

With the existing pom configuration, the GPG signing step under the release profile fails because of the above error. 

This change passes a command-line argument to the GPG program, which allows the maven-gpg-plugin to pass the passphrase to GPG and succeed. The passphrase can be set via property in the maven system.xml, as demonstrated here: https://gist.github.com/michaelajr/ff4693bce9fc20e5200b34683aa4ba51 . Besides setting it in the servers section as demonstrated there it is also possible to set it in the properties section of the profile with the property gpg.passphrase. Or using other mechanisms.

Interestingly, after it is successful, the GPG system caches the authorization for a time and subsequent attempts pass. In other words, the following sequence can be observed:
1. pom without this change.
2. mvn verify -Prelease
  2.1 gpg: signing failed: Inappropriate ioctl for device
3. Add this change to the pom.
4. mvn verify -Prelease
  4.1 success
5. Remove this change from the pom.
6. mvn verify -Prelease
  6.1 success
7. Time passes.
8. mvn verify -Prelease
  8.1 gpg: signing failed: Inappropriate ioctl for device

This means that it isn't entirely necessary to commit this change in order to make use of it on a temporary basis.

For unattended use, though, this change is necessary, as noted here: https://issues.apache.org/jira/browse/MGPG-59 . If run in Jenkins as part of a build server, something like this change is necessary.

There is another approach to this issue discussed here: https://github.com/pstadler/keybase-gpg-github/issues/11 . This approach works, but forces the operation into interactive mode, which is not useful in unattended use.


However, I haven't been able to find that this GPG signing is actually used anywhere. At least it hasn't been used for some time. The GPG signer is only invoked when when the release profile is specified. Under standard usage of the maven release process, the GPG signer does not get invoked. Checking the Jenkins Artifactory, I see that recent releases of remoting have not included the ".asc" files generated by GPG signing. It looks like the last release that included the ".asc" files with the GPG signatures was 3.10, over a year ago. If these libraries were also uploaded to the central maven repository, then the GPG signature files would be required.

Checking PGP signing via 
mvn com.github.s4u.plugins:pgpverify-maven-plugin:check
also shows that remoting currently lacks a PGP signature.


In conclusion, this change could be important for generating the PGP signature for remoting, but it doesn't look like having the PGP signature is important.