### PR TITLE
[JENKINS-48778] Re-work the implementation of the no_proxy capability.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,6 +119,14 @@ These properties require independent configuration on both sides of the channel.
       <td><a href="https://issues.jenkins-ci.org/browse/JENKINS-41730">JENKINS-41730</a></td>
       <td>If specified, only the protocols from the list will be tried during the connection. The option provides protocol names, but the order of the check is defined internally and cannot be changed.</td>
     </tr>
+    <tr>
+      <td>[NO_PROXY](no_proxy.md) (or no_proxy)</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></a></td>
+      <td>Provides specifications for hosts that should not be proxied. See the [NO_PROXY](no_proxy.md) page for details on supported specifications.</td>
+    </tr>
     <!--Template
     <tr>
       <td></td>

--- a/docs/no_proxy.md
+++ b/docs/no_proxy.md
@@ -1,0 +1,28 @@
+# NO_PROXY Environment Variable
+
+This optional setting provides a way to specify one or more hosts where the connection should not be proxied.
+Similar settings are available in many applications. Unfortunately, there is no standard specification across the different implementations.
+Each one defines its own syntax and supported capabilities.
+
+Remoting provides an implementation that is similar to a number of other applications and systems. Its simple rules provide
+sufficient power and flexibility for many needs.
+
+Rules:
+1. Environment variable may be named `NO_PROXY` or `no_proxy`.
+1. Different specification pieces may be separated by a comma (`,`) or a pipe (`|`).
+1. Each piece may specify an IP address, a network, or a host / domain.
+1. An IP address may be IPv4 or IPv6.
+1. An IPv6 address may be expressed in full or compressed form.
+1. A network is expressed in CIDR notation, for example, `192.168.17.0/24`.
+1. Localhost and loopback addresses are not proxied by default.
+1. All subdomains matching a domain or host are not proxied.
+1.1. A `NO_PROXY` setting of `jenkins.io` matches `repo.jenkins.io`, `sub.sub.jenkins.io`, and `jenkins.io`. It also matches `myjenkins.io`.
+1.1. The following forms are identical: `jenkins.io`, `.jenkins.io`, and `*.jenkins.io`.
+1. All other notations are ignored.
+
+## History
+
+The exact implementation has changed in different remoting versions. The 3.28 release of Remoting clarified and expanded a
+number of these capabilities. All specifications that worked prior to 3.28 should still work. Enhancements added at 3.28
+include environment variable capitalization, pipe separation, compressed
+IPv6 form, networks, and simple hostnames or root domains. The [Changelog](../CHANGELOG.md) provides information on some of the prior changes.

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.40</version>
+    <version>1.49</version>
     <relativePath />
   </parent>
 
@@ -154,18 +154,6 @@ THE SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <!-- for JRE requirement check annotation -->
       <groupId>org.jvnet</groupId>
       <artifactId>animal-sniffer-annotation</artifactId>
@@ -206,6 +194,16 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci</groupId>
       <artifactId>test-annotations</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.6</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-net</groupId>
