### PR TITLE
[JENKINS-49987] Clean up warnings about anonymous callable.

### DIFF
--- a/src/main/java/hudson/remoting/forward/ForwarderFactory.java
+++ b/src/main/java/hudson/remoting/forward/ForwarderFactory.java
@@ -52,18 +52,7 @@ public class ForwarderFactory {
      * Creates a connector on the remote side that connects to the speicied host and port.
      */
     public static Forwarder create(VirtualChannel channel, final String remoteHost, final int remotePort) throws IOException, InterruptedException {
-        return channel.call(new Callable<Forwarder,IOException>() {
-            public Forwarder call() throws IOException {
-                return new ForwarderImpl(remoteHost,remotePort);
-            }
-
-            @Override
-            public void checkRoles(RoleChecker checker) throws SecurityException {
-                checker.check(this,ROLE);
-            }
-
-            private static final long serialVersionUID = 1L;
-        });
+        return channel.call(new ForwarderCallable(remoteHost, remotePort));
     }
 
     public static Forwarder create(String remoteHost, int remotePort) {
@@ -111,4 +100,25 @@ public class ForwarderFactory {
      * Role that's willing to open a socket to arbitrary node nad forward that to the other side.
      */
     public static final Role ROLE = new Role(ForwarderFactory.class);
+
+    private static class ForwarderCallable implements Callable<Forwarder,IOException> {
+
+        private static final long serialVersionUID = 1L;
+        private final String remoteHost;
+        private final int remotePort;
+
+        public ForwarderCallable(String remoteHost, int remotePort) {
+            this.remoteHost = remoteHost;
+            this.remotePort = remotePort;
+        }
+
+        public Forwarder call() throws IOException {
+            return new ForwarderImpl(remoteHost, remotePort);
+        }
+
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            checker.check(this,ROLE);
+        }
+    }
 }

--- a/src/main/java/hudson/remoting/forward/ForwarderFactory.java
+++ b/src/main/java/hudson/remoting/forward/ForwarderFactory.java
@@ -118,7 +118,7 @@ public class ForwarderFactory {
 
         @Override
         public void checkRoles(RoleChecker checker) throws SecurityException {
-            checker.check(this,ROLE);
+            checker.check(this, ROLE);
         }
     }
 }

--- a/src/main/java/hudson/remoting/forward/PortForwarder.java
+++ b/src/main/java/hudson/remoting/forward/PortForwarder.java
@@ -161,7 +161,7 @@ public class PortForwarder extends Thread implements Closeable, ListeningPort {
 
         @Override
         public void checkRoles(RoleChecker checker) throws SecurityException {
-            checker.check(this,ROLE);
+            checker.check(this, ROLE);
         }
     }
 }

--- a/src/main/java/hudson/remoting/forward/PortForwarder.java
+++ b/src/main/java/hudson/remoting/forward/PortForwarder.java
@@ -132,19 +132,7 @@ public class PortForwarder extends Thread implements Closeable, ListeningPort {
         // need a remotable reference
         final Forwarder proxy = ch.export(Forwarder.class, forwarder);
 
-        return ch.call(new Callable<ListeningPort,IOException>() {
-            public ListeningPort call() throws IOException {
-                final Channel channel = getOpenChannelOrFail(); // We initialize it early, so the forwarder won's start its daemon if the channel is shutting down
-                PortForwarder t = new PortForwarder(acceptingPort, proxy);
-                t.start();
-                return channel.export(ListeningPort.class,t);
-            }
-
-            @Override
-            public void checkRoles(RoleChecker checker) throws SecurityException {
-                checker.check(this,ROLE);
-            }
-        });
+        return ch.call(new ListeningPortCallable(acceptingPort, proxy));
     }
 
     private static final Logger LOGGER = Logger.getLogger(PortForwarder.class.getName());
@@ -153,4 +141,27 @@ public class PortForwarder extends Thread implements Closeable, ListeningPort {
      * Role that's willing to listen on a socket and forward that to the other side.
      */
     public static final Role ROLE = new Role(PortForwarder.class);
+
+    private static class ListeningPortCallable implements Callable<ListeningPort,IOException> {
+        private static final long serialVersionUID = 1L;
+        private final int acceptingPort;
+        private final Forwarder proxy;
+
+        public ListeningPortCallable(int acceptingPort, Forwarder proxy) {
+            this.acceptingPort = acceptingPort;
+            this.proxy = proxy;
+        }
+
+        public ListeningPort call() throws IOException {
+            final Channel channel = getOpenChannelOrFail(); // We initialize it early, so the forwarder won's start its daemon if the channel is shutting down
+            PortForwarder t = new PortForwarder(acceptingPort, proxy);
+            t.start();
+            return channel.export(ListeningPort.class,t);
+        }
+
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            checker.check(this,ROLE);
+        }
+    }
 }

