### PR TITLE
Channel.notifyJar was being called too often

### DIFF
--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -6,12 +6,15 @@ import java.io.File;
 import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.OutputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Implements {@link JarLoader} to be called from the other side.
@@ -20,6 +23,9 @@ import java.util.concurrent.ConcurrentMap;
  */
 @edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_BAD_FIELD")
 class JarLoaderImpl implements JarLoader, SerializableOnlyOverRemoting {
+
+    private static final Logger LOGGER = Logger.getLogger(JarLoaderImpl.class.getName());
+
     private final ConcurrentMap<Checksum,URL> knownJars = new ConcurrentHashMap<>();
 
     @edu.umd.cs.findbugs.annotations.SuppressWarnings("DMI_COLLECTION_OF_URLS") // TODO: fix this
@@ -33,6 +39,20 @@ class JarLoaderImpl implements JarLoader, SerializableOnlyOverRemoting {
         if (url==null)
             throw new IOException("Unadvertised jar file "+k);
 
+        Channel channel = Channel.current();
+        if (channel != null) {
+            if (url.getProtocol().equals("file")) {
+                try {
+                    channel.notifyJar(new File(url.toURI()));
+                } catch (URISyntaxException | IllegalArgumentException x) {
+                    LOGGER.log(Level.WARNING, "cannot properly report " + url, x);
+                }
+            } else {
+                LOGGER.log(Level.FINE, "serving non-file URL {0}", url);
+            }
+        } else {
+            LOGGER.log(Level.WARNING, "no active channel");
+        }
         Util.copy(url.openStream(), sink);
         presentOnRemote.add(k);
     }

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -867,7 +867,6 @@ final class RemoteClassLoader extends URLClassLoader {
                         if (referer == null && !channel.jarLoader.isPresentOnRemote(sum)) {
                             // for the class being requested, if the remote doesn't have the jar yet
                             // send the image as well, so as not to require another call to get this class loaded
-                            channel.notifyJar(jar);
                             imageRef = new ResourceImageBoth(urlOfClassFile,sum);
                         } else { // otherwise just send the checksum and save space
                             imageRef = new ResourceImageInJar(sum,null /* TODO: we need to check if the URL of c points to the expected location of the file */);
@@ -948,7 +947,6 @@ final class RemoteClassLoader extends URLClassLoader {
                     Checksum sum = channel.jarLoader.calcChecksum(jar);
                     ResourceImageRef ir;
                     if (!channel.jarLoader.isPresentOnRemote(sum)) {
-                        channel.notifyJar(jar);
                         ir = new ResourceImageBoth(resource, sum);   // remote probably doesn't have
                     } else {
                         ir = new ResourceImageInJar(sum, null);


### PR DESCRIPTION
Fixes a bug in #204: the JAR loaded statistic was being triggered (AFAICT) every time the remote side wanted to use some JAR, even if it was in the local JAR cache and did not actually need to be sent.