### PR TITLE
Downgrade error messages from SynchronousCommandTransport

### DIFF
--- a/src/main/java/hudson/remoting/SynchronousCommandTransport.java
+++ b/src/main/java/hudson/remoting/SynchronousCommandTransport.java
@@ -92,7 +92,7 @@ public abstract class SynchronousCommandTransport extends CommandTransport {
                 LOGGER.log(Level.SEVERE, "I/O error in channel "+name,e);
                 channel.terminate((InterruptedIOException) new InterruptedIOException().initCause(e));
             } catch (IOException e) {
-                LOGGER.log(Level.SEVERE, "I/O error in channel "+name,e);
+                LOGGER.log(Level.INFO, "I/O error in channel "+name,e);
                 channel.terminate(e);
             } catch (RuntimeException e) {
                 LOGGER.log(Level.SEVERE, "Unexpected error in channel "+name,e);

--- a/src/main/java/hudson/remoting/SynchronousCommandTransport.java
+++ b/src/main/java/hudson/remoting/SynchronousCommandTransport.java
@@ -49,7 +49,7 @@ public abstract class SynchronousCommandTransport extends CommandTransport {
             this.receiver = receiver;
             setUncaughtExceptionHandler((t, e) -> {
                 LOGGER.log(Level.SEVERE, "Uncaught exception in SynchronousCommandTransport.ReaderThread " + t, e);
-                channel.terminate((IOException) new IOException("Unexpected reader termination").initCause(e));
+                channel.terminate(new IOException("Unexpected reader termination", e));
             });
         }
 
@@ -74,9 +74,7 @@ public abstract class SynchronousCommandTransport extends CommandTransport {
                         LOGGER.log(Level.WARNING, "Socket timeout in the Synchronous channel reader", ex);
                         continue;
                     } catch (EOFException e) {
-                        IOException ioe = new IOException("Unexpected termination of the channel");
-                        ioe.initCause(e);
-                        throw ioe;
+                        throw new IOException("Unexpected termination of the channel", e);
                     } catch (ClassNotFoundException e) {
                         LOGGER.log(Level.SEVERE, "Unable to read a command (channel " + name + ")",e);
                         continue;
@@ -96,11 +94,11 @@ public abstract class SynchronousCommandTransport extends CommandTransport {
                 channel.terminate(e);
             } catch (RuntimeException e) {
                 LOGGER.log(Level.SEVERE, "Unexpected error in channel "+name,e);
-                channel.terminate((IOException) new IOException("Unexpected reader termination").initCause(e));
+                channel.terminate(new IOException("Unexpected reader termination", e));
                 throw e;
             } catch (Error e) {
                 LOGGER.log(Level.SEVERE, "Unexpected error in channel "+name,e);
-                channel.terminate((IOException) new IOException("Unexpected reader termination").initCause(e));
+                channel.terminate(new IOException("Unexpected reader termination", e));
                 throw e;
             } finally {
                 channel.pipeWriter.shutdown();


### PR DESCRIPTION
Observing a lot of these in Evergreen coming from the `docker` plugin. Not actionable by developers (probably).