### PR TITLE
[JENKINS-47977] Jenkins build fails with Root directory not writable

### DIFF
--- a/src/main/java/hudson/remoting/ChannelBuilder.java
+++ b/src/main/java/hudson/remoting/ChannelBuilder.java
@@ -217,7 +217,11 @@ public class ChannelBuilder {
      * @throws IOException Default JAR Cache location cannot be initialized
      */
     public ChannelBuilder withJarCacheOrDefault(@CheckForNull JarCache jarCache) throws IOException {
-        this.jarCache = jarCache != null ? jarCache : JarCache.getDefault();
+        try {
+            this.jarCache = jarCache != null ? jarCache : JarCache.getDefault();
+        } catch (IOException ioe) {
+            LOGGER.log(Level.WARNING, "Could not create jar cache. Running without cache.", ioe);
+        }
         return this;
     }
 


### PR DESCRIPTION
See [JENKINS-47977](https://issues.jenkins-ci.org/browse/JENKINS-47977)

If we cannot create create the jar cache, leave it null.

In some cases, the default jar cache directory may not be writeable, which will cause
an IO exception trying to create the cache. Fail a bit more gracefully by running without a cache. This seems to be a supported configuration by the code. Further, the user can specify a jar cache location.

@oleg-nenashev, did you have any different ideas on how to deal with this one?