### PR TITLE
[JENKINS-53569] Remove unnecessary locking.

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/protocol/ProtocolStack.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/ProtocolStack.java
@@ -597,7 +597,6 @@ public class ProtocolStack<T> implements Closeable, ByteBufferPool {
         /**
          * Flag to track this {@link ProtocolLayer} as removed from the stack.
          */
-        @GuardedBy("ProtocolStack.stackLock")
         private boolean removed;
 
         /**
@@ -752,22 +751,7 @@ public class ProtocolStack<T> implements Closeable, ByteBufferPool {
          * Requests removal of this {@link ProtocolLayer} from the {@link ProtocolStack}
          */
         public void remove() {
-            stackLock.readLock().lock();
-            try {
-                if (removed) {
-                    return;
-                }
-                if (nextSend == null) {
-                    throw new UnsupportedOperationException("Network layer is not supposed to call remove");
-                }
-                if (nextRecv == null) {
-                    throw new UnsupportedOperationException("Application layer is not supposed to call remove");
-                }
-                // we just want to have a lock, we abuse the read lock here as the readers are eventually consistent
-                removed = true;
-            } finally {
-                stackLock.readLock().unlock();
-            }
+            removed = true;
         }
 
         /**


### PR DESCRIPTION
See [JENKINS-53569](https://issues.jenkins-ci.org/browse/JENKINS-53569) for a description of the deadlock, including stack traces of the deadlocked threads.

There is no indication that this section of code constitutes a critical section. The only meaningful thing it does is atomic and is handled elsewhere in the code by good design. The extra checks serve no significant purpose.

The code in Filter that calls this grabs a lock on Filter before it calls this meaning that it already holds one lock. If another thread grabs the lock on ProtocolStack before the Filter than a thread is always possible. Locking occurs too frequently without a strategy for preventing deadlock.

Locking is complex enough without abusing locks in weird ways.

@reviewbybees 