+      <artifactId>commons-net</artifactId>
+      <version>3.6</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/hudson/remoting/NoProxyEvaluator.java
+++ b/src/main/java/hudson/remoting/NoProxyEvaluator.java
@@ -1,0 +1,155 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2018, Sun Microsystems, Inc., Kohsuke Kawaguchi, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.remoting;
+
+import org.apache.commons.net.util.SubnetUtils;
+import org.apache.http.conn.util.InetAddressUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+@Restricted(NoExternalUse.class)
+public class NoProxyEvaluator {
+
+    private static final Pattern COMMA = Pattern.compile(",");
+    private static final Pattern PIPE = Pattern.compile("\\|");
+
+    private final Set<InetAddress> noProxyIpAddresses = new HashSet<>();
+    private final Set<SubnetUtils.SubnetInfo> noProxySubnets = new HashSet<>();
+    private final Set<String> noProxyDomainsHosts = new HashSet<>();
+
+    public static boolean shouldProxy(String host) {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator(getEnvironmentValue());
+        return evaluator.shouldProxyHost(host);
+    }
+
+    NoProxyEvaluator(String noProxySpecification) {
+        if (noProxySpecification != null) {
+            processSpecificationsIntoTypes(noProxySpecification);
+        }
+    }
+
+    boolean shouldProxyHost(String host) {
+        if (host.toLowerCase(Locale.ROOT).equals("localhost")) {
+            return false;
+        }
+        if (isIpAddress(host)) {
+            try {
+                InetAddress hostAddress = InetAddress.getByName(host);
+                if (hostAddress.isLoopbackAddress()) {
+                    return false;
+                }
+                if (matchesIpAddress(hostAddress)) {
+                    return false;
+                }
+                return !matchesSubnet(host);
+            } catch (UnknownHostException e) {
+                // Could not process it so just proxy it.
+                return true;
+            }
+        }
+        return !matchesDomainHost(host);
+    }
+
+    private static String getEnvironmentValue() {
+        String noProxy = System.getenv("no_proxy");
+        if (noProxy == null) {
+            noProxy = System.getenv("NO_PROXY");
+        }
+        return noProxy;
+    }
+
+    private boolean matchesIpAddress(InetAddress hostAddress) {
+        return noProxyIpAddresses.stream().
+                anyMatch(inetAddress -> inetAddress.equals(hostAddress));
+    }
+
+    private void processSpecificationsIntoTypes(String noProxySpecification) {
+        noProxySpecification = noProxySpecification.trim();
+        String[] noProxySpecifications = splitComponents(noProxySpecification);
+        for (String specification : noProxySpecifications){
+            specification = stripLeadingStarDot(stripLeadingDot(specification.trim()));
+            if (specification.isEmpty() ) {
+                continue;
+            }
+            if (isIpAddress(specification)) {
+                try {
+                    noProxyIpAddresses.add(InetAddress.getByName(specification));
+                } catch (UnknownHostException e) {
+                    // Failed to create InetAddress.
+                }
+                continue;
+            }
+            try {
+                SubnetUtils subnetUtils = new SubnetUtils(specification);
+                SubnetUtils.SubnetInfo subnetInfo = subnetUtils.getInfo();
+                noProxySubnets.add(subnetInfo);
+                continue;
+            } catch (IllegalArgumentException iae) {
+                // Not a subnet definition.
+            }
+            noProxyDomainsHosts.add(specification);
+        }
+    }
+
+    private String[] splitComponents(String noProxySpecification) {
+        String[] noProxySpecifications;
+        if (noProxySpecification.contains(",")) {
+            noProxySpecifications = COMMA.split(noProxySpecification);
+        } else if (noProxySpecification.contains("|")) {
+            noProxySpecifications = PIPE.split(noProxySpecification);
+        } else {
+            noProxySpecifications = new String[] {noProxySpecification};
+        }
+        return noProxySpecifications;
+    }
+
+    private String stripLeadingDot(String string) {
+        return string.startsWith(".") ? string.substring(1) : string;
+    }
+
+    private String stripLeadingStarDot(String string) {
+        return string.startsWith("*.") ? string.substring(2) : string;
+    }
+
+    private boolean matchesSubnet(String host) {
+        return noProxySubnets.stream().anyMatch(subnet -> subnet.isInRange(host));
+    }
+
+    private boolean matchesDomainHost(String host) {
+        return noProxyDomainsHosts.stream().
+               anyMatch(host::endsWith);
+    }
+
+    private boolean isIpAddress(String host) {
+        return InetAddressUtils.isIPv4Address(host) || InetAddressUtils.isIPv6Address(host);
+    }
+
+}

--- a/src/main/java/hudson/remoting/Util.java
+++ b/src/main/java/hudson/remoting/Util.java
@@ -11,8 +11,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.net.ProxySelector;
-import java.net.URI;
 import java.net.URLConnection;
 import java.net.MalformedURLException;
 import java.net.Proxy;