--- a/src/test/java/hudson/remoting/ClassFilterTest.java
+++ b/src/test/java/hudson/remoting/ClassFilterTest.java
@@ -160,13 +160,7 @@ public class ClassFilterTest implements Serializable {
      */
     private void fire(String name, Channel from) throws Exception {
         final Security218 a = new Security218(name);
-        from.call(new CallableBase<Void, IOException>() {
-            @Override
-            public Void call() throws IOException {
-                a.toString();   // this will ensure 'a' gets sent over
-                return null;
-            }
-        });
+        from.call(new Security218Callable(a));
     }
 
     /**
@@ -280,5 +274,19 @@ public class ClassFilterTest implements Serializable {
 
     private void clearRecord() {
         System.setProperty("attack", "");
+    }
+
+    private static class Security218Callable extends CallableBase<Void, IOException> {
+        private final Security218 a;
+
+        public Security218Callable(Security218 a) {
+            this.a = a;
+        }
+
+        @Override
+        public Void call() throws IOException {
+            a.toString();   // this will ensure 'a' gets sent over
+            return null;
+        }
     }
 }

--- a/src/test/java/hudson/remoting/PipeTest.java
+++ b/src/test/java/hudson/remoting/PipeTest.java
@@ -266,13 +266,7 @@ public class PipeTest extends RmiTestBase implements Serializable {
      */
     public void testQuickBurstWrite() throws Exception {
         final Pipe p = Pipe.createLocalToRemote();
-        Future<Integer> f = channel.callAsync(new CallableBase<Integer, IOException>() {
-            public Integer call() throws IOException {
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                IOUtils.copy(p.getIn(), baos);
-                return baos.size();
-            }
-        });
+        Future<Integer> f = channel.callAsync(new QuickBurstCallable(p));
         OutputStream os = p.getOut();
         os.write(1);
         os.close();
@@ -296,5 +290,19 @@ public class PipeTest extends RmiTestBase implements Serializable {
 
     private Object writeReplace() {
         return null;
+    }
+
+    private static class QuickBurstCallable extends CallableBase<Integer, IOException> {
+        private final Pipe p;
+
+        public QuickBurstCallable(Pipe p) {
+            this.p = p;
+        }
+
+        public Integer call() throws IOException {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            IOUtils.copy(p.getIn(), baos);
+            return baos.size();
+        }
     }
 }

--- a/src/test/java/hudson/remoting/PipeWriterTest.java
+++ b/src/test/java/hudson/remoting/PipeWriterTest.java
@@ -75,11 +75,7 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
      * coordinated.
      */
     public void testResponseIoCoord() throws Exception {
-        channel.call(new ResponseIoCoordCallable() {
-            void touch() throws IOException {
-                ros.write(0);
-            }
-        });
+        channel.call(new ResponseCallableWriter());
         // but I/O should be complete before the call returns.
         assertTrue(slow.written);
     }
@@ -88,11 +84,7 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
      * Ditto for {@link OutputStream#flush()}
      */
     public void testResponseIoCoordFlush() throws Exception {
-        channel.call(new ResponseIoCoordCallable() {
-            void touch() throws IOException {
-                ros.flush();
-            }
-        });
+        channel.call(new ResponseCallableFlusher());
         assertTrue(slow.flushed);
     }
 
@@ -100,11 +92,7 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
      * Ditto for {@link OutputStream#close()}
      */
     public void testResponseIoCoordClose() throws Exception {
-        channel.call(new ResponseIoCoordCallable() {
-            void touch() throws IOException {
-                ros.close();
-            }
-        });
+        channel.call(new ResponseCallableCloser());
         assertTrue(slow.closed);
     }
 
@@ -131,29 +119,17 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
     }
 
     public void testRequestIoCoord() throws Exception {
-        channel.call(new RequestIoCoordCallable() {
-            void touch() throws IOException {
-                ros.write(0);
-            }
-        });
+        channel.call(new RequestCallableWriter());
         assertSlowStreamTouched();
     }
 
     public void testRequestIoCoordFlush() throws Exception {
-        channel.call(new RequestIoCoordCallable() {
-            void touch() throws IOException {
-                ros.flush();
-            }
-        });
+        channel.call(new RequestCallableFlusher());
         assertSlowStreamTouched();
     }
 
     public void testRequestIoCoordClose() throws Exception {
-        channel.call(new RequestIoCoordCallable() {
-            void touch() throws IOException {
-                ros.close();
-            }
-        });
+        channel.call(new RequestCallableCloser());
         assertSlowStreamTouched();
     }
 
@@ -197,6 +173,42 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
             } catch (InterruptedException e) {
                 throw new InterruptedIOException();
             }
+        }
+    }
+
+    private class ResponseCallableWriter extends ResponseIoCoordCallable {
+        void touch() throws IOException {
+            ros.write(0);
+        }
+    }
+
+    private class ResponseCallableFlusher extends ResponseIoCoordCallable {
+        void touch() throws IOException {
+            ros.flush();
+        }
+    }
+
+    private class ResponseCallableCloser extends ResponseIoCoordCallable {
+        void touch() throws IOException {
+            ros.close();
+        }
+    }
+
+    private class RequestCallableWriter extends RequestIoCoordCallable {
+        void touch() throws IOException {
+            ros.write(0);
+        }
+    }
+
+    private class RequestCallableFlusher extends RequestIoCoordCallable {
+        void touch() throws IOException {
+            ros.flush();
+        }
+    }
+
+    private class RequestCallableCloser extends RequestIoCoordCallable {
+        void touch() throws IOException {
+            ros.close();
         }
     }
 }

