### PR TITLE
[JENKINS-54566] Ignore attempts to flush a ProxyOutputStream which has already been finalized

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -568,7 +568,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
                     }
                 } catch (Throwable t) {
                     logger.log(Level.SEVERE, "Failed to execute command " + cmd + " (channel " + Channel.this.name + ")", t);
-                    logger.log(Level.SEVERE, "This command is created here", cmd.createdAt);
+                    if (cmd.createdAt != null) {
+                        logger.log(Level.SEVERE, "This command is created here", cmd.createdAt);
+                    }
                 }
             }
 

--- a/src/main/java/hudson/remoting/ProxyOutputStream.java
+++ b/src/main/java/hudson/remoting/ProxyOutputStream.java
@@ -25,7 +25,6 @@ package hudson.remoting;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.util.concurrent.ExecutionException;
@@ -152,8 +151,9 @@ final class ProxyOutputStream extends OutputStream implements ErrorPropagatingOu
     }
 
     public synchronized void flush() throws IOException {
-        if(channel!=null)
-            channel.send(new Flush(channel.newIoId(),oid));
+        if (channel != null && /* see #finalize */ oid != -1) {
+            channel.send(new Flush(channel.newIoId(), oid));
+        }
     }
 
     public synchronized void close() throws IOException {


### PR DESCRIPTION
At least suppresses the visible error in [JENKINS-54566](https://issues.jenkins-ci.org/browse/JENKINS-54566).