### PR TITLE
Better diagnostics for errors from RemoteClassLoader.fetch4

### DIFF
--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -839,19 +839,20 @@ final class RemoteClassLoader extends URLClassLoader {
         /**
          * Fetch a single class and creates a {@link ClassFile2} for it.
          */
-        public ClassFile2 fetch4(String className, ClassFile2 referer) throws ClassNotFoundException {
+        public ClassFile2 fetch4(String className, @CheckForNull ClassFile2 referer) throws ClassNotFoundException {
+            Class<?> referrerClass = referer == null ? null : referer.clazz;
             Class<?> c;
             try {
                 c = (referer==null?this.cl:referer.clazz.getClassLoader()).loadClass(className);
             } catch (LinkageError e) {
-                throw (LinkageError)new LinkageError("Failed to load "+className).initCause(e);
+                throw new LinkageError("Failed to load " + className + " via " + referrerClass, e);
             }
             ClassLoader ecl = c.getClassLoader();
             if (ecl == null) {
             	if (USE_BOOTSTRAP_CLASSLOADER) {
             		ecl = PSEUDO_BOOTSTRAP;
             	} else {
-            		throw new ClassNotFoundException("Classloading from system classloader disabled");
+            		throw new ClassNotFoundException("Bootstrap pseudo-classloader disabled: " + className + " via " + referrerClass);
             	}
             }
 
@@ -880,7 +881,7 @@ final class RemoteClassLoader extends URLClassLoader {
                 }
                 return fetch2(className).upconvert(referer,c,urlOfClassFile);
             } catch (IOException e) {
-                throw new ClassNotFoundException();
+                throw new ClassNotFoundException("Failed to load " + className + " via " + referrerClass, e);
             }
         }
 


### PR DESCRIPTION
I suspect the root cause of

```
java.lang.LinkageError
	at hudson.util.ProcessTree$UnixReflection.<clinit>(ProcessTree.java:710)
	at hudson.util.ProcessTree$Unix.get(ProcessTree.java:578)
	at hudson.util.ProcessTree.killAll(ProcessTree.java:145)
	at hudson.Proc$LocalProc.destroy(Proc.java:384)
	at hudson.Proc$LocalProc.kill(Proc.java:376)
	at com.cloudbees.opscenter.server.jnlp.controller.JnlpSlaveControllerImpl.kill(JnlpSlaveControllerImpl.java:98)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at …
Caused by: java.lang.ClassNotFoundException: Classloading from system classloader disabled
	at hudson.remoting.RemoteClassLoader$ClassLoaderProxy.fetch4(RemoteClassLoader.java:854)
	at hudson.remoting.RemoteClassLoader$ClassLoaderProxy.fetch3(RemoteClassLoader.java:889)
	at sun.reflect.GeneratedMethodAccessor72.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.remoting.RemoteInvocationHandler$RPCRequest.perform(RemoteInvocationHandler.java:927)
	at hudson.remoting.Request$2.run(Request.java:364)
	at …
```

was using Java 9+ for an agent, but it would be better for the `ClassNotFoundException` to be explicit about what it was being asked to load and why.

See also much older stack traces in [JENKINS-10238](https://issues.jenkins-ci.org/browse/JENKINS-10238).