--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -45,12 +45,7 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
         dir.mkdirs();
 
         channel.setJarCache(new FileSystemJarCache(dir, true));
-        channel.call(new CallableBase<Void, IOException>() {
-            public Void call() throws IOException {
-                Channel.currentOrFail().setJarCache(new FileSystemJarCache(dir, true));
-                return null;
-            }
-        });
+        channel.call(new JarCacherCallable());
         sum1 = channel.jarLoader.calcChecksum(jar1);
         sum2 = channel.jarLoader.calcChecksum(jar2);
     }
@@ -233,6 +228,13 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
             } catch (ExecutionException e) {
                 throw new IOException(e);
             }
+        }
+    }
+
+    private class JarCacherCallable extends CallableBase<Void, IOException> {
+        public Void call() throws IOException {
+            Channel.currentOrFail().setJarCache(new FileSystemJarCache(dir, true));
+            return null;
         }
     }
 }

--- a/src/test/java/hudson/remoting/ProxyWriterTest.java
+++ b/src/test/java/hudson/remoting/ProxyWriterTest.java
@@ -165,7 +165,7 @@ public class ProxyWriterTest extends RmiTestBase implements Serializable {
     private static class GcCallable extends CallableBase<Boolean, IOException> {
         public Boolean call() throws IOException {
             System.gc();
-            return W.get()==null;
+            return W.get() == null;
         }
     }
 
@@ -177,7 +177,7 @@ public class ProxyWriterTest extends RmiTestBase implements Serializable {
         }
 
         public Void call() throws IOException {
-            w.write("1--",0,1);
+            w.write("1--", 0, 1);
             return null;
         }
     }

