### PR TITLE
[JENKINS-54005] Another instance of an unnecessarily severe warning.

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -790,7 +790,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     }
 
     /*package*/ void unexport(int id, @CheckForNull Throwable cause) {
-        unexport(id, cause, true);
+        unexport(id, cause, false);
     }
     
     /**

--- a/src/main/java/hudson/remoting/ExportTable.java
+++ b/src/main/java/hudson/remoting/ExportTable.java
@@ -498,7 +498,7 @@ final class ExportTable {
      * Logs error if the object has been already unexported.
      */
     void unexportByOid(Integer oid, Throwable callSite) {
-        unexportByOid(oid, callSite, true);
+        unexportByOid(oid, callSite, false);
     }
     
     /**


### PR DESCRIPTION
See [JENKINS-54005](https://issues.jenkins-ci.org/browse/JENKINS-54005)

See also a previous PR, #283, which downgraded the message severity of an extremely similar message on related paths.

In rare cases, the Unexport command gets a little out of sequence and attempts to unexport an object that has already been unexported. It logs this at SEVERE level, when there is no indication of any harm. The issue is marked as minor.

Like that one and the one before it, this PR reduces the log level to remove the unnecessarily severe message.

Again, it is unclear how to create a meaningful test, particularly as it is only a log level change.