### PR TITLE
[JENKINS-51108] Allow remoting to publish incrementals.

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-4</version>
+  </extension>
+</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ THE SOFTWARE.
 
   <groupId>org.jenkins-ci.main</groupId>
   <artifactId>remoting</artifactId>
-  <version>3.28-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
 
   <name>Jenkins remoting layer</name>
   <description>
@@ -71,6 +71,8 @@ THE SOFTWARE.
     <findbugs.threshold>Low</findbugs.threshold>
     <!-- TODO: Required to override by a version with certchain support (MJARSIGNER-53) on @oleg-nenashev's machine. Remove once it's in upstream -->
     <maven-jarsigner-plugin.version>1.4</maven-jarsigner-plugin.version>
+    <revision>3.28</revision>
+    <changelist>-SNAPSHOT</changelist>
   </properties>
 
   <repositories>


### PR DESCRIPTION
See [JENKINS-51108](https://issues.jenkins-ci.org/browse/JENKINS-51108).

Part of the epic [JENKINS-50686](https://issues.jenkins-ci.org/browse/JENKINS-50686) and [JEP-305](https://github.com/jenkinsci/jep/blob/master/jep/305/README.adoc).

This change allows Remoting to publish incrementals. Under standard usage it behaves as before but now it has the option to publish incrementals. I'm not sure how that will work with jar signing for cases where that is needed. For now it will work where jar signing isn't necessary.

@reviewbybees 