--- a/src/test/java/hudson/remoting/ProxyWriterTest.java
+++ b/src/test/java/hudson/remoting/ProxyWriterTest.java
@@ -51,12 +51,7 @@ public class ProxyWriterTest extends RmiTestBase implements Serializable {
         StringWriter sw = new StringWriter();
         final RemoteWriter w = new RemoteWriter(sw);
 
-        channel.call(new CallableBase<Void, IOException>() {
-            public Void call() throws IOException {
-                writeBunchOfData(w);
-                return null;
-            }
-        });
+        channel.call(new WriteBunchOfDataCallable(w));
 
         StringWriter correct = new StringWriter();
         writeBunchOfData(correct);
@@ -96,13 +91,7 @@ public class ProxyWriterTest extends RmiTestBase implements Serializable {
         };
         final RemoteWriter w = new RemoteWriter(sw);
 
-        channel.call(new CallableBase<Void, IOException>() {
-            public Void call() throws IOException {
-                w.write("hello");
-                W = new WeakReference<RemoteWriter>(w);
-                return null;
-            }
-        });
+        channel.call(new WeakReferenceCallable(w));
 
         // induce a GC. There's no good reliable way to do this,
         // and if GC doesn't happen within this loop, the test can pass
@@ -111,12 +100,7 @@ public class ProxyWriterTest extends RmiTestBase implements Serializable {
             assertTrue("There shouldn't be any errors: " + log.toString(), log.size() == 0);
 
             Thread.sleep(100);
-            if (channel.call(new CallableBase<Boolean, IOException>() {
-                public Boolean call() throws IOException {
-                    System.gc();
-                    return W.get()==null;
-                }
-            }))
+            if (channel.call(new GcCallable()))
                 break;
         }
 
@@ -136,12 +120,7 @@ public class ProxyWriterTest extends RmiTestBase implements Serializable {
         final RemoteWriter w = new RemoteWriter(sw);
 
         for (int i=0; i<16; i++) {
-            channel.call(new CallableBase<Void, IOException>() {
-                public Void call() throws IOException {
-                    w.write("1--",0,1);
-                    return null;
-                }
-            });
+            channel.call(new WriterCallable(w));
             w.write("2");
         }
 
@@ -154,5 +133,52 @@ public class ProxyWriterTest extends RmiTestBase implements Serializable {
 
     public static Test suite() throws Exception {
         return buildSuite(ProxyWriterTest.class);
+    }
+
+    private static class WriteBunchOfDataCallable extends CallableBase<Void, IOException> {
+        private final RemoteWriter w;
+
+        public WriteBunchOfDataCallable(RemoteWriter w) {
+            this.w = w;
+        }
+
+        public Void call() throws IOException {
+            writeBunchOfData(w);
+            return null;
+        }
+    }
+
+    private static class WeakReferenceCallable extends CallableBase<Void, IOException> {
+        private final RemoteWriter w;
+
+        public WeakReferenceCallable(RemoteWriter w) {
+            this.w = w;
+        }
+
+        public Void call() throws IOException {
+            w.write("hello");
+            W = new WeakReference<RemoteWriter>(w);
+            return null;
+        }
+    }
+
+    private static class GcCallable extends CallableBase<Boolean, IOException> {
+        public Boolean call() throws IOException {
+            System.gc();
+            return W.get()==null;
+        }
+    }
+
+    private static class WriterCallable extends CallableBase<Void, IOException> {
+        private final RemoteWriter w;
+
+        public WriterCallable(RemoteWriter w) {
+            this.w = w;
+        }
+
+        public Void call() throws IOException {
+            w.write("1--",0,1);
+            return null;
+        }
     }
 }

--- a/src/test/java/hudson/remoting/throughput/Sender.java
+++ b/src/test/java/hudson/remoting/throughput/Sender.java
@@ -41,11 +41,7 @@ public class Sender {
                     new BufferedOutputStream(SocketChannelStream.out(s)));
 
             final Pipe p = Pipe.createLocalToRemote();
-            Future<byte[]> f = ch.callAsync(new CallableBase<byte[], Throwable>() {
-                public byte[] call() throws Exception {
-                    return digest(p.getIn());
-                }
-            });
+            Future<byte[]> f = ch.callAsync(new DigestCallable(p));
 
             System.out.println("Started");
             long start = System.nanoTime();
@@ -72,5 +68,17 @@ public class Sender {
         byte[] buf = new byte[10*1024*1024];
         new Random(0).nextBytes(buf);
         return buf;
+    }
+
+    private static class DigestCallable extends CallableBase<byte[], Throwable> {
+        private final Pipe p;
+
+        public DigestCallable(Pipe p) {
+            this.p = p;
+        }
+
+        public byte[] call() throws Exception {
+            return digest(p.getIn());
+        }
     }
 }

--- a/src/test/java/org/jenkinsci/remoting/nio/SocketClientMain.java
+++ b/src/test/java/org/jenkinsci/remoting/nio/SocketClientMain.java
@@ -42,13 +42,21 @@ public class SocketClientMain {
     }
 
     private static String echo(Channel ch, final String arg) throws Exception {
-        return ch.call(new CallableBase<String, Exception>() {
-            public String call() throws Exception {
-                LOGGER.info("Echoing back "+arg);
-                return arg;
-            }
-        });
+        return ch.call(new EchoingCallable(arg));
     }
 
     private static final Logger LOGGER = Logger.getLogger(SocketClientMain.class.getName());
+
+    private static class EchoingCallable extends CallableBase<String, Exception> {
+        private final String arg;
+
+        public EchoingCallable(String arg) {
+            this.arg = arg;
+        }
+
+        public String call() throws Exception {
+            LOGGER.info("Echoing back "+ arg);
+            return arg;
+        }
+    }
 }

--- a/src/test/java/org/jenkinsci/remoting/nio/SocketClientMain.java
+++ b/src/test/java/org/jenkinsci/remoting/nio/SocketClientMain.java
@@ -55,7 +55,7 @@ public class SocketClientMain {
         }
 
         public String call() throws Exception {
-            LOGGER.info("Echoing back "+ arg);
+            LOGGER.info("Echoing back " + arg);
             return arg;
         }
     }


### PR DESCRIPTION
See [JENKINS-49987](https://issues.jenkins-ci.org/browse/JENKINS-49987)

Convert them to static, named classes. These are ones that I was easily able to locate relating to Callable. After these changes, the warnings no longer show up during Remoting build tests.

@oleg-nenashev Are there any concerns with this about compatibility or over-the-wire format changes?