@@ -22,7 +20,6 @@ import javax.annotation.Nonnull;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
 /**
@@ -98,75 +95,6 @@ public class Util {
     }
 
     /**
-     * Check if given URL is in the exclusion list defined by the no_proxy environment variable.
-     * On most *NIX system wildcards are not supported but if one top domain is added, all related subdomains will also
-     * be ignored. Both "mit.edu" and ".mit.edu" are valid syntax.
-     * http://www.gnu.org/software/wget/manual/html_node/Proxies.html
-     *
-     * Regexp:
-     * - \Q and \E: https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html
-     * - To match IPV4/IPV/FQDN: Regular Expressions Cookbook, 2nd Edition (ISBN: 9781449327453)
-     *
-     * Warning: this method won't match shortened representation of IPV6 address
-     */
-    public static boolean inNoProxyEnvVar(@Nonnull  String host) {
-        String noProxy = System.getenv("no_proxy");
-        if (noProxy != null) {
-            noProxy = noProxy.trim()
-                    // Remove spaces
-                    .replaceAll("\\s+", "")
-                    // Convert .foobar.com to foobar.com
-                    .replaceAll("((?<=^|,)\\.)*(([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,})(?=($|,))", "$2");
-
-            if (!noProxy.isEmpty()) {
-                // IPV4 and IPV6
-                if (host.matches("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$") || host.matches("^(?:[a-fA-F0-9]{1,4}:){7}[a-fA-F0-9]{1,4}$")) {
-                    return noProxy.matches(".*(^|,)\\Q" + host + "\\E($|,).*");
-                }
-                else {
-                    int depth = 0;
-                    String originalHost = host;
-                    // Loop while we have a valid domain name: acme.com
-                    // We add a safeguard to avoid a case where the host would always be valid because the regex would
-                    // for example fail to remove subdomains.
-                    // According to Wikipedia (no RFC defines it), 128 is the max number of subdivision for a valid FQDN:
-                    // https://en.wikipedia.org/wiki/Subdomain#Overview
-                    while (host.matches("^([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,}$") && depth < 128) {
-                        ++depth;
-                        // Check if the no_proxy contains the host
-                        if (noProxy.matches(".*(^|,)\\Q" + host + "\\E($|,).*"))
-                            return true;
-                        // Remove first subdomain: master.jenkins.acme.com -> jenkins.acme.com
-                        host = host.replaceFirst("^[a-z0-9]+(-[a-z0-9]+)*\\.", "");
-                    }
-                    
-                    String[] noProxyArray = noProxy.split(",");
-                    // fix for https://issues.jenkins-ci.org/browse/JENKINS-51223, basic suffix match
-                    if (depth > 0 && suffixMatch(originalHost, noProxyArray)) {
-                    	return true;
-                    }
-                }
-            }
-        }
-
-        return false;
-    }
-
-    // fix for https://issues.jenkins-ci.org/browse/JENKINS-51223
-    // adds curl-like algorithm for matching to existing regexp used in
-    // inNoProxyEnvVars
-    static boolean suffixMatch(String host, String[] noProxyArray) {
-		for (String proxy : noProxyArray) {
-			// still needs to capture some form of subdomain, like ".svc"
-			if (!proxy.contains("."))
-				continue;
-			if (host.endsWith(proxy))
-				return true;
-		}
-		return false;
-	}
-
-    /**
      * Gets URL connection.
      * If http_proxy environment variable exists,  the connection uses the proxy.
      * Credentials can be passed e.g. to support running Jenkins behind a (reverse) proxy requiring authorization
@@ -178,7 +106,7 @@ public class Util {
             httpProxy = System.getenv("http_proxy");
         }
         URLConnection con = null;
-        if (httpProxy != null && "http".equals(url.getProtocol()) && !inNoProxyEnvVar(url.getHost())) {
+        if (httpProxy != null && "http".equals(url.getProtocol()) && NoProxyEvaluator.shouldProxy(url.getHost())) {
             try {
                 URL proxyUrl = new URL(httpProxy);
                 SocketAddress addr = new InetSocketAddress(proxyUrl.getHost(), proxyUrl.getPort());

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -24,6 +24,7 @@
 package org.jenkinsci.remoting.engine;
 
 import hudson.remoting.Base64;
+import hudson.remoting.NoProxyEvaluator;
 import hudson.remoting.Util;
 
 import org.jenkinsci.remoting.util.https.NoCheckHostnameVerifier;
@@ -543,7 +544,7 @@ public class JnlpAgentEndpointResolver {
     }
 
     static boolean inNoProxyEnvVar(String host) {
-    	return Util.inNoProxyEnvVar(host);
+    	return !NoProxyEvaluator.shouldProxy(host);
     }
 
     @CheckForNull

--- a/src/test/java/hudson/remoting/NoProxyEvaluatorTest.java
+++ b/src/test/java/hudson/remoting/NoProxyEvaluatorTest.java
@@ -1,0 +1,251 @@
+package hudson.remoting;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class NoProxyEvaluatorTest {
+
+    @Test
+    public void testWrongIPV4() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("127.0.0.1");
+
+        assertTrue(evaluator.shouldProxyHost("10.0.0.1"));
+    }
+
+    @Test
+    public void testIPV6() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+        assertFalse(evaluator.shouldProxyHost("2001:0db8:85a3:0000:0000:8a2e:0370:7334"));
+    }
+
+    @Test
+    public void testWrongIPV6() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("0:0:0:0:0:0:0:1");
+
+        assertTrue(evaluator.shouldProxyHost("2001:0db8:85a3:0000:0000:8a2e:0370:7334"));
+    }
+
+    @Test
+    public void testFQDN() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("foobar.com");
+
+        assertFalse(evaluator.shouldProxyHost("foobar.com"));
+        assertFalse(evaluator.shouldProxyHost("sub.foobar.com"));
+        assertFalse(evaluator.shouldProxyHost("sub.sub.foobar.com"));
+
+        assertTrue(evaluator.shouldProxyHost("foobar.org"));
+        assertTrue(evaluator.shouldProxyHost("jenkins.com"));
+    }
+
+    @Test
+    public void testSubFQDN() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("sub.foobar.com");
+
+        assertFalse(evaluator.shouldProxyHost("sub.foobar.com"));
+        assertFalse(evaluator.shouldProxyHost("sub.sub.foobar.com"));
+
+        assertTrue(evaluator.shouldProxyHost("foobar.com"));
+    }
+
+    @Test
+    public void testFQDNWithDot() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator(".foobar.com");
+
+        assertFalse(evaluator.shouldProxyHost("foobar.com"));
+        assertFalse(evaluator.shouldProxyHost("sub.foobar.com"));
+        assertFalse(evaluator.shouldProxyHost("sub.sub.foobar.com"));
+
+        assertTrue(evaluator.shouldProxyHost("foobar.org"));
+        assertTrue(evaluator.shouldProxyHost("jenkins.com"));
+    }
+
+    @Test
+    public void testSubFQDNWithDot() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator(".sub.foobar.com");
+
+        assertFalse(evaluator.shouldProxyHost("sub.foobar.com"));
+        assertFalse(evaluator.shouldProxyHost("sub.sub.foobar.com"));
+
+        assertTrue(evaluator.shouldProxyHost("foobar.com"));
+    }
+
+    @Test
+    public void testSubFWDNWithDotMinimalSuffix() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator(".svc");
+
+        assertFalse(evaluator.shouldProxyHost("bn-myproj.svc"));
+    }
+
+    @Test
+    public void testSubFWDNWithDotMinimalSuffixMixedCase() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator(".svc,.default,.local,localhost,.boehringer.com,10.250.0.0/16,10.251.0.0/16,10.183.195.106,10.183.195.107,10.183.195.108,10.183.195.109,10.183.195.11,10.183.195.111,10.183.195.112,10.183.195.113,10.183.195.13,10.250.127.");
+
+        assertFalse(evaluator.shouldProxyHost("bn-myproj.svc"));
+    }
+
+    @Test
+    public void testWithInvalidCharsMatching() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("foo+.co=m");
+
+        assertFalse(evaluator.shouldProxyHost("foo+.co=m"));
+    }
+
+    @Test
+    public void testWithInvalidCharsNonMatching() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("foo+.co=m");
+
+        assertTrue(evaluator.shouldProxyHost("foo.com"));
+    }
+
+    @Test
+    public void testMixed() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator(" 127.0.0.1,  0:0:0:0:0:0:0:1,\tfoobar.com, .jenkins.com");
+
+        assertFalse(evaluator.shouldProxyHost("127.0.0.1"));
+        assertFalse(evaluator.shouldProxyHost("0:0:0:0:0:0:0:1"));
+        assertFalse(evaluator.shouldProxyHost("foobar.com"));
+        assertFalse(evaluator.shouldProxyHost("sub.foobar.com"));
+        assertFalse(evaluator.shouldProxyHost("sub.jenkins.com"));
+
+        assertTrue(evaluator.shouldProxyHost("foobar.org"));
+        assertTrue(evaluator.shouldProxyHost("jenkins.org"));
+        assertTrue(evaluator.shouldProxyHost("sub.foobar.org"));
+        assertTrue(evaluator.shouldProxyHost("sub.jenkins.org"));
+    }
+
+    @Test
+    public void testSimpleHostname() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("jenkinsmaster");
+
+        assertFalse(evaluator.shouldProxyHost("jenkinsmaster"));
+    }
+
+    @Test
+    public void testIPv4Loopback() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator(null);
+
+        assertFalse(evaluator.shouldProxyHost("127.0.0.1"));
+    }
+
+    @Test
+    public void testIPv6LoopbackAbbreviated() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator(null);
+
+        assertFalse(evaluator.shouldProxyHost("::1"));
+    }
+
+    @Test
+    public void testIPv6LoopbackFullLength() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator(null);
+
+        assertFalse(evaluator.shouldProxyHost("0000:0000:0000:0000:0000:0000:0000:0001"));
+    }
+
+    @Test
+    public void testLocalhost() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator(null);
+
+        assertFalse(evaluator.shouldProxyHost("localhost"));
+    }
+
+    @Test
+    public void testNullSpecification() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator(null);
+
+        assertTrue(evaluator.shouldProxyHost("jenkins.io"));
+    }
+
+    @Test
+    public void testEmptySpecification() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("");
+
+        assertTrue(evaluator.shouldProxyHost("jenkins.io"));
+    }
+
+    @Test
+    public void testBlankSpecification() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("    ");
+
+        assertTrue(evaluator.shouldProxyHost("jenkins.io"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullHost() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("jenkins.io");
+
+        assertTrue(evaluator.shouldProxyHost(null));
+    }
+
+    @Test
+    public void testEmptyHost() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("jenkins.io");
+
+        assertTrue(evaluator.shouldProxyHost(""));
+    }
+
+    @Test
+    public void testBlankHost() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("jenkins.io");
+
+        assertTrue(evaluator.shouldProxyHost("     "));
+    }
+
+    @Test
+    public void testCidrWithin() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("1.232.12.0/20");
+
+        assertFalse(evaluator.shouldProxyHost("1.232.12.3"));
+    }
+
+    @Test
+    public void testCidrBelow() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("1.232.12.0/20");
+
+        assertFalse(evaluator.shouldProxyHost("1.232.11.3"));
+    }
+
+    @Test
+    public void testCidrAbove() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("1.232.12.0/24");
+
+        assertTrue(evaluator.shouldProxyHost("1.232.13.3"));
+    }
+
+    @Test
+    public void testJavaStyleSeparator() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("foobar.com| .jenkins.io");
+
+        assertFalse(evaluator.shouldProxyHost("sub.foobar.com"));
+        assertFalse(evaluator.shouldProxyHost("repo.jenkins.io"));
+        assertTrue(evaluator.shouldProxyHost("foo.com"));
+    }
+
+    @Test
+    public void testMixedSeparators() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("foobar.com| .jenkins.io,fred.com");
+
+        assertFalse(evaluator.shouldProxyHost("sub.fred.com"));
+        assertTrue(evaluator.shouldProxyHost("sub.foobar.com"));
+        assertTrue(evaluator.shouldProxyHost("repo.jenkins.io"));
+        assertTrue(evaluator.shouldProxyHost("foo.com"));
+    }
+
+    @Test
+    public void testIPv6Full() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("2001:0db8:0a0b:12f0:0000:0000:0000:0001");
+
+        assertFalse(evaluator.shouldProxyHost("2001:0db8:0a0b:12f0:0000:0000:0000:0001"));
+        assertFalse(evaluator.shouldProxyHost("2001:0db8:0a0b:12f0::0001"));
+    }
+
+    @Test
+    public void testIPv6Compressed() {
+        NoProxyEvaluator evaluator = new NoProxyEvaluator("2001:0db8:0a0b:12f0::0001");
+
+        assertFalse(evaluator.shouldProxyHost("2001:0db8:0a0b:12f0:0000:0000:0000:0001"));
+        assertFalse(evaluator.shouldProxyHost("2001:0db8:0a0b:12f0::0001"));
+    }
+
+}

--- a/src/test/java/hudson/remoting/UtilTest.java
+++ b/src/test/java/hudson/remoting/UtilTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, Schneider Electric
+ * Copyright (c) 2016-2018, Schneider Electric, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,160 +24,21 @@
 
 package hudson.remoting;
 
-import junit.framework.TestCase;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.IOException;
 
+import static org.junit.Assert.*;
+
 /**
  * @author Etienne Bec
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(Util.class)
-public class UtilTest extends TestCase {
+public class UtilTest {
 
     @Rule public TemporaryFolder temp = new TemporaryFolder();
-
-    @Before
-    public void mockSystem() {
-        PowerMockito.mockStatic(System.class);
-    }
-
-    @Test
-    public void testIPV4() {
-        PowerMockito.when(System.getenv("no_proxy")).thenReturn("10.0.0.1");
-
-        assertEquals(true, Util.inNoProxyEnvVar("10.0.0.1"));
-    }
-
-    @Test
-    public void testWrongIPV4() {
-        PowerMockito.when(System.getenv("no_proxy")).thenReturn("127.0.0.1");
-
-        assertEquals(false, Util.inNoProxyEnvVar("10.0.0.1"));
-    }
-
-    @Test
-    public void testIPV6() {
-        PowerMockito.when(System.getenv("no_proxy")).thenReturn("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
-        assertEquals(true, Util.inNoProxyEnvVar("2001:0db8:85a3:0000:0000:8a2e:0370:7334"));
-    }
-
-    @Test
-    public void testWrongIPV6() {
-        PowerMockito.when(System.getenv("no_proxy")).thenReturn("0:0:0:0:0:0:0:1");
-
-        assertEquals(false, Util.inNoProxyEnvVar("2001:0db8:85a3:0000:0000:8a2e:0370:7334"));
-    }
-
-    @Test
-    public void testFQDN() {
-        PowerMockito.when(System.getenv("no_proxy")).thenReturn("foobar.com");
-
-        assertEquals(true, Util.inNoProxyEnvVar("foobar.com"));
-        assertEquals(true, Util.inNoProxyEnvVar("sub.foobar.com"));
-        assertEquals(true, Util.inNoProxyEnvVar("sub.sub.foobar.com"));
-
-        assertEquals(false, Util.inNoProxyEnvVar("foobar.org"));
-        assertEquals(false, Util.inNoProxyEnvVar("jenkins.com"));
-    }
-
-    @Test
-    public void testSubFQDN() {
-        PowerMockito.when(System.getenv("no_proxy")).thenReturn("sub.foobar.com");
-
-        assertEquals(true, Util.inNoProxyEnvVar("sub.foobar.com"));
-        assertEquals(true, Util.inNoProxyEnvVar("sub.sub.foobar.com"));
-
-        assertEquals(false, Util.inNoProxyEnvVar("foobar.com"));
-    }
-
-    @Test
-    public void testFQDNWithDot() {
-        PowerMockito.when(System.getenv("no_proxy")).thenReturn(".foobar.com");
-
-        assertEquals(true, Util.inNoProxyEnvVar("foobar.com"));
-        assertEquals(true, Util.inNoProxyEnvVar("sub.foobar.com"));
-        assertEquals(true, Util.inNoProxyEnvVar("sub.sub.foobar.com"));
-
-        assertEquals(false, Util.inNoProxyEnvVar("foobar.org"));
-        assertEquals(false, Util.inNoProxyEnvVar("jenkins.com"));
-    }
-
-    @Test
-    public void testSubFQDNWithDot() {
-        PowerMockito.when(System.getenv("no_proxy")).thenReturn(".sub.foobar.com");
-
-        assertEquals(true, Util.inNoProxyEnvVar("sub.foobar.com"));
-        assertEquals(true, Util.inNoProxyEnvVar("sub.sub.foobar.com"));
-
-        assertEquals(false, Util.inNoProxyEnvVar("foobar.com"));
-    }
-    
-    @Test
-    public void testSubFWDNWithDotMinimalSuffix() {
-    	PowerMockito.when(System.getenv("no_proxy")).thenReturn(".svc");
-    	
-    	assertEquals(true, Util.inNoProxyEnvVar("bn-myproj.svc"));
-    }
-
-    @Test
-    public void testSubFWDNWithDotMinimalSuffixMixedCase() {
-    	PowerMockito.when(System.getenv("no_proxy")).thenReturn(".svc,.default,.local,localhost,.boehringer.com,10.250.0.0/16,10.251.0.0/16,10.183.195.106,10.183.195.107,10.183.195.108,10.183.195.109,10.183.195.11,10.183.195.111,10.183.195.112,10.183.195.113,10.183.195.13,10.250.127.");
-    	
-    	assertEquals(true, Util.inNoProxyEnvVar("bn-myproj.svc"));
-    }
-
-    @Test
-    public void testNoProxyWithInvalidChars() {
-        PowerMockito.when(System.getenv("no_proxy")).thenReturn("foo+.co=m");
-
-        assertEquals(false, Util.inNoProxyEnvVar("foo+.co=m"));
-    }
-
-    @Test
-    public void testNoProxyWithInvalidChar() {
-        PowerMockito.when(System.getenv("no_proxy")).thenReturn("foo.co=m");
-
-        assertEquals(false, Util.inNoProxyEnvVar("foo.co=m"));
-    }
-
-    @Test
-    public void testNoProxyWithInvalidCharInMinimalSuffix() {
-        PowerMockito.when(System.getenv("no_proxy")).thenReturn(".sv=c");
-
-        assertEquals(false, Util.inNoProxyEnvVar("foo.sv=c"));
-    }
-    @Test
-    public void testSubFWDNWithoutDotMinimalSuffix() {
-    	PowerMockito.when(System.getenv("no_proxy")).thenReturn("svc");
-    	
-    	assertEquals(false, Util.inNoProxyEnvVar("bn-myproj.svc"));
-    }
-
-    @Test
-    public void testMixed() {
-        PowerMockito.when(System.getenv("no_proxy")).thenReturn(" 127.0.0.1,  0:0:0:0:0:0:0:1,\tfoobar.com, .jenkins.com");
-
-        assertEquals(true, Util.inNoProxyEnvVar("127.0.0.1"));
-        assertEquals(true, Util.inNoProxyEnvVar("0:0:0:0:0:0:0:1"));
-        assertEquals(true, Util.inNoProxyEnvVar("foobar.com"));
-        assertEquals(true, Util.inNoProxyEnvVar("sub.foobar.com"));
-        assertEquals(true, Util.inNoProxyEnvVar("sub.jenkins.com"));
-
-        assertEquals(false, Util.inNoProxyEnvVar("foobar.org"));
-        assertEquals(false, Util.inNoProxyEnvVar("jenkins.org"));
-        assertEquals(false, Util.inNoProxyEnvVar("sub.foobar.org"));
-        assertEquals(false, Util.inNoProxyEnvVar("sub.jenkins.org"));
-    }
 
     @Test
     public void mkdirs() throws IOException {


### PR DESCRIPTION
See [JENKINS-48778](https://issues.jenkins-ci.org/browse/JENKINS-48778)

We've had several issues submitted against the no_proxy implementation in Remoting. We resolved one a couple of months ago. Implementing that one turned out to be harder and less clean than it needed to be. As I started working on this one, I realized the area could use some restructuring, improved capabilities, and better documentation.

Unfortunately, there isn't a single standard or reference on how no_proxy should behave. Implementations and rules vary by application or system. I modeled this proposal after [this](https://github.com/golang/go/issues/16704#issuecomment-312502347) well-researched proposal for Go. There are a few differences.

This new version should retain all existing capabilities. If something worked before to specify a no_proxy system, that should continue working. This introduces a few new formats and rules, such as subnets and compressed IPv6. It also relaxes a correctness check that doesn't need to be performed at this level.

@reviewbybees 