### PR TITLE
Fix [JENKINS-42533] Trying to unexport already unexported object

### DIFF
--- a/src/main/java/hudson/remoting/ProxyOutputStream.java
+++ b/src/main/java/hudson/remoting/ProxyOutputStream.java
@@ -341,7 +341,7 @@ final class ProxyOutputStream extends OutputStream implements ErrorPropagatingOu
         protected void execute(final Channel channel) {
             channel.pipeWriter.submit(ioId,new Runnable() {
                 public void run() {
-                    channel.unexport(oid,createdAt);
+                    channel.unexport(oid,createdAt, false);
                 }
             });
         }

--- a/src/main/java/hudson/remoting/ProxyOutputStream.java
+++ b/src/main/java/hudson/remoting/ProxyOutputStream.java
@@ -341,7 +341,7 @@ final class ProxyOutputStream extends OutputStream implements ErrorPropagatingOu
         protected void execute(final Channel channel) {
             channel.pipeWriter.submit(ioId,new Runnable() {
                 public void run() {
-                    channel.unexport(oid,createdAt, false);
+                    channel.unexport(oid,createdAt,false);
                 }
             });
         }

--- a/src/main/java/hudson/remoting/ProxyWriter.java
+++ b/src/main/java/hudson/remoting/ProxyWriter.java
@@ -377,7 +377,7 @@ final class ProxyWriter extends Writer {
         protected void execute(final Channel channel) {
             channel.pipeWriter.submit(ioId,new Runnable() {
                 public void run() {
-                    channel.unexport(oid,createdAt, false);
+                    channel.unexport(oid,createdAt,false);
                 }
             });
         }

--- a/src/main/java/hudson/remoting/ProxyWriter.java
+++ b/src/main/java/hudson/remoting/ProxyWriter.java
@@ -377,7 +377,7 @@ final class ProxyWriter extends Writer {
         protected void execute(final Channel channel) {
             channel.pipeWriter.submit(ioId,new Runnable() {
                 public void run() {
-                    channel.unexport(oid,createdAt);
+                    channel.unexport(oid,createdAt, false);
                 }
             });
         }


### PR DESCRIPTION
See [JENKINS-42533](https://issues.jenkins-ci.org/browse/JENKINS-42533)

In rare cases, the Unexport command gets a little out of sequence and attempts to unexport an object that has already been unexported. It logs this at SEVERE level, when there is no indication of any harm. The issue is marked as minor.

Implement the fix in a similar pattern to [JENKINS-22853](https://issues.jenkins-ci.org/browse/JENKINS-22853), as noted in the PR. That fix reduced the log level for a similar message coming from the EOF command. As with that fix, it is unclear how to create a meaningful test, particularly as it is only a log level change..