### PR TITLE
[JENKINS-52945] AnonymousClassWarnings should not warn about enums

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/util/AnonymousClassWarnings.java
+++ b/src/main/java/org/jenkinsci/remoting/util/AnonymousClassWarnings.java
@@ -70,7 +70,9 @@ public class AnonymousClassWarnings {
     }
 
     private static void doCheck(@Nonnull Class<?> c) {
-        if (c.isAnonymousClass()) { // e.g., pkg.Outer$1
+        if (c.isEnum()) { // e.g., com.cloudbees.plugins.credentials.CredentialsScope$1 ~ CredentialsScope.SYSTEM
+            // ignore, enums serialize specially
+        } else if (c.isAnonymousClass()) { // e.g., pkg.Outer$1
             warn(c, "anonymous");
         } else if (c.isLocalClass()) { // e.g., pkg.Outer$1Local
             warn(c, "local");

--- a/src/main/java/org/jenkinsci/remoting/util/AnonymousClassWarnings.java
+++ b/src/main/java/org/jenkinsci/remoting/util/AnonymousClassWarnings.java
@@ -70,7 +70,7 @@ public class AnonymousClassWarnings {
     }
 
     private static void doCheck(@Nonnull Class<?> c) {
-        if (c.isEnum()) { // e.g., com.cloudbees.plugins.credentials.CredentialsScope$1 ~ CredentialsScope.SYSTEM
+        if (Enum.class.isAssignableFrom(c)) { // e.g., com.cloudbees.plugins.credentials.CredentialsScope$1 ~ CredentialsScope.SYSTEM
             // ignore, enums serialize specially
         } else if (c.isAnonymousClass()) { // e.g., pkg.Outer$1
             warn(c, "anonymous");


### PR DESCRIPTION
Recently noticed this complaining about a class in `credentials` plugin, and found that the warning was spurious in that case.