### PR TITLE
[JENKINS-50730] Tweak the log messaging on reconnect.

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -664,7 +664,14 @@ public class Engine extends Thread {
                 // try to connect back to the server every 10 secs.
                 resolver.waitForReady();
 
-                events.onReconnect();
+                try {
+                    events.status("Performing onReconnect operation.");
+                    events.onReconnect();
+                    events.status("onReconnect operation completed.");
+                } catch (NoClassDefFoundError e) {
+                    events.status("onReconnect operation failed.");
+                    LOGGER.log(Level.FINE, "Reconnection error.", e);
+                }
             }
         } catch (Throwable e) {
             events.error(e);


### PR DESCRIPTION
See [JENKINS-50730](https://issues.jenkins-ci.org/browse/JENKINS-50730). 

The real problem there is that the connection was somehow terminated. Commonly Remoting issues involve something in the networking or system environment terminating the connection from outside the process. The trick can be to determine what is doing that.

The current log messages seem to confuse a number of people into thinking that a particular message is the cause of their problems when it is merely a failure in an attempt to reconnect. This proposal is to tweak the log messages to downgrade the severity of the confusing stack trace and add a little more messages about the attempt to reconnect.

This proposal also ends up skipping the System.exit() when handling this NoClassDefFoundError. Logging it at a low level seems to be justified because of Remoting's complex mechanism of loading classes remotely. It starts as a regular ClassNotFoundException but ends up getting elevated to an error. In my tests, it continues to behave fine with this change but I'm not entirely confident this will be the case for all situations.