### PR TITLE
[JENKINS-48778] Refactoring earlier unreleased implementation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,16 +191,6 @@ THE SOFTWARE.
       <artifactId>test-annotations</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.6</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-net</groupId>
-      <artifactId>commons-net</artifactId>
-      <version>3.6</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/hudson/remoting/NoProxyEvaluator.java
+++ b/src/main/java/hudson/remoting/NoProxyEvaluator.java
@@ -23,8 +23,8 @@
  */
 package hudson.remoting;
 
-import org.apache.commons.net.util.SubnetUtils;
-import org.apache.http.conn.util.InetAddressUtils;
+import org.jenkinsci.remoting.org.apache.commons.net.util.SubnetUtils;
+import org.jenkinsci.remoting.org.apache.commons.validator.routines.InetAddressValidator;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -149,7 +149,7 @@ public class NoProxyEvaluator {
     }
 
     private boolean isIpAddress(String host) {
-        return InetAddressUtils.isIPv4Address(host) || InetAddressUtils.isIPv6Address(host);
+        return InetAddressValidator.getInstance().isValid(host);
     }
 
 }

--- a/src/main/java/org/jenkinsci/remoting/org/apache/commons/net/util/SubnetUtils.java
+++ b/src/main/java/org/jenkinsci/remoting/org/apache/commons/net/util/SubnetUtils.java
@@ -1,0 +1,368 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jenkinsci.remoting.org.apache.commons.net.util;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A class that performs some subnet calculations given a network address and a subnet mask.
+ * @see "http://www.faqs.org/rfcs/rfc1519.html"
+ * @since 2.0
+ */
+//[PATCH]
+@Restricted(NoExternalUse.class)
+// end of [PATCH]
+public class SubnetUtils {
+
+    private static final String IP_ADDRESS = "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})";
+    private static final String SLASH_FORMAT = IP_ADDRESS + "/(\\d{1,3})";
+    private static final Pattern addressPattern = Pattern.compile(IP_ADDRESS);
+    private static final Pattern cidrPattern = Pattern.compile(SLASH_FORMAT);
+    private static final int NBITS = 32;
+
+    private int netmask = 0;
+    private int address = 0;
+    private int network = 0;
+    private int broadcast = 0;
+
+    /** Whether the broadcast/network address are included in host count */
+    private boolean inclusiveHostCount = false;
+
+
+    /**
+     * Constructor that takes a CIDR-notation string, e.g. "192.168.0.1/16"
+     * @param cidrNotation A CIDR-notation string, e.g. "192.168.0.1/16"
+     * @throws IllegalArgumentException if the parameter is invalid,
+     * i.e. does not match n.n.n.n/m where n=1-3 decimal digits, m = 1-3 decimal digits in range 1-32
+     */
+    public SubnetUtils(String cidrNotation) {
+        calculate(cidrNotation);
+    }
+
+    /**
+     * Constructor that takes a dotted decimal address and a dotted decimal mask.
+     * @param address An IP address, e.g. "192.168.0.1"
+     * @param mask A dotted decimal netmask e.g. "255.255.0.0"
+     * @throws IllegalArgumentException if the address or mask is invalid,
+     * i.e. does not match n.n.n.n where n=1-3 decimal digits and the mask is not all zeros
+     */
+    public SubnetUtils(String address, String mask) {
+        calculate(toCidrNotation(address, mask));
+    }
+
+
+    /**
+     * Returns <code>true</code> if the return value of {@link SubnetInfo#getAddressCount()}
+     * includes the network and broadcast addresses.
+     * @since 2.2
+     * @return true if the hostcount includes the network and broadcast addresses
+     */
+    public boolean isInclusiveHostCount() {
+        return inclusiveHostCount;
+    }
+
+    /**
+     * Set to <code>true</code> if you want the return value of {@link SubnetInfo#getAddressCount()}
+     * to include the network and broadcast addresses.
+     * @param inclusiveHostCount true if network and broadcast addresses are to be included
+     * @since 2.2
+     */
+    public void setInclusiveHostCount(boolean inclusiveHostCount) {
+        this.inclusiveHostCount = inclusiveHostCount;
+    }
+
+
+
+    /**
+     * Convenience container for subnet summary information.
+     *
+     */
+    public final class SubnetInfo {
+        /* Mask to convert unsigned int to a long (i.e. keep 32 bits) */
+        private static final long UNSIGNED_INT_MASK = 0x0FFFFFFFFL;
+
+        private SubnetInfo() {}
+
+        private int netmask()       { return netmask; }
+        private int network()       { return network; }
+        private int address()       { return address; }
+        private int broadcast()     { return broadcast; }
+
+        // long versions of the values (as unsigned int) which are more suitable for range checking
+        private long networkLong()  { return network &  UNSIGNED_INT_MASK; }
+        private long broadcastLong(){ return broadcast &  UNSIGNED_INT_MASK; }
+
+        private int low() {
+            return (isInclusiveHostCount() ? network() :
+                broadcastLong() - networkLong() > 1 ? network() + 1 : 0);
+        }
+
+        private int high() {
+            return (isInclusiveHostCount() ? broadcast() :
+                broadcastLong() - networkLong() > 1 ? broadcast() -1  : 0);
+        }
+
+        /**
+         * Returns true if the parameter <code>address</code> is in the
+         * range of usable endpoint addresses for this subnet. This excludes the
+         * network and broadcast adresses.
+         * @param address A dot-delimited IPv4 address, e.g. "192.168.0.1"
+         * @return True if in range, false otherwise
+         */
+        public boolean isInRange(String address) {
+            return isInRange(toInteger(address));
+        }
+
+        /**
+         *
+         * @param address the address to check
+         * @return true if it is in range
+         * @since 3.4 (made public)
+         */
+        public boolean isInRange(int address) {
+            long addLong = address & UNSIGNED_INT_MASK;
+            long lowLong = low() & UNSIGNED_INT_MASK;
+            long highLong = high() & UNSIGNED_INT_MASK;
+            return addLong >= lowLong && addLong <= highLong;
+        }
+
+        public String getBroadcastAddress() {
+            return format(toArray(broadcast()));
+        }
+
+        public String getNetworkAddress() {
+            return format(toArray(network()));
+        }
+
+        public String getNetmask() {
+            return format(toArray(netmask()));
+        }
+
+        public String getAddress() {
+            return format(toArray(address()));
+        }
+
+        /**
+         * Return the low address as a dotted IP address.
+         * Will be zero for CIDR/31 and CIDR/32 if the inclusive flag is false.
+         *
+         * @return the IP address in dotted format, may be "0.0.0.0" if there is no valid address
+         */
+        public String getLowAddress() {
+            return format(toArray(low()));
+        }
+
+        /**
+         * Return the high address as a dotted IP address.
+         * Will be zero for CIDR/31 and CIDR/32 if the inclusive flag is false.
+         *
+         * @return the IP address in dotted format, may be "0.0.0.0" if there is no valid address
+         */
+        public String getHighAddress() {
+            return format(toArray(high()));
+        }
+
+        /**
+         * Get the count of available addresses.
+         * Will be zero for CIDR/31 and CIDR/32 if the inclusive flag is false.
+         * @return the count of addresses, may be zero.
+         * @throws RuntimeException if the correct count is greater than {@code Integer.MAX_VALUE}
+         * @deprecated (3.4) use {@link #getAddressCountLong()} instead
+         */
+        @Deprecated
+        public int getAddressCount() {
+            long countLong = getAddressCountLong();
+            if (countLong > Integer.MAX_VALUE) {
+                throw new RuntimeException("Count is larger than an integer: " + countLong);
+            }
+            // N.B. cannot be negative
+            return (int)countLong;
+        }
+
+        /**
+         * Get the count of available addresses.
+         * Will be zero for CIDR/31 and CIDR/32 if the inclusive flag is false.
+         * @return the count of addresses, may be zero.
+         * @since 3.4
+         */
+        public long getAddressCountLong() {
+            long b = broadcastLong();
+            long n = networkLong();
+            long count = b - n + (isInclusiveHostCount() ? 1 : -1);
+            return count < 0 ? 0 : count;
+        }
+
+        public int asInteger(String address) {
+            return toInteger(address);
+        }
+
+        public String getCidrSignature() {
+            return toCidrNotation(
+                    format(toArray(address())),
+                    format(toArray(netmask()))
+            );
+        }
+
+        public String[] getAllAddresses() {
+            int ct = getAddressCount();
+            String[] addresses = new String[ct];
+            if (ct == 0) {
+                return addresses;
+            }
+            for (int add = low(), j=0; add <= high(); ++add, ++j) {
+                addresses[j] = format(toArray(add));
+            }
+            return addresses;
+        }
+
+        /**
+         * {@inheritDoc}
+         * @since 2.2
+         */
+        @Override
+        public String toString() {
+            final StringBuilder buf = new StringBuilder();
+            buf.append("CIDR Signature:\t[").append(getCidrSignature()).append("]")
+                .append(" Netmask: [").append(getNetmask()).append("]\n")
+                .append("Network:\t[").append(getNetworkAddress()).append("]\n")
+                .append("Broadcast:\t[").append(getBroadcastAddress()).append("]\n")
+                 .append("First Address:\t[").append(getLowAddress()).append("]\n")
+                 .append("Last Address:\t[").append(getHighAddress()).append("]\n")
+                 .append("# Addresses:\t[").append(getAddressCount()).append("]\n");
+            return buf.toString();
+        }
+    }
+
+    /**
+     * Return a {@link SubnetInfo} instance that contains subnet-specific statistics
+     * @return new instance
+     */
+    public final SubnetInfo getInfo() { return new SubnetInfo(); }
+
+    /*
+     * Initialize the internal fields from the supplied CIDR mask
+     */
+    private void calculate(String mask) {
+        Matcher matcher = cidrPattern.matcher(mask);
+
+        if (matcher.matches()) {
+            address = matchAddress(matcher);
+
+            /* Create a binary netmask from the number of bits specification /x */
+            int cidrPart = rangeCheck(Integer.parseInt(matcher.group(5)), 0, NBITS);
+            for (int j = 0; j < cidrPart; ++j) {
+                netmask |= (1 << 31 - j);
+            }
+
+            /* Calculate base network address */
+            network = (address & netmask);
+
+            /* Calculate broadcast address */
+            broadcast = network | ~(netmask);
+        } else {
+            throw new IllegalArgumentException("Could not parse [" + mask + "]");
+        }
+    }
+
+    /*
+     * Convert a dotted decimal format address to a packed integer format
+     */
+    private int toInteger(String address) {
+        Matcher matcher = addressPattern.matcher(address);
+        if (matcher.matches()) {
+            return matchAddress(matcher);
+        } else {
+            throw new IllegalArgumentException("Could not parse [" + address + "]");
+        }
+    }
+
+    /*
+     * Convenience method to extract the components of a dotted decimal address and
+     * pack into an integer using a regex match
+     */
+    private int matchAddress(Matcher matcher) {
+        int addr = 0;
+        for (int i = 1; i <= 4; ++i) {
+            int n = (rangeCheck(Integer.parseInt(matcher.group(i)), 0, 255));
+            addr |= ((n & 0xff) << 8*(4-i));
+        }
+        return addr;
+    }
+
+    /*
+     * Convert a packed integer address into a 4-element array
+     */
+    private int[] toArray(int val) {
+        int ret[] = new int[4];
+        for (int j = 3; j >= 0; --j) {
+            ret[j] |= ((val >>> 8*(3-j)) & (0xff));
+        }
+        return ret;
+    }
+
+    /*
+     * Convert a 4-element array into dotted decimal format
+     */
+    private String format(int[] octets) {
+        StringBuilder str = new StringBuilder();
+        for (int i =0; i < octets.length; ++i){
+            str.append(octets[i]);
+            if (i != octets.length - 1) {
+                str.append(".");
+            }
+        }
+        return str.toString();
+    }
+
+    /*
+     * Convenience function to check integer boundaries.
+     * Checks if a value x is in the range [begin,end].
+     * Returns x if it is in range, throws an exception otherwise.
+     */
+    private int rangeCheck(int value, int begin, int end) {
+        if (value >= begin && value <= end) { // (begin,end]
+            return value;
+        }
+
+        throw new IllegalArgumentException("Value [" + value + "] not in range ["+begin+","+end+"]");
+    }
+
+    /*
+     * Count the number of 1-bits in a 32-bit integer using a divide-and-conquer strategy
+     * see Hacker's Delight section 5.1
+     */
+    int pop(int x) {
+        x = x - ((x >>> 1) & 0x55555555);
+        x = (x & 0x33333333) + ((x >>> 2) & 0x33333333);
+        x = (x + (x >>> 4)) & 0x0F0F0F0F;
+        x = x + (x >>> 8);
+        x = x + (x >>> 16);
+        return x & 0x0000003F;
+    }
+
+    /* Convert two dotted decimal addresses to a single xxx.xxx.xxx.xxx/yy format
+     * by counting the 1-bit population in the mask address. (It may be better to count
+     * NBITS-#trailing zeroes for this case)
+     */
+    private String toCidrNotation(String addr, String mask) {
+        return addr + "/" + pop(toInteger(mask));
+    }
+}

--- a/src/main/java/org/jenkinsci/remoting/org/apache/commons/validator/routines/InetAddressValidator.java
+++ b/src/main/java/org/jenkinsci/remoting/org/apache/commons/validator/routines/InetAddressValidator.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* Copied from commons-validator:commons-validator:1.6, with [PATCH] modifications */
+package org.jenkinsci.remoting.org.apache.commons.validator.routines;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * <p><b>InetAddress</b> validation and conversion routines (<code>java.net.InetAddress</code>).</p>
+ *
+ * <p>This class provides methods to validate a candidate IP address.
+ *
+ * <p>
+ * This class is a Singleton; you can retrieve the instance via the {@link #getInstance()} method.
+ * </p>
+ *
+ * @version $Revision: 1783032 $
+ * @since Validator 1.4
+ */
+//[PATCH]
+@Restricted(NoExternalUse.class)
+// end of [PATCH]
+public class InetAddressValidator implements Serializable {
+
+    private static final int IPV4_MAX_OCTET_VALUE = 255;
+
+    private static final int MAX_UNSIGNED_SHORT = 0xffff;
+
+    private static final int BASE_16 = 16;
+
+    private static final long serialVersionUID = -919201640201914789L;
+
+    private static final String IPV4_REGEX =
+            "^(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})$";
+
+    // Max number of hex groups (separated by :) in an IPV6 address
+    private static final int IPV6_MAX_HEX_GROUPS = 8;
+
+    // Max hex digits in each IPv6 group
+    private static final int IPV6_MAX_HEX_DIGITS_PER_GROUP = 4;
+
+    /**
+     * Singleton instance of this class.
+     */
+    private static final InetAddressValidator VALIDATOR = new InetAddressValidator();
+
+    /** IPv4 RegexValidator */
+    private final RegexValidator ipv4Validator = new RegexValidator(IPV4_REGEX);
+
+    /**
+     * Returns the singleton instance of this validator.
+     * @return the singleton instance of this validator
+     */
+    public static InetAddressValidator getInstance() {
+        return VALIDATOR;
+    }
+
+    /**
+     * Checks if the specified string is a valid IP address.
+     * @param inetAddress the string to validate
+     * @return true if the string validates as an IP address
+     */
+    public boolean isValid(String inetAddress) {
+        return isValidInet4Address(inetAddress) || isValidInet6Address(inetAddress);
+    }
+
+    /**
+     * Validates an IPv4 address. Returns true if valid.
+     * @param inet4Address the IPv4 address to validate
+     * @return true if the argument contains a valid IPv4 address
+     */
+    public boolean isValidInet4Address(String inet4Address) {
+        // verify that address conforms to generic IPv4 format
+        String[] groups = ipv4Validator.match(inet4Address);
+
+        if (groups == null) {
+            return false;
+        }
+
+        // verify that address subgroups are legal
+        for (String ipSegment : groups) {
+            if (ipSegment == null || ipSegment.length() == 0) {
+                return false;
+            }
+
+            int iIpSegment = 0;
+
+            try {
+                iIpSegment = Integer.parseInt(ipSegment);
+            } catch(NumberFormatException e) {
+                return false;
+            }
+
+            if (iIpSegment > IPV4_MAX_OCTET_VALUE) {
+                return false;
+            }
+
+            if (ipSegment.length() > 1 && ipSegment.startsWith("0")) {
+                return false;
+            }
+
+        }
+
+        return true;
+    }
+
+    /**
+     * Validates an IPv6 address. Returns true if valid.
+     * @param inet6Address the IPv6 address to validate
+     * @return true if the argument contains a valid IPv6 address
+     * 
+     * @since 1.4.1
+     */
+    public boolean isValidInet6Address(String inet6Address) {
+        boolean containsCompressedZeroes = inet6Address.contains("::");
+        if (containsCompressedZeroes && (inet6Address.indexOf("::") != inet6Address.lastIndexOf("::"))) {
+            return false;
+        }
+        if ((inet6Address.startsWith(":") && !inet6Address.startsWith("::"))
+                || (inet6Address.endsWith(":") && !inet6Address.endsWith("::"))) {
+            return false;
+        }
+        String[] octets = inet6Address.split(":");
+        if (containsCompressedZeroes) {
+            List<String> octetList = new ArrayList<String>(Arrays.asList(octets));
+            if (inet6Address.endsWith("::")) {
+                // String.split() drops ending empty segments
+                octetList.add("");
+            } else if (inet6Address.startsWith("::") && !octetList.isEmpty()) {
+                octetList.remove(0);
+            }
+            octets = octetList.toArray(new String[octetList.size()]);
+        }
+        if (octets.length > IPV6_MAX_HEX_GROUPS) {
+            return false;
+        }
+        int validOctets = 0;
+        int emptyOctets = 0; // consecutive empty chunks
+        for (int index = 0; index < octets.length; index++) {
+            String octet = octets[index];
+            if (octet.length() == 0) {
+                emptyOctets++;
+                if (emptyOctets > 1) {
+                    return false;
+                }
+            } else {
+                emptyOctets = 0;
+                // Is last chunk an IPv4 address?
+                if (index == octets.length - 1 && octet.contains(".")) {
+                    if (!isValidInet4Address(octet)) {
+                        return false;
+                    }
+                    validOctets += 2;
+                    continue;
+                }
+                if (octet.length() > IPV6_MAX_HEX_DIGITS_PER_GROUP) {
+                    return false;
+                }
+                int octetInt = 0;
+                try {
+                    octetInt = Integer.parseInt(octet, BASE_16);
+                } catch (NumberFormatException e) {
+                    return false;
+                }
+                if (octetInt < 0 || octetInt > MAX_UNSIGNED_SHORT) {
+                    return false;
+                }
+            }
+            validOctets++;
+        }
+        if (validOctets > IPV6_MAX_HEX_GROUPS || (validOctets < IPV6_MAX_HEX_GROUPS && !containsCompressedZeroes)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/jenkinsci/remoting/org/apache/commons/validator/routines/RegexValidator.java
+++ b/src/main/java/org/jenkinsci/remoting/org/apache/commons/validator/routines/RegexValidator.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* Copied from commons-validator:commons-validator:1.6, with [PATCH] modifications */
+package org.jenkinsci.remoting.org.apache.commons.validator.routines;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.io.Serializable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * <b>Regular Expression</b> validation (using JDK 1.4+ regex support).
+ * <p>
+ * Construct the validator either for a single regular expression or a set (array) of
+ * regular expressions. By default validation is <i>case sensitive</i> but constructors
+ * are provided to allow  <i>case in-sensitive</i> validation. For example to create
+ * a validator which does <i>case in-sensitive</i> validation for a set of regular
+ * expressions:
+ * </p>
+ * <pre>
+ * <code>
+ * String[] regexs = new String[] {...};
+ * RegexValidator validator = new RegexValidator(regexs, false);
+ * </code>
+ * </pre>
+ *
+ * <ul>
+ *   <li>Validate <code>true</code> or <code>false</code>:</li>
+ *   <li>
+ *     <ul>
+ *       <li><code>boolean valid = validator.isValidRootUrl(value);</code></li>
+ *     </ul>
+ *   </li>
+ *   <li>Validate returning an aggregated String of the matched groups:</li>
+ *   <li>
+ *     <ul>
+ *       <li><code>String result = validator.validate(value);</code></li>
+ *     </ul>
+ *   </li>
+ *   <li>Validate returning the matched groups:</li>
+ *   <li>
+ *     <ul>
+ *       <li><code>String[] result = validator.match(value);</code></li>
+ *     </ul>
+ *   </li>
+ * </ul>
+ *
+ * <b>Note that patterns are matched against the entire input.</b>
+ *
+ * <p>
+ * Cached instances pre-compile and re-use {@link Pattern}(s) - which according
+ * to the {@link Pattern} API are safe to use in a multi-threaded environment.
+ * </p>
+ *
+ * @version $Revision: 1739356 $
+ * @since Validator 1.4
+ */
+//[PATCH]
+@Restricted(NoExternalUse.class)
+// end of [PATCH]
+public class RegexValidator implements Serializable {
+
+    private static final long serialVersionUID = -8832409930574867162L;
+
+    private final Pattern[] patterns;
+
+    /**
+     * Construct a <i>case sensitive</i> validator for a single
+     * regular expression.
+     *
+     * @param regex The regular expression this validator will
+     * validate against
+     */
+    public RegexValidator(String regex) {
+        this(regex, true);
+    }
+
+    /**
+     * Construct a validator for a single regular expression
+     * with the specified case sensitivity.
+     *
+     * @param regex The regular expression this validator will
+     * validate against
+     * @param caseSensitive when <code>true</code> matching is <i>case
+     * sensitive</i>, otherwise matching is <i>case in-sensitive</i>
+     */
+    public RegexValidator(String regex, boolean caseSensitive) {
+        this(new String[] {regex}, caseSensitive);
+    }
+
+    /**
+     * Construct a <i>case sensitive</i> validator that matches any one
+     * of the set of regular expressions.
+     *
+     * @param regexs The set of regular expressions this validator will
+     * validate against
+     */
+    public RegexValidator(String[] regexs) {
+        this(regexs, true);
+    }
+
+    /**
+     * Construct a validator that matches any one of the set of regular
+     * expressions with the specified case sensitivity.
+     *
+     * @param regexs The set of regular expressions this validator will
+     * validate against
+     * @param caseSensitive when <code>true</code> matching is <i>case
+     * sensitive</i>, otherwise matching is <i>case in-sensitive</i>
+     */
+    public RegexValidator(String[] regexs, boolean caseSensitive) {
+        if (regexs == null || regexs.length == 0) {
+            throw new IllegalArgumentException("Regular expressions are missing");
+        }
+        patterns = new Pattern[regexs.length];
+        int flags =  (caseSensitive ? 0: Pattern.CASE_INSENSITIVE);
+        for (int i = 0; i < regexs.length; i++) {
+            if (regexs[i] == null || regexs[i].length() == 0) {
+                throw new IllegalArgumentException("Regular expression[" + i + "] is missing");
+            }
+            patterns[i] =  Pattern.compile(regexs[i], flags);
+        }
+    }
+
+    /**
+     * Validate a value against the set of regular expressions.
+     *
+     * @param value The value to validate.
+     * @return <code>true</code> if the value is valid
+     * otherwise <code>false</code>.
+     */
+    public boolean isValid(String value) {
+        if (value == null) {
+            return false;
+        }
+        for (int i = 0; i < patterns.length; i++) {
+            if (patterns[i].matcher(value).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Validate a value against the set of regular expressions
+     * returning the array of matched groups.
+     *
+     * @param value The value to validate.
+     * @return String array of the <i>groups</i> matched if
+     * valid or <code>null</code> if invalid
+     */
+//[PATCH]
+    @SuppressFBWarnings("PZLA") // Remoting uses Low threshold
+// end of [PATCH]
+    public String[] match(String value) {
+        if (value == null) {
+            return null;
+        }
+        for (int i = 0; i < patterns.length; i++) {
+            Matcher matcher = patterns[i].matcher(value);
+            if (matcher.matches()) {
+                int count = matcher.groupCount();
+                String[] groups = new String[count];
+                for (int j = 0; j < count; j++) {
+                    groups[j] = matcher.group(j+1);
+                }
+                return groups;
+            }
+        }
+        return null;
+    }
+
+
+    /**
+     * Validate a value against the set of regular expressions
+     * returning a String value of the aggregated groups.
+     *
+     * @param value The value to validate.
+     * @return Aggregated String value comprised of the
+     * <i>groups</i> matched if valid or <code>null</code> if invalid
+     */
+    public String validate(String value) {
+        if (value == null) {
+            return null;
+        }
+        for (int i = 0; i < patterns.length; i++) {
+            Matcher matcher = patterns[i].matcher(value);
+            if (matcher.matches()) {
+                int count = matcher.groupCount();
+                if (count == 1) {
+                    return matcher.group(1);
+                }
+                StringBuilder buffer = new StringBuilder();
+                for (int j = 0; j < count; j++) {
+                    String component = matcher.group(j+1);
+                    if (component != null) {
+                        buffer.append(component);
+                    }
+                }
+                return buffer.toString();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Provide a String representation of this validator.
+     * @return A String representation of this validator
+     */
+    @Override
+    public String toString() {
+        StringBuilder buffer = new StringBuilder();
+        buffer.append("RegexValidator{");
+        for (int i = 0; i < patterns.length; i++) {
+            if (i > 0) {
+                buffer.append(",");
+            }
+            buffer.append(patterns[i].pattern());
+        }
+        buffer.append("}");
+        return buffer.toString();
+    }
+
+}

--- a/src/test/java/org/jenkinsci/remoting/org/apache/commons/net/util/SubnetUtilsTest.java
+++ b/src/test/java/org/jenkinsci/remoting/org/apache/commons/net/util/SubnetUtilsTest.java
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jenkinsci.remoting.org.apache.commons.net.util;
+
+import org.jenkinsci.remoting.org.apache.commons.net.util.SubnetUtils.SubnetInfo;
+
+import junit.framework.TestCase;
+
+@SuppressWarnings("deprecation") // deliberate use of deprecated methods
+public class SubnetUtilsTest extends TestCase {
+
+    // TODO Lower address test
+    public void testAddresses() {
+        SubnetUtils utils = new SubnetUtils("192.168.0.1/29");
+        SubnetInfo info = utils.getInfo();
+        assertTrue(info.isInRange("192.168.0.1"));
+        // We don't count the broadcast address as usable
+        assertFalse(info.isInRange("192.168.0.7"));
+        assertFalse(info.isInRange("192.168.0.8"));
+        assertFalse(info.isInRange("10.10.2.1"));
+        assertFalse(info.isInRange("192.168.1.1"));
+        assertFalse(info.isInRange("192.168.0.255"));
+    }
+
+    /**
+     * Test using the inclusiveHostCount flag, which includes the network and broadcast addresses in host counts
+     */
+    public void testCidrAddresses() {
+        SubnetUtils utils = new SubnetUtils("192.168.0.1/8");
+        utils.setInclusiveHostCount(true);
+        SubnetInfo info = utils.getInfo();
+        assertEquals("255.0.0.0", info.getNetmask());
+        assertEquals(16777216, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/9");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.128.0.0", info.getNetmask());
+        assertEquals(8388608, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/10");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.192.0.0", info.getNetmask());
+        assertEquals(4194304, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/11");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.224.0.0", info.getNetmask());
+        assertEquals(2097152, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/12");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.240.0.0", info.getNetmask());
+        assertEquals(1048576, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/13");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.248.0.0", info.getNetmask());
+        assertEquals(524288, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/14");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.252.0.0", info.getNetmask());
+        assertEquals(262144, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/15");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.254.0.0", info.getNetmask());
+        assertEquals(131072, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/16");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.0.0", info.getNetmask());
+        assertEquals(65536, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/17");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.128.0", info.getNetmask());
+        assertEquals(32768, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/18");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.192.0", info.getNetmask());
+        assertEquals(16384, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/19");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.224.0", info.getNetmask());
+        assertEquals(8192, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/20");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.240.0", info.getNetmask());
+        assertEquals(4096, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/21");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.248.0", info.getNetmask());
+        assertEquals(2048, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/22");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.252.0", info.getNetmask());
+        assertEquals(1024, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/23");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.254.0", info.getNetmask());
+        assertEquals(512, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/24");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.255.0", info.getNetmask());
+        assertEquals(256, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/25");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.255.128", info.getNetmask());
+        assertEquals(128, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/26");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.255.192", info.getNetmask());
+        assertEquals(64, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/27");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.255.224", info.getNetmask());
+        assertEquals(32, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/28");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.255.240", info.getNetmask());
+        assertEquals(16, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/29");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.255.248", info.getNetmask());
+        assertEquals(8, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/30");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.255.252", info.getNetmask());
+        assertEquals(4, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/31");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.255.254", info.getNetmask());
+        assertEquals(2, info.getAddressCount());
+
+        utils = new SubnetUtils("192.168.0.1/32");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("255.255.255.255", info.getNetmask());
+        assertEquals(1, info.getAddressCount());
+
+        new SubnetUtils("192.168.0.1/1");
+    }
+
+    public void testInvalidMasks() {
+        try {
+            new SubnetUtils("192.168.0.1/33");
+            fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // Ignored
+        }
+    }
+
+    public void testNET428_31() throws Exception {
+        final SubnetUtils subnetUtils = new SubnetUtils("1.2.3.4/31");
+        assertEquals(0, subnetUtils.getInfo().getAddressCount());
+        String[] address = subnetUtils.getInfo().getAllAddresses();
+        assertNotNull(address);
+        assertEquals(0, address.length);
+    }
+
+    public void testNET428_32() throws Exception {
+        final SubnetUtils subnetUtils = new SubnetUtils("1.2.3.4/32");
+        assertEquals(0, subnetUtils.getInfo().getAddressCount());
+        String[] address = subnetUtils.getInfo().getAllAddresses();
+        assertNotNull(address);
+        assertEquals(0, address.length);
+    }
+
+    public void testParseSimpleNetmask() {
+        final String address = "192.168.0.1";
+        final String masks[] = new String[] { "255.0.0.0", "255.255.0.0", "255.255.255.0", "255.255.255.248" };
+        final String bcastAddresses[] = new String[] { "192.255.255.255", "192.168.255.255", "192.168.0.255",
+                "192.168.0.7" };
+        final String lowAddresses[] = new String[] { "192.0.0.1", "192.168.0.1", "192.168.0.1", "192.168.0.1" };
+        final String highAddresses[] = new String[] { "192.255.255.254", "192.168.255.254", "192.168.0.254",
+                "192.168.0.6" };
+        final String networkAddresses[] = new String[] { "192.0.0.0", "192.168.0.0", "192.168.0.0", "192.168.0.0" };
+        final String cidrSignatures[] = new String[] { "192.168.0.1/8", "192.168.0.1/16", "192.168.0.1/24",
+                "192.168.0.1/29" };
+        final int usableAddresses[] = new int[] { 16777214, 65534, 254, 6 };
+
+        for (int i = 0; i < masks.length; ++i) {
+            SubnetUtils utils = new SubnetUtils(address, masks[i]);
+            SubnetInfo info = utils.getInfo();
+            assertEquals(bcastAddresses[i], info.getBroadcastAddress());
+            assertEquals(cidrSignatures[i], info.getCidrSignature());
+            assertEquals(lowAddresses[i], info.getLowAddress());
+            assertEquals(highAddresses[i], info.getHighAddress());
+            assertEquals(networkAddresses[i], info.getNetworkAddress());
+            assertEquals(usableAddresses[i], info.getAddressCount());
+        }
+    }
+
+    public void testParseSimpleNetmaskExclusive() {
+        String address = "192.168.15.7";
+        String masks[] = new String[] { "255.255.255.252", "255.255.255.254", "255.255.255.255" };
+        String bcast[] = new String[] { "192.168.15.7", "192.168.15.7", "192.168.15.7" };
+        String netwk[] = new String[] { "192.168.15.4", "192.168.15.6", "192.168.15.7" };
+        String lowAd[] = new String[] { "192.168.15.5", "0.0.0.0", "0.0.0.0" };
+        String highA[] = new String[] { "192.168.15.6", "0.0.0.0", "0.0.0.0" };
+        String cidrS[] = new String[] { "192.168.15.7/30", "192.168.15.7/31", "192.168.15.7/32" };
+        int usableAd[] = new int[] { 2, 0, 0 };
+        // low and high addresses don't exist
+
+        for (int i = 0; i < masks.length; ++i) {
+            SubnetUtils utils = new SubnetUtils(address, masks[i]);
+            utils.setInclusiveHostCount(false);
+            SubnetInfo info = utils.getInfo();
+            assertEquals("ci " + masks[i], cidrS[i], info.getCidrSignature());
+            assertEquals("bc " + masks[i], bcast[i], info.getBroadcastAddress());
+            assertEquals("nw " + masks[i], netwk[i], info.getNetworkAddress());
+            assertEquals("ac " + masks[i], usableAd[i], info.getAddressCount());
+            assertEquals("lo " + masks[i], lowAd[i], info.getLowAddress());
+            assertEquals("hi " + masks[i], highA[i], info.getHighAddress());
+        }
+    }
+
+    public void testParseSimpleNetmaskInclusive() {
+        String address = "192.168.15.7";
+        String masks[] = new String[] { "255.255.255.252", "255.255.255.254", "255.255.255.255" };
+        String bcast[] = new String[] { "192.168.15.7", "192.168.15.7", "192.168.15.7" };
+        String netwk[] = new String[] { "192.168.15.4", "192.168.15.6", "192.168.15.7" };
+        String lowAd[] = new String[] { "192.168.15.4", "192.168.15.6", "192.168.15.7" };
+        String highA[] = new String[] { "192.168.15.7", "192.168.15.7", "192.168.15.7" };
+        String cidrS[] = new String[] { "192.168.15.7/30", "192.168.15.7/31", "192.168.15.7/32" };
+        int usableAd[] = new int[] { 4, 2, 1 };
+
+        for (int i = 0; i < masks.length; ++i) {
+            SubnetUtils utils = new SubnetUtils(address, masks[i]);
+            utils.setInclusiveHostCount(true);
+            SubnetInfo info = utils.getInfo();
+            assertEquals("ci " + masks[i], cidrS[i], info.getCidrSignature());
+            assertEquals("bc " + masks[i], bcast[i], info.getBroadcastAddress());
+            assertEquals("ac " + masks[i], usableAd[i], info.getAddressCount());
+            assertEquals("nw " + masks[i], netwk[i], info.getNetworkAddress());
+            assertEquals("lo " + masks[i], lowAd[i], info.getLowAddress());
+            assertEquals("hi " + masks[i], highA[i], info.getHighAddress());
+        }
+    }
+
+    public void testZeroAddressAndCidr() {
+        new SubnetUtils("0.0.0.0/0");
+    }
+
+    public void testNET521() {
+        SubnetUtils utils;
+        SubnetInfo info;
+
+        utils = new SubnetUtils("0.0.0.0/0");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("0.0.0.0", info.getNetmask());
+        assertEquals(4294967296L, info.getAddressCountLong());
+        try {
+            info.getAddressCount();
+            fail("Expected RuntimeException");
+        } catch (RuntimeException expected) {
+            // ignored
+        }
+        utils = new SubnetUtils("128.0.0.0/1");
+        utils.setInclusiveHostCount(true);
+        info = utils.getInfo();
+        assertEquals("128.0.0.0", info.getNetmask());
+        assertEquals(2147483648L, info.getAddressCountLong());
+        try {
+            info.getAddressCount();
+            fail("Expected RuntimeException");
+        } catch (RuntimeException expected) {
+            // ignored
+        }
+        // if we exclude the broadcast and network addresses, the count is less than Integer.MAX_VALUE
+        utils.setInclusiveHostCount(false);
+        info = utils.getInfo();
+        assertEquals(2147483646, info.getAddressCount());
+    }
+
+    public void testNET520() {
+        SubnetUtils utils = new SubnetUtils("0.0.0.0/0");
+        utils.setInclusiveHostCount(true);
+        SubnetInfo info = utils.getInfo();
+        assertEquals("0.0.0.0",info.getNetworkAddress());
+        assertEquals("255.255.255.255",info.getBroadcastAddress());
+        assertTrue(info.isInRange("127.0.0.0"));
+        utils.setInclusiveHostCount(false);
+        assertTrue(info.isInRange("127.0.0.0"));
+    }
+}

--- a/src/test/java/org/jenkinsci/remoting/org/apache/commons/validator/routines/InetAddressValidatorTest.java
+++ b/src/test/java/org/jenkinsci/remoting/org/apache/commons/validator/routines/InetAddressValidatorTest.java
@@ -1,0 +1,604 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jenkinsci.remoting.org.apache.commons.validator.routines;
+
+import junit.framework.TestCase;
+
+/**
+ * Test cases for InetAddressValidator.
+ *
+ * @version $Revision$
+ */
+public class InetAddressValidatorTest extends TestCase {
+
+    private InetAddressValidator validator;
+
+    /**
+     * Constructor.
+     * @param name
+     */
+    public InetAddressValidatorTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void setUp() {
+        validator = new InetAddressValidator();
+    }
+
+    /**
+     * Test IPs that point to real, well-known hosts (without actually looking them up).
+     */
+    public void testInetAddressesFromTheWild() {
+        assertTrue("www.apache.org IP should be valid",       validator.isValid("140.211.11.130"));
+        assertTrue("www.l.google.com IP should be valid",     validator.isValid("72.14.253.103"));
+        assertTrue("fsf.org IP should be valid",              validator.isValid("199.232.41.5"));
+        assertTrue("appscs.ign.com IP should be valid",       validator.isValid("216.35.123.87"));
+    }
+
+    public void testVALIDATOR_335() {
+        assertTrue("2001:0438:FFFE:0000:0000:0000:0000:0A35 should be valid",       validator.isValid("2001:0438:FFFE:0000:0000:0000:0000:0A35"));
+    }
+
+    /**
+     * Test valid and invalid IPs from each address class.
+     */
+    public void testInetAddressesByClass() {
+        assertTrue("class A IP should be valid",              validator.isValid("24.25.231.12"));
+        assertFalse("illegal class A IP should be invalid",   validator.isValid("2.41.32.324"));
+
+        assertTrue("class B IP should be valid",              validator.isValid("135.14.44.12"));
+        assertFalse("illegal class B IP should be invalid",   validator.isValid("154.123.441.123"));
+
+        assertTrue("class C IP should be valid",              validator.isValid("213.25.224.32"));
+        assertFalse("illegal class C IP should be invalid",   validator.isValid("201.543.23.11"));
+
+        assertTrue("class D IP should be valid",              validator.isValid("229.35.159.6"));
+        assertFalse("illegal class D IP should be invalid",   validator.isValid("231.54.11.987"));
+
+        assertTrue("class E IP should be valid",              validator.isValid("248.85.24.92"));
+        assertFalse("illegal class E IP should be invalid",   validator.isValid("250.21.323.48"));
+    }
+
+    /**
+     * Test reserved IPs.
+     */
+    public void testReservedInetAddresses() {
+        assertTrue("localhost IP should be valid",            validator.isValid("127.0.0.1"));
+        assertTrue("broadcast IP should be valid",            validator.isValid("255.255.255.255"));
+    }
+
+    /**
+     * Test obviously broken IPs.
+     */
+    public void testBrokenInetAddresses() {
+        assertFalse("IP with characters should be invalid",     validator.isValid("124.14.32.abc"));
+        assertFalse("IP with leading zeroes should be invalid", validator.isValid("124.14.32.01"));
+        assertFalse("IP with three groups should be invalid",   validator.isValid("23.64.12"));
+        assertFalse("IP with five groups should be invalid",    validator.isValid("26.34.23.77.234"));
+    }
+
+    /**
+     * Test IPv6 addresses.
+     * <p>These tests were ported from a
+     * <a href="http://download.dartware.com/thirdparty/test-ipv6-regex.pl">Perl script</a>.</p>
+     * 
+     */
+    public void testIPv6() {
+        // The original Perl script contained a lot of duplicate tests.
+        // I removed the duplicates I noticed, but there may be more.
+        assertFalse("IPV6 empty string should be invalid", validator.isValidInet6Address(""));// empty string 
+        assertTrue("IPV6 ::1 should be valid", validator.isValidInet6Address("::1"));// loopback, compressed, non-routable 
+        assertTrue("IPV6 :: should be valid", validator.isValidInet6Address("::"));// unspecified, compressed, non-routable 
+        assertTrue("IPV6 0:0:0:0:0:0:0:1 should be valid", validator.isValidInet6Address("0:0:0:0:0:0:0:1"));// loopback, full 
+        assertTrue("IPV6 0:0:0:0:0:0:0:0 should be valid", validator.isValidInet6Address("0:0:0:0:0:0:0:0"));// unspecified, full 
+        assertTrue("IPV6 2001:DB8:0:0:8:800:200C:417A should be valid", validator.isValidInet6Address("2001:DB8:0:0:8:800:200C:417A"));// unicast, full 
+        assertTrue("IPV6 FF01:0:0:0:0:0:0:101 should be valid", validator.isValidInet6Address("FF01:0:0:0:0:0:0:101"));// multicast, full 
+        assertTrue("IPV6 2001:DB8::8:800:200C:417A should be valid", validator.isValidInet6Address("2001:DB8::8:800:200C:417A"));// unicast, compressed 
+        assertTrue("IPV6 FF01::101 should be valid", validator.isValidInet6Address("FF01::101"));// multicast, compressed 
+        assertFalse("IPV6 2001:DB8:0:0:8:800:200C:417A:221 should be invalid", validator.isValidInet6Address("2001:DB8:0:0:8:800:200C:417A:221"));// unicast, full 
+        assertFalse("IPV6 FF01::101::2 should be invalid", validator.isValidInet6Address("FF01::101::2"));// multicast, compressed 
+        assertTrue("IPV6 fe80::217:f2ff:fe07:ed62 should be valid", validator.isValidInet6Address("fe80::217:f2ff:fe07:ed62"));
+        assertTrue("IPV6 2001:0000:1234:0000:0000:C1C0:ABCD:0876 should be valid", validator.isValidInet6Address("2001:0000:1234:0000:0000:C1C0:ABCD:0876"));
+        assertTrue("IPV6 3ffe:0b00:0000:0000:0001:0000:0000:000a should be valid", validator.isValidInet6Address("3ffe:0b00:0000:0000:0001:0000:0000:000a"));
+        assertTrue("IPV6 FF02:0000:0000:0000:0000:0000:0000:0001 should be valid", validator.isValidInet6Address("FF02:0000:0000:0000:0000:0000:0000:0001"));
+        assertTrue("IPV6 0000:0000:0000:0000:0000:0000:0000:0001 should be valid", validator.isValidInet6Address("0000:0000:0000:0000:0000:0000:0000:0001"));
+        assertTrue("IPV6 0000:0000:0000:0000:0000:0000:0000:0000 should be valid", validator.isValidInet6Address("0000:0000:0000:0000:0000:0000:0000:0000"));
+        assertFalse("IPV6 02001:0000:1234:0000:0000:C1C0:ABCD:0876 should be invalid", validator.isValidInet6Address("02001:0000:1234:0000:0000:C1C0:ABCD:0876")); // extra 0 not allowed! 
+        assertFalse("IPV6 2001:0000:1234:0000:00001:C1C0:ABCD:0876 should be invalid", validator.isValidInet6Address("2001:0000:1234:0000:00001:C1C0:ABCD:0876")); // extra 0 not allowed! 
+        assertFalse("IPV6 2001:0000:1234:0000:0000:C1C0:ABCD:0876 0 should be invalid", validator.isValidInet6Address("2001:0000:1234:0000:0000:C1C0:ABCD:0876 0")); // junk after valid address
+        assertFalse("IPV6 2001:0000:1234: 0000:0000:C1C0:ABCD:0876 should be invalid", validator.isValidInet6Address("2001:0000:1234: 0000:0000:C1C0:ABCD:0876")); // internal space
+        assertFalse("IPV6 3ffe:0b00:0000:0001:0000:0000:000a should be invalid", validator.isValidInet6Address("3ffe:0b00:0000:0001:0000:0000:000a")); // seven segments
+        assertFalse("IPV6 FF02:0000:0000:0000:0000:0000:0000:0000:0001 should be invalid", validator.isValidInet6Address("FF02:0000:0000:0000:0000:0000:0000:0000:0001")); // nine segments
+        assertFalse("IPV6 3ffe:b00::1::a should be invalid", validator.isValidInet6Address("3ffe:b00::1::a")); // double "::"
+        assertFalse("IPV6 ::1111:2222:3333:4444:5555:6666:: should be invalid", validator.isValidInet6Address("::1111:2222:3333:4444:5555:6666::")); // double "::"
+        assertTrue("IPV6 2::10 should be valid", validator.isValidInet6Address("2::10"));
+        assertTrue("IPV6 ff02::1 should be valid", validator.isValidInet6Address("ff02::1"));
+        assertTrue("IPV6 fe80:: should be valid", validator.isValidInet6Address("fe80::"));
+        assertTrue("IPV6 2002:: should be valid", validator.isValidInet6Address("2002::"));
+        assertTrue("IPV6 2001:db8:: should be valid", validator.isValidInet6Address("2001:db8::"));
+        assertTrue("IPV6 2001:0db8:1234:: should be valid", validator.isValidInet6Address("2001:0db8:1234::"));
+        assertTrue("IPV6 ::ffff:0:0 should be valid", validator.isValidInet6Address("::ffff:0:0"));
+        assertTrue("IPV6 1:2:3:4:5:6:7:8 should be valid", validator.isValidInet6Address("1:2:3:4:5:6:7:8"));
+        assertTrue("IPV6 1:2:3:4:5:6::8 should be valid", validator.isValidInet6Address("1:2:3:4:5:6::8"));
+        assertTrue("IPV6 1:2:3:4:5::8 should be valid", validator.isValidInet6Address("1:2:3:4:5::8"));
+        assertTrue("IPV6 1:2:3:4::8 should be valid", validator.isValidInet6Address("1:2:3:4::8"));
+        assertTrue("IPV6 1:2:3::8 should be valid", validator.isValidInet6Address("1:2:3::8"));
+        assertTrue("IPV6 1:2::8 should be valid", validator.isValidInet6Address("1:2::8"));
+        assertTrue("IPV6 1::8 should be valid", validator.isValidInet6Address("1::8"));
+        assertTrue("IPV6 1::2:3:4:5:6:7 should be valid", validator.isValidInet6Address("1::2:3:4:5:6:7"));
+        assertTrue("IPV6 1::2:3:4:5:6 should be valid", validator.isValidInet6Address("1::2:3:4:5:6"));
+        assertTrue("IPV6 1::2:3:4:5 should be valid", validator.isValidInet6Address("1::2:3:4:5"));
+        assertTrue("IPV6 1::2:3:4 should be valid", validator.isValidInet6Address("1::2:3:4"));
+        assertTrue("IPV6 1::2:3 should be valid", validator.isValidInet6Address("1::2:3"));
+        assertTrue("IPV6 ::2:3:4:5:6:7:8 should be valid", validator.isValidInet6Address("::2:3:4:5:6:7:8"));
+        assertTrue("IPV6 ::2:3:4:5:6:7 should be valid", validator.isValidInet6Address("::2:3:4:5:6:7"));
+        assertTrue("IPV6 ::2:3:4:5:6 should be valid", validator.isValidInet6Address("::2:3:4:5:6"));
+        assertTrue("IPV6 ::2:3:4:5 should be valid", validator.isValidInet6Address("::2:3:4:5"));
+        assertTrue("IPV6 ::2:3:4 should be valid", validator.isValidInet6Address("::2:3:4"));
+        assertTrue("IPV6 ::2:3 should be valid", validator.isValidInet6Address("::2:3"));
+        assertTrue("IPV6 ::8 should be valid", validator.isValidInet6Address("::8"));
+        assertTrue("IPV6 1:2:3:4:5:6:: should be valid", validator.isValidInet6Address("1:2:3:4:5:6::"));
+        assertTrue("IPV6 1:2:3:4:5:: should be valid", validator.isValidInet6Address("1:2:3:4:5::"));
+        assertTrue("IPV6 1:2:3:4:: should be valid", validator.isValidInet6Address("1:2:3:4::"));
+        assertTrue("IPV6 1:2:3:: should be valid", validator.isValidInet6Address("1:2:3::"));
+        assertTrue("IPV6 1:2:: should be valid", validator.isValidInet6Address("1:2::"));
+        assertTrue("IPV6 1:: should be valid", validator.isValidInet6Address("1::"));
+        assertTrue("IPV6 1:2:3:4:5::7:8 should be valid", validator.isValidInet6Address("1:2:3:4:5::7:8"));
+        assertFalse("IPV6 1:2:3::4:5::7:8 should be invalid", validator.isValidInet6Address("1:2:3::4:5::7:8")); // Double "::"
+        assertFalse("IPV6 12345::6:7:8 should be invalid", validator.isValidInet6Address("12345::6:7:8"));
+        assertTrue("IPV6 1:2:3:4::7:8 should be valid", validator.isValidInet6Address("1:2:3:4::7:8"));
+        assertTrue("IPV6 1:2:3::7:8 should be valid", validator.isValidInet6Address("1:2:3::7:8"));
+        assertTrue("IPV6 1:2::7:8 should be valid", validator.isValidInet6Address("1:2::7:8"));
+        assertTrue("IPV6 1::7:8 should be valid", validator.isValidInet6Address("1::7:8"));
+        // IPv4 addresses as dotted-quads
+        assertTrue("IPV6 1:2:3:4:5:6:1.2.3.4 should be valid", validator.isValidInet6Address("1:2:3:4:5:6:1.2.3.4"));
+        assertTrue("IPV6 1:2:3:4:5::1.2.3.4 should be valid", validator.isValidInet6Address("1:2:3:4:5::1.2.3.4"));
+        assertTrue("IPV6 1:2:3:4::1.2.3.4 should be valid", validator.isValidInet6Address("1:2:3:4::1.2.3.4"));
+        assertTrue("IPV6 1:2:3::1.2.3.4 should be valid", validator.isValidInet6Address("1:2:3::1.2.3.4"));
+        assertTrue("IPV6 1:2::1.2.3.4 should be valid", validator.isValidInet6Address("1:2::1.2.3.4"));
+        assertTrue("IPV6 1::1.2.3.4 should be valid", validator.isValidInet6Address("1::1.2.3.4"));
+        assertTrue("IPV6 1:2:3:4::5:1.2.3.4 should be valid", validator.isValidInet6Address("1:2:3:4::5:1.2.3.4"));
+        assertTrue("IPV6 1:2:3::5:1.2.3.4 should be valid", validator.isValidInet6Address("1:2:3::5:1.2.3.4"));
+        assertTrue("IPV6 1:2::5:1.2.3.4 should be valid", validator.isValidInet6Address("1:2::5:1.2.3.4"));
+        assertTrue("IPV6 1::5:1.2.3.4 should be valid", validator.isValidInet6Address("1::5:1.2.3.4"));
+        assertTrue("IPV6 1::5:11.22.33.44 should be valid", validator.isValidInet6Address("1::5:11.22.33.44"));
+        assertFalse("IPV6 1::5:400.2.3.4 should be invalid", validator.isValidInet6Address("1::5:400.2.3.4"));
+        assertFalse("IPV6 1::5:260.2.3.4 should be invalid", validator.isValidInet6Address("1::5:260.2.3.4"));
+        assertFalse("IPV6 1::5:256.2.3.4 should be invalid", validator.isValidInet6Address("1::5:256.2.3.4"));
+        assertFalse("IPV6 1::5:1.256.3.4 should be invalid", validator.isValidInet6Address("1::5:1.256.3.4"));
+        assertFalse("IPV6 1::5:1.2.256.4 should be invalid", validator.isValidInet6Address("1::5:1.2.256.4"));
+        assertFalse("IPV6 1::5:1.2.3.256 should be invalid", validator.isValidInet6Address("1::5:1.2.3.256"));
+        assertFalse("IPV6 1::5:300.2.3.4 should be invalid", validator.isValidInet6Address("1::5:300.2.3.4"));
+        assertFalse("IPV6 1::5:1.300.3.4 should be invalid", validator.isValidInet6Address("1::5:1.300.3.4"));
+        assertFalse("IPV6 1::5:1.2.300.4 should be invalid", validator.isValidInet6Address("1::5:1.2.300.4"));
+        assertFalse("IPV6 1::5:1.2.3.300 should be invalid", validator.isValidInet6Address("1::5:1.2.3.300"));
+        assertFalse("IPV6 1::5:900.2.3.4 should be invalid", validator.isValidInet6Address("1::5:900.2.3.4"));
+        assertFalse("IPV6 1::5:1.900.3.4 should be invalid", validator.isValidInet6Address("1::5:1.900.3.4"));
+        assertFalse("IPV6 1::5:1.2.900.4 should be invalid", validator.isValidInet6Address("1::5:1.2.900.4"));
+        assertFalse("IPV6 1::5:1.2.3.900 should be invalid", validator.isValidInet6Address("1::5:1.2.3.900"));
+        assertFalse("IPV6 1::5:300.300.300.300 should be invalid", validator.isValidInet6Address("1::5:300.300.300.300"));
+        assertFalse("IPV6 1::5:3000.30.30.30 should be invalid", validator.isValidInet6Address("1::5:3000.30.30.30"));
+        assertFalse("IPV6 1::400.2.3.4 should be invalid", validator.isValidInet6Address("1::400.2.3.4"));
+        assertFalse("IPV6 1::260.2.3.4 should be invalid", validator.isValidInet6Address("1::260.2.3.4"));
+        assertFalse("IPV6 1::256.2.3.4 should be invalid", validator.isValidInet6Address("1::256.2.3.4"));
+        assertFalse("IPV6 1::1.256.3.4 should be invalid", validator.isValidInet6Address("1::1.256.3.4"));
+        assertFalse("IPV6 1::1.2.256.4 should be invalid", validator.isValidInet6Address("1::1.2.256.4"));
+        assertFalse("IPV6 1::1.2.3.256 should be invalid", validator.isValidInet6Address("1::1.2.3.256"));
+        assertFalse("IPV6 1::300.2.3.4 should be invalid", validator.isValidInet6Address("1::300.2.3.4"));
+        assertFalse("IPV6 1::1.300.3.4 should be invalid", validator.isValidInet6Address("1::1.300.3.4"));
+        assertFalse("IPV6 1::1.2.300.4 should be invalid", validator.isValidInet6Address("1::1.2.300.4"));
+        assertFalse("IPV6 1::1.2.3.300 should be invalid", validator.isValidInet6Address("1::1.2.3.300"));
+        assertFalse("IPV6 1::900.2.3.4 should be invalid", validator.isValidInet6Address("1::900.2.3.4"));
+        assertFalse("IPV6 1::1.900.3.4 should be invalid", validator.isValidInet6Address("1::1.900.3.4"));
+        assertFalse("IPV6 1::1.2.900.4 should be invalid", validator.isValidInet6Address("1::1.2.900.4"));
+        assertFalse("IPV6 1::1.2.3.900 should be invalid", validator.isValidInet6Address("1::1.2.3.900"));
+        assertFalse("IPV6 1::300.300.300.300 should be invalid", validator.isValidInet6Address("1::300.300.300.300"));
+        assertFalse("IPV6 1::3000.30.30.30 should be invalid", validator.isValidInet6Address("1::3000.30.30.30"));
+        assertFalse("IPV6 ::400.2.3.4 should be invalid", validator.isValidInet6Address("::400.2.3.4"));
+        assertFalse("IPV6 ::260.2.3.4 should be invalid", validator.isValidInet6Address("::260.2.3.4"));
+        assertFalse("IPV6 ::256.2.3.4 should be invalid", validator.isValidInet6Address("::256.2.3.4"));
+        assertFalse("IPV6 ::1.256.3.4 should be invalid", validator.isValidInet6Address("::1.256.3.4"));
+        assertFalse("IPV6 ::1.2.256.4 should be invalid", validator.isValidInet6Address("::1.2.256.4"));
+        assertFalse("IPV6 ::1.2.3.256 should be invalid", validator.isValidInet6Address("::1.2.3.256"));
+        assertFalse("IPV6 ::300.2.3.4 should be invalid", validator.isValidInet6Address("::300.2.3.4"));
+        assertFalse("IPV6 ::1.300.3.4 should be invalid", validator.isValidInet6Address("::1.300.3.4"));
+        assertFalse("IPV6 ::1.2.300.4 should be invalid", validator.isValidInet6Address("::1.2.300.4"));
+        assertFalse("IPV6 ::1.2.3.300 should be invalid", validator.isValidInet6Address("::1.2.3.300"));
+        assertFalse("IPV6 ::900.2.3.4 should be invalid", validator.isValidInet6Address("::900.2.3.4"));
+        assertFalse("IPV6 ::1.900.3.4 should be invalid", validator.isValidInet6Address("::1.900.3.4"));
+        assertFalse("IPV6 ::1.2.900.4 should be invalid", validator.isValidInet6Address("::1.2.900.4"));
+        assertFalse("IPV6 ::1.2.3.900 should be invalid", validator.isValidInet6Address("::1.2.3.900"));
+        assertFalse("IPV6 ::300.300.300.300 should be invalid", validator.isValidInet6Address("::300.300.300.300"));
+        assertFalse("IPV6 ::3000.30.30.30 should be invalid", validator.isValidInet6Address("::3000.30.30.30"));
+        assertTrue("IPV6 fe80::217:f2ff:254.7.237.98 should be valid", validator.isValidInet6Address("fe80::217:f2ff:254.7.237.98"));
+        assertTrue("IPV6 ::ffff:192.168.1.26 should be valid", validator.isValidInet6Address("::ffff:192.168.1.26"));
+        assertFalse("IPV6 2001:1:1:1:1:1:255Z255X255Y255 should be invalid", validator.isValidInet6Address("2001:1:1:1:1:1:255Z255X255Y255")); // garbage instead of "." in IPv4
+        assertFalse("IPV6 ::ffff:192x168.1.26 should be invalid", validator.isValidInet6Address("::ffff:192x168.1.26")); // ditto
+        assertTrue("IPV6 ::ffff:192.168.1.1 should be valid", validator.isValidInet6Address("::ffff:192.168.1.1"));
+        assertTrue("IPV6 0:0:0:0:0:0:13.1.68.3 should be valid", validator.isValidInet6Address("0:0:0:0:0:0:13.1.68.3"));// IPv4-compatible IPv6 address, full, deprecated 
+        assertTrue("IPV6 0:0:0:0:0:FFFF:129.144.52.38 should be valid", validator.isValidInet6Address("0:0:0:0:0:FFFF:129.144.52.38"));// IPv4-mapped IPv6 address, full 
+        assertTrue("IPV6 ::13.1.68.3 should be valid", validator.isValidInet6Address("::13.1.68.3"));// IPv4-compatible IPv6 address, compressed, deprecated 
+        assertTrue("IPV6 ::FFFF:129.144.52.38 should be valid", validator.isValidInet6Address("::FFFF:129.144.52.38"));// IPv4-mapped IPv6 address, compressed 
+        assertTrue("IPV6 fe80:0:0:0:204:61ff:254.157.241.86 should be valid", validator.isValidInet6Address("fe80:0:0:0:204:61ff:254.157.241.86"));
+        assertTrue("IPV6 fe80::204:61ff:254.157.241.86 should be valid", validator.isValidInet6Address("fe80::204:61ff:254.157.241.86"));
+        assertTrue("IPV6 ::ffff:12.34.56.78 should be valid", validator.isValidInet6Address("::ffff:12.34.56.78"));
+        assertFalse("IPV6 ::ffff:2.3.4 should be invalid", validator.isValidInet6Address("::ffff:2.3.4"));
+        assertFalse("IPV6 ::ffff:257.1.2.3 should be invalid", validator.isValidInet6Address("::ffff:257.1.2.3"));
+        assertFalse("IPV6 1.2.3.4 should be invalid", validator.isValidInet6Address("1.2.3.4"));
+        assertFalse("IPV6 1.2.3.4:1111:2222:3333:4444::5555 should be invalid", validator.isValidInet6Address("1.2.3.4:1111:2222:3333:4444::5555"));
+        assertFalse("IPV6 1.2.3.4:1111:2222:3333::5555 should be invalid", validator.isValidInet6Address("1.2.3.4:1111:2222:3333::5555"));
+        assertFalse("IPV6 1.2.3.4:1111:2222::5555 should be invalid", validator.isValidInet6Address("1.2.3.4:1111:2222::5555"));
+        assertFalse("IPV6 1.2.3.4:1111::5555 should be invalid", validator.isValidInet6Address("1.2.3.4:1111::5555"));
+        assertFalse("IPV6 1.2.3.4::5555 should be invalid", validator.isValidInet6Address("1.2.3.4::5555"));
+        assertFalse("IPV6 1.2.3.4:: should be invalid", validator.isValidInet6Address("1.2.3.4::"));
+        // Testing IPv4 addresses represented as dotted-quads
+        // Leading zeroes in IPv4 addresses not allowed: some systems treat the leading "0" in ".086" as the start of an octal number
+        // Update: The BNF in RFC-3986 explicitly defines the dec-octet (for IPv4 addresses) not to have a leading zero
+        assertFalse("IPV6 fe80:0000:0000:0000:0204:61ff:254.157.241.086 should be invalid", validator.isValidInet6Address("fe80:0000:0000:0000:0204:61ff:254.157.241.086"));
+        assertTrue("IPV6 ::ffff:192.0.2.128 should be valid", validator.isValidInet6Address("::ffff:192.0.2.128")); // but this is OK, since there's a single digit
+        assertFalse("IPV6 XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:1.2.3.4 should be invalid", validator.isValidInet6Address("XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:00.00.00.00 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:00.00.00.00"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:000.000.000.000 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:000.000.000.000"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:256.256.256.256 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:256.256.256.256"));
+        assertTrue("IPV6 fe80:0000:0000:0000:0204:61ff:fe9d:f156 should be valid", validator.isValidInet6Address("fe80:0000:0000:0000:0204:61ff:fe9d:f156"));
+        assertTrue("IPV6 fe80:0:0:0:204:61ff:fe9d:f156 should be valid", validator.isValidInet6Address("fe80:0:0:0:204:61ff:fe9d:f156"));
+        assertTrue("IPV6 fe80::204:61ff:fe9d:f156 should be valid", validator.isValidInet6Address("fe80::204:61ff:fe9d:f156"));
+        assertFalse("IPV6 : should be invalid", validator.isValidInet6Address(":"));
+        assertTrue("IPV6 ::ffff:c000:280 should be valid", validator.isValidInet6Address("::ffff:c000:280"));
+        assertFalse("IPV6 1111:2222:3333:4444::5555: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444::5555:"));
+        assertFalse("IPV6 1111:2222:3333::5555: should be invalid", validator.isValidInet6Address("1111:2222:3333::5555:"));
+        assertFalse("IPV6 1111:2222::5555: should be invalid", validator.isValidInet6Address("1111:2222::5555:"));
+        assertFalse("IPV6 1111::5555: should be invalid", validator.isValidInet6Address("1111::5555:"));
+        assertFalse("IPV6 ::5555: should be invalid", validator.isValidInet6Address("::5555:"));
+        assertFalse("IPV6 ::: should be invalid", validator.isValidInet6Address(":::"));
+        assertFalse("IPV6 1111: should be invalid", validator.isValidInet6Address("1111:"));
+        assertFalse("IPV6 :1111:2222:3333:4444::5555 should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444::5555"));
+        assertFalse("IPV6 :1111:2222:3333::5555 should be invalid", validator.isValidInet6Address(":1111:2222:3333::5555"));
+        assertFalse("IPV6 :1111:2222::5555 should be invalid", validator.isValidInet6Address(":1111:2222::5555"));
+        assertFalse("IPV6 :1111::5555 should be invalid", validator.isValidInet6Address(":1111::5555"));
+        assertFalse("IPV6 :::5555 should be invalid", validator.isValidInet6Address(":::5555"));
+        assertTrue("IPV6 2001:0db8:85a3:0000:0000:8a2e:0370:7334 should be valid", validator.isValidInet6Address("2001:0db8:85a3:0000:0000:8a2e:0370:7334"));
+        assertTrue("IPV6 2001:db8:85a3:0:0:8a2e:370:7334 should be valid", validator.isValidInet6Address("2001:db8:85a3:0:0:8a2e:370:7334"));
+        assertTrue("IPV6 2001:db8:85a3::8a2e:370:7334 should be valid", validator.isValidInet6Address("2001:db8:85a3::8a2e:370:7334"));
+        assertTrue("IPV6 2001:0db8:0000:0000:0000:0000:1428:57ab should be valid", validator.isValidInet6Address("2001:0db8:0000:0000:0000:0000:1428:57ab"));
+        assertTrue("IPV6 2001:0db8:0000:0000:0000::1428:57ab should be valid", validator.isValidInet6Address("2001:0db8:0000:0000:0000::1428:57ab"));
+        assertTrue("IPV6 2001:0db8:0:0:0:0:1428:57ab should be valid", validator.isValidInet6Address("2001:0db8:0:0:0:0:1428:57ab"));
+        assertTrue("IPV6 2001:0db8:0:0::1428:57ab should be valid", validator.isValidInet6Address("2001:0db8:0:0::1428:57ab"));
+        assertTrue("IPV6 2001:0db8::1428:57ab should be valid", validator.isValidInet6Address("2001:0db8::1428:57ab"));
+        assertTrue("IPV6 2001:db8::1428:57ab should be valid", validator.isValidInet6Address("2001:db8::1428:57ab"));
+        assertTrue("IPV6 ::ffff:0c22:384e should be valid", validator.isValidInet6Address("::ffff:0c22:384e"));
+        assertTrue("IPV6 2001:0db8:1234:0000:0000:0000:0000:0000 should be valid", validator.isValidInet6Address("2001:0db8:1234:0000:0000:0000:0000:0000"));
+        assertTrue("IPV6 2001:0db8:1234:ffff:ffff:ffff:ffff:ffff should be valid", validator.isValidInet6Address("2001:0db8:1234:ffff:ffff:ffff:ffff:ffff"));
+        assertTrue("IPV6 2001:db8:a::123 should be valid", validator.isValidInet6Address("2001:db8:a::123"));
+        assertFalse("IPV6 123 should be invalid", validator.isValidInet6Address("123"));
+        assertFalse("IPV6 ldkfj should be invalid", validator.isValidInet6Address("ldkfj"));
+        assertFalse("IPV6 2001::FFD3::57ab should be invalid", validator.isValidInet6Address("2001::FFD3::57ab"));
+        assertFalse("IPV6 2001:db8:85a3::8a2e:37023:7334 should be invalid", validator.isValidInet6Address("2001:db8:85a3::8a2e:37023:7334"));
+        assertFalse("IPV6 2001:db8:85a3::8a2e:370k:7334 should be invalid", validator.isValidInet6Address("2001:db8:85a3::8a2e:370k:7334"));
+        assertFalse("IPV6 1:2:3:4:5:6:7:8:9 should be invalid", validator.isValidInet6Address("1:2:3:4:5:6:7:8:9"));
+        assertFalse("IPV6 1::2::3 should be invalid", validator.isValidInet6Address("1::2::3"));
+        assertFalse("IPV6 1:::3:4:5 should be invalid", validator.isValidInet6Address("1:::3:4:5"));
+        assertFalse("IPV6 1:2:3::4:5:6:7:8:9 should be invalid", validator.isValidInet6Address("1:2:3::4:5:6:7:8:9"));
+        assertTrue("IPV6 1111:2222:3333:4444:5555:6666:7777:8888 should be valid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:7777:8888"));
+        assertTrue("IPV6 1111:2222:3333:4444:5555:6666:7777:: should be valid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:7777::"));
+        assertTrue("IPV6 1111:2222:3333:4444:5555:6666:: should be valid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666::"));
+        assertTrue("IPV6 1111:2222:3333:4444:5555:: should be valid", validator.isValidInet6Address("1111:2222:3333:4444:5555::"));
+        assertTrue("IPV6 1111:2222:3333:4444:: should be valid", validator.isValidInet6Address("1111:2222:3333:4444::"));
+        assertTrue("IPV6 1111:2222:3333:: should be valid", validator.isValidInet6Address("1111:2222:3333::"));
+        assertTrue("IPV6 1111:2222:: should be valid", validator.isValidInet6Address("1111:2222::"));
+        assertTrue("IPV6 1111:: should be valid", validator.isValidInet6Address("1111::"));
+        assertTrue("IPV6 1111:2222:3333:4444:5555:6666::8888 should be valid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666::8888"));
+        assertTrue("IPV6 1111:2222:3333:4444:5555::8888 should be valid", validator.isValidInet6Address("1111:2222:3333:4444:5555::8888"));
+        assertTrue("IPV6 1111:2222:3333:4444::8888 should be valid", validator.isValidInet6Address("1111:2222:3333:4444::8888"));
+        assertTrue("IPV6 1111:2222:3333::8888 should be valid", validator.isValidInet6Address("1111:2222:3333::8888"));
+        assertTrue("IPV6 1111:2222::8888 should be valid", validator.isValidInet6Address("1111:2222::8888"));
+        assertTrue("IPV6 1111::8888 should be valid", validator.isValidInet6Address("1111::8888"));
+        assertTrue("IPV6 ::8888 should be valid", validator.isValidInet6Address("::8888"));
+        assertTrue("IPV6 1111:2222:3333:4444:5555::7777:8888 should be valid", validator.isValidInet6Address("1111:2222:3333:4444:5555::7777:8888"));
+        assertTrue("IPV6 1111:2222:3333:4444::7777:8888 should be valid", validator.isValidInet6Address("1111:2222:3333:4444::7777:8888"));
+        assertTrue("IPV6 1111:2222:3333::7777:8888 should be valid", validator.isValidInet6Address("1111:2222:3333::7777:8888"));
+        assertTrue("IPV6 1111:2222::7777:8888 should be valid", validator.isValidInet6Address("1111:2222::7777:8888"));
+        assertTrue("IPV6 1111::7777:8888 should be valid", validator.isValidInet6Address("1111::7777:8888"));
+        assertTrue("IPV6 ::7777:8888 should be valid", validator.isValidInet6Address("::7777:8888"));
+        assertTrue("IPV6 1111:2222:3333:4444::6666:7777:8888 should be valid", validator.isValidInet6Address("1111:2222:3333:4444::6666:7777:8888"));
+        assertTrue("IPV6 1111:2222:3333::6666:7777:8888 should be valid", validator.isValidInet6Address("1111:2222:3333::6666:7777:8888"));
+        assertTrue("IPV6 1111:2222::6666:7777:8888 should be valid", validator.isValidInet6Address("1111:2222::6666:7777:8888"));
+        assertTrue("IPV6 1111::6666:7777:8888 should be valid", validator.isValidInet6Address("1111::6666:7777:8888"));
+        assertTrue("IPV6 ::6666:7777:8888 should be valid", validator.isValidInet6Address("::6666:7777:8888"));
+        assertTrue("IPV6 1111:2222:3333::5555:6666:7777:8888 should be valid", validator.isValidInet6Address("1111:2222:3333::5555:6666:7777:8888"));
+        assertTrue("IPV6 1111:2222::5555:6666:7777:8888 should be valid", validator.isValidInet6Address("1111:2222::5555:6666:7777:8888"));
+        assertTrue("IPV6 1111::5555:6666:7777:8888 should be valid", validator.isValidInet6Address("1111::5555:6666:7777:8888"));
+        assertTrue("IPV6 ::5555:6666:7777:8888 should be valid", validator.isValidInet6Address("::5555:6666:7777:8888"));
+        assertTrue("IPV6 1111:2222::4444:5555:6666:7777:8888 should be valid", validator.isValidInet6Address("1111:2222::4444:5555:6666:7777:8888"));
+        assertTrue("IPV6 1111::4444:5555:6666:7777:8888 should be valid", validator.isValidInet6Address("1111::4444:5555:6666:7777:8888"));
+        assertTrue("IPV6 ::4444:5555:6666:7777:8888 should be valid", validator.isValidInet6Address("::4444:5555:6666:7777:8888"));
+        assertTrue("IPV6 1111::3333:4444:5555:6666:7777:8888 should be valid", validator.isValidInet6Address("1111::3333:4444:5555:6666:7777:8888"));
+        assertTrue("IPV6 ::3333:4444:5555:6666:7777:8888 should be valid", validator.isValidInet6Address("::3333:4444:5555:6666:7777:8888"));
+        assertTrue("IPV6 ::2222:3333:4444:5555:6666:7777:8888 should be valid", validator.isValidInet6Address("::2222:3333:4444:5555:6666:7777:8888"));
+        assertTrue("IPV6 1111:2222:3333:4444:5555:6666:123.123.123.123 should be valid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:123.123.123.123"));
+        assertTrue("IPV6 1111:2222:3333:4444:5555::123.123.123.123 should be valid", validator.isValidInet6Address("1111:2222:3333:4444:5555::123.123.123.123"));
+        assertTrue("IPV6 1111:2222:3333:4444::123.123.123.123 should be valid", validator.isValidInet6Address("1111:2222:3333:4444::123.123.123.123"));
+        assertTrue("IPV6 1111:2222:3333::123.123.123.123 should be valid", validator.isValidInet6Address("1111:2222:3333::123.123.123.123"));
+        assertTrue("IPV6 1111:2222::123.123.123.123 should be valid", validator.isValidInet6Address("1111:2222::123.123.123.123"));
+        assertTrue("IPV6 1111::123.123.123.123 should be valid", validator.isValidInet6Address("1111::123.123.123.123"));
+        assertTrue("IPV6 ::123.123.123.123 should be valid", validator.isValidInet6Address("::123.123.123.123"));
+        assertTrue("IPV6 1111:2222:3333:4444::6666:123.123.123.123 should be valid", validator.isValidInet6Address("1111:2222:3333:4444::6666:123.123.123.123"));
+        assertTrue("IPV6 1111:2222:3333::6666:123.123.123.123 should be valid", validator.isValidInet6Address("1111:2222:3333::6666:123.123.123.123"));
+        assertTrue("IPV6 1111:2222::6666:123.123.123.123 should be valid", validator.isValidInet6Address("1111:2222::6666:123.123.123.123"));
+        assertTrue("IPV6 1111::6666:123.123.123.123 should be valid", validator.isValidInet6Address("1111::6666:123.123.123.123"));
+        assertTrue("IPV6 ::6666:123.123.123.123 should be valid", validator.isValidInet6Address("::6666:123.123.123.123"));
+        assertTrue("IPV6 1111:2222:3333::5555:6666:123.123.123.123 should be valid", validator.isValidInet6Address("1111:2222:3333::5555:6666:123.123.123.123"));
+        assertTrue("IPV6 1111:2222::5555:6666:123.123.123.123 should be valid", validator.isValidInet6Address("1111:2222::5555:6666:123.123.123.123"));
+        assertTrue("IPV6 1111::5555:6666:123.123.123.123 should be valid", validator.isValidInet6Address("1111::5555:6666:123.123.123.123"));
+        assertTrue("IPV6 ::5555:6666:123.123.123.123 should be valid", validator.isValidInet6Address("::5555:6666:123.123.123.123"));
+        assertTrue("IPV6 1111:2222::4444:5555:6666:123.123.123.123 should be valid", validator.isValidInet6Address("1111:2222::4444:5555:6666:123.123.123.123"));
+        assertTrue("IPV6 1111::4444:5555:6666:123.123.123.123 should be valid", validator.isValidInet6Address("1111::4444:5555:6666:123.123.123.123"));
+        assertTrue("IPV6 ::4444:5555:6666:123.123.123.123 should be valid", validator.isValidInet6Address("::4444:5555:6666:123.123.123.123"));
+        assertTrue("IPV6 1111::3333:4444:5555:6666:123.123.123.123 should be valid", validator.isValidInet6Address("1111::3333:4444:5555:6666:123.123.123.123"));
+        assertTrue("IPV6 ::2222:3333:4444:5555:6666:123.123.123.123 should be valid", validator.isValidInet6Address("::2222:3333:4444:5555:6666:123.123.123.123"));
+        // Trying combinations of "0" and "::"
+        // These are all syntactically correct, but are bad form 
+        // because "0" adjacent to "::" should be combined into "::"
+        assertTrue("IPV6 ::0:0:0:0:0:0:0 should be valid", validator.isValidInet6Address("::0:0:0:0:0:0:0"));
+        assertTrue("IPV6 ::0:0:0:0:0:0 should be valid", validator.isValidInet6Address("::0:0:0:0:0:0"));
+        assertTrue("IPV6 ::0:0:0:0:0 should be valid", validator.isValidInet6Address("::0:0:0:0:0"));
+        assertTrue("IPV6 ::0:0:0:0 should be valid", validator.isValidInet6Address("::0:0:0:0"));
+        assertTrue("IPV6 ::0:0:0 should be valid", validator.isValidInet6Address("::0:0:0"));
+        assertTrue("IPV6 ::0:0 should be valid", validator.isValidInet6Address("::0:0"));
+        assertTrue("IPV6 ::0 should be valid", validator.isValidInet6Address("::0"));
+        assertTrue("IPV6 0:0:0:0:0:0:0:: should be valid", validator.isValidInet6Address("0:0:0:0:0:0:0::"));
+        assertTrue("IPV6 0:0:0:0:0:0:: should be valid", validator.isValidInet6Address("0:0:0:0:0:0::"));
+        assertTrue("IPV6 0:0:0:0:0:: should be valid", validator.isValidInet6Address("0:0:0:0:0::"));
+        assertTrue("IPV6 0:0:0:0:: should be valid", validator.isValidInet6Address("0:0:0:0::"));
+        assertTrue("IPV6 0:0:0:: should be valid", validator.isValidInet6Address("0:0:0::"));
+        assertTrue("IPV6 0:0:: should be valid", validator.isValidInet6Address("0:0::"));
+        assertTrue("IPV6 0:: should be valid", validator.isValidInet6Address("0::"));
+        // Invalid data
+        assertFalse("IPV6 XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX should be invalid", validator.isValidInet6Address("XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX"));
+        // Too many components
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:7777:8888:9999 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:7777:8888:9999"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:7777:8888:: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:7777:8888::"));
+        assertFalse("IPV6 ::2222:3333:4444:5555:6666:7777:8888:9999 should be invalid", validator.isValidInet6Address("::2222:3333:4444:5555:6666:7777:8888:9999"));
+        // Too few components
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:7777 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:7777"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555"));
+        assertFalse("IPV6 1111:2222:3333:4444 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444"));
+        assertFalse("IPV6 1111:2222:3333 should be invalid", validator.isValidInet6Address("1111:2222:3333"));
+        assertFalse("IPV6 1111:2222 should be invalid", validator.isValidInet6Address("1111:2222"));
+        assertFalse("IPV6 1111 should be invalid", validator.isValidInet6Address("1111"));
+        // Missing :
+        assertFalse("IPV6 11112222:3333:4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address("11112222:3333:4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 1111:22223333:4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address("1111:22223333:4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 1111:2222:33334444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address("1111:2222:33334444:5555:6666:7777:8888"));
+        assertFalse("IPV6 1111:2222:3333:44445555:6666:7777:8888 should be invalid", validator.isValidInet6Address("1111:2222:3333:44445555:6666:7777:8888"));
+        assertFalse("IPV6 1111:2222:3333:4444:55556666:7777:8888 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:55556666:7777:8888"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:66667777:8888 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:66667777:8888"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:77778888 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:77778888"));
+        // Missing : intended for ::
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:7777:8888: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:7777:8888:"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:7777: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:7777:"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:"));
+        assertFalse("IPV6 1111:2222:3333:4444: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:"));
+        assertFalse("IPV6 1111:2222:3333: should be invalid", validator.isValidInet6Address("1111:2222:3333:"));
+        assertFalse("IPV6 1111:2222: should be invalid", validator.isValidInet6Address("1111:2222:"));
+        assertFalse("IPV6 :8888 should be invalid", validator.isValidInet6Address(":8888"));
+        assertFalse("IPV6 :7777:8888 should be invalid", validator.isValidInet6Address(":7777:8888"));
+        assertFalse("IPV6 :6666:7777:8888 should be invalid", validator.isValidInet6Address(":6666:7777:8888"));
+        assertFalse("IPV6 :5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":5555:6666:7777:8888"));
+        assertFalse("IPV6 :4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 :3333:4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":3333:4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 :2222:3333:4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":2222:3333:4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 :1111:2222:3333:4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444:5555:6666:7777:8888"));
+        // :::
+        assertFalse("IPV6 :::2222:3333:4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":::2222:3333:4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 1111:::3333:4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address("1111:::3333:4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 1111:2222:::4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address("1111:2222:::4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 1111:2222:3333:::5555:6666:7777:8888 should be invalid", validator.isValidInet6Address("1111:2222:3333:::5555:6666:7777:8888"));
+        assertFalse("IPV6 1111:2222:3333:4444:::6666:7777:8888 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:::6666:7777:8888"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:::7777:8888 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:::7777:8888"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:::8888 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:::8888"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:7777::: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:7777:::"));
+        // Double ::
+        assertFalse("IPV6 ::2222::4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address("::2222::4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 ::2222:3333::5555:6666:7777:8888 should be invalid", validator.isValidInet6Address("::2222:3333::5555:6666:7777:8888"));
+        assertFalse("IPV6 ::2222:3333:4444::6666:7777:8888 should be invalid", validator.isValidInet6Address("::2222:3333:4444::6666:7777:8888"));
+        assertFalse("IPV6 ::2222:3333:4444:5555::7777:8888 should be invalid", validator.isValidInet6Address("::2222:3333:4444:5555::7777:8888"));
+        assertFalse("IPV6 ::2222:3333:4444:5555:7777::8888 should be invalid", validator.isValidInet6Address("::2222:3333:4444:5555:7777::8888"));
+        assertFalse("IPV6 ::2222:3333:4444:5555:7777:8888:: should be invalid", validator.isValidInet6Address("::2222:3333:4444:5555:7777:8888::"));
+        assertFalse("IPV6 1111::3333::5555:6666:7777:8888 should be invalid", validator.isValidInet6Address("1111::3333::5555:6666:7777:8888"));
+        assertFalse("IPV6 1111::3333:4444::6666:7777:8888 should be invalid", validator.isValidInet6Address("1111::3333:4444::6666:7777:8888"));
+        assertFalse("IPV6 1111::3333:4444:5555::7777:8888 should be invalid", validator.isValidInet6Address("1111::3333:4444:5555::7777:8888"));
+        assertFalse("IPV6 1111::3333:4444:5555:6666::8888 should be invalid", validator.isValidInet6Address("1111::3333:4444:5555:6666::8888"));
+        assertFalse("IPV6 1111::3333:4444:5555:6666:7777:: should be invalid", validator.isValidInet6Address("1111::3333:4444:5555:6666:7777::"));
+        assertFalse("IPV6 1111:2222::4444::6666:7777:8888 should be invalid", validator.isValidInet6Address("1111:2222::4444::6666:7777:8888"));
+        assertFalse("IPV6 1111:2222::4444:5555::7777:8888 should be invalid", validator.isValidInet6Address("1111:2222::4444:5555::7777:8888"));
+        assertFalse("IPV6 1111:2222::4444:5555:6666::8888 should be invalid", validator.isValidInet6Address("1111:2222::4444:5555:6666::8888"));
+        assertFalse("IPV6 1111:2222::4444:5555:6666:7777:: should be invalid", validator.isValidInet6Address("1111:2222::4444:5555:6666:7777::"));
+        assertFalse("IPV6 1111:2222:3333::5555::7777:8888 should be invalid", validator.isValidInet6Address("1111:2222:3333::5555::7777:8888"));
+        assertFalse("IPV6 1111:2222:3333::5555:6666::8888 should be invalid", validator.isValidInet6Address("1111:2222:3333::5555:6666::8888"));
+        assertFalse("IPV6 1111:2222:3333::5555:6666:7777:: should be invalid", validator.isValidInet6Address("1111:2222:3333::5555:6666:7777::"));
+        assertFalse("IPV6 1111:2222:3333:4444::6666::8888 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444::6666::8888"));
+        assertFalse("IPV6 1111:2222:3333:4444::6666:7777:: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444::6666:7777::"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555::7777:: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555::7777::"));
+        // Too many components"
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:7777:8888:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:7777:8888:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:7777:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:7777:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666::1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666::1.2.3.4"));
+        assertFalse("IPV6 ::2222:3333:4444:5555:6666:7777:1.2.3.4 should be invalid", validator.isValidInet6Address("::2222:3333:4444:5555:6666:7777:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:1.2.3.4.5 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:1.2.3.4.5"));
+        // Too few components
+        assertFalse("IPV6 1111:2222:3333:4444:5555:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:3333:4444:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:3333:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:3333:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:1.2.3.4"));
+        assertFalse("IPV6 1111:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:1.2.3.4"));
+        assertFalse("IPV6 1.2.3.4 should be invalid", validator.isValidInet6Address("1.2.3.4"));
+        // Missing :
+        assertFalse("IPV6 11112222:3333:4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address("11112222:3333:4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 1111:22223333:4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:22223333:4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:33334444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:33334444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:3333:44445555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:3333:44445555:6666:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:3333:4444:55556666:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:55556666:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:66661.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:66661.2.3.4"));
+        // Missing .
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:255255.255.255 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:255255.255.255"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:255.255255.255 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:255.255255.255"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:255.255.255255 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:255.255.255255"));
+        // Missing : intended for ::
+        assertFalse("IPV6 :1.2.3.4 should be invalid", validator.isValidInet6Address(":1.2.3.4"));
+        assertFalse("IPV6 :6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":6666:1.2.3.4"));
+        assertFalse("IPV6 :5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":5555:6666:1.2.3.4"));
+        assertFalse("IPV6 :4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 :3333:4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":3333:4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 :2222:3333:4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":2222:3333:4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 :1111:2222:3333:4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444:5555:6666:1.2.3.4"));
+        // :::
+        assertFalse("IPV6 :::2222:3333:4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":::2222:3333:4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 1111:::3333:4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:::3333:4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:::4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:::4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:3333:::5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:3333:::5555:6666:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:3333:4444:::6666:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:::6666:1.2.3.4"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:::1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:::1.2.3.4"));
+        // Double ::
+        assertFalse("IPV6 ::2222::4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address("::2222::4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 ::2222:3333::5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address("::2222:3333::5555:6666:1.2.3.4"));
+        assertFalse("IPV6 ::2222:3333:4444::6666:1.2.3.4 should be invalid", validator.isValidInet6Address("::2222:3333:4444::6666:1.2.3.4"));
+        assertFalse("IPV6 ::2222:3333:4444:5555::1.2.3.4 should be invalid", validator.isValidInet6Address("::2222:3333:4444:5555::1.2.3.4"));
+        assertFalse("IPV6 1111::3333::5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address("1111::3333::5555:6666:1.2.3.4"));
+        assertFalse("IPV6 1111::3333:4444::6666:1.2.3.4 should be invalid", validator.isValidInet6Address("1111::3333:4444::6666:1.2.3.4"));
+        assertFalse("IPV6 1111::3333:4444:5555::1.2.3.4 should be invalid", validator.isValidInet6Address("1111::3333:4444:5555::1.2.3.4"));
+        assertFalse("IPV6 1111:2222::4444::6666:1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222::4444::6666:1.2.3.4"));
+        assertFalse("IPV6 1111:2222::4444:5555::1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222::4444:5555::1.2.3.4"));
+        assertFalse("IPV6 1111:2222:3333::5555::1.2.3.4 should be invalid", validator.isValidInet6Address("1111:2222:3333::5555::1.2.3.4"));
+        // Missing parts
+        assertFalse("IPV6 ::. should be invalid", validator.isValidInet6Address("::."));
+        assertFalse("IPV6 ::.. should be invalid", validator.isValidInet6Address("::.."));
+        assertFalse("IPV6 ::... should be invalid", validator.isValidInet6Address("::..."));
+        assertFalse("IPV6 ::1... should be invalid", validator.isValidInet6Address("::1..."));
+        assertFalse("IPV6 ::1.2.. should be invalid", validator.isValidInet6Address("::1.2.."));
+        assertFalse("IPV6 ::1.2.3. should be invalid", validator.isValidInet6Address("::1.2.3."));
+        assertFalse("IPV6 ::.2.. should be invalid", validator.isValidInet6Address("::.2.."));
+        assertFalse("IPV6 ::.2.3. should be invalid", validator.isValidInet6Address("::.2.3."));
+        assertFalse("IPV6 ::.2.3.4 should be invalid", validator.isValidInet6Address("::.2.3.4"));
+        assertFalse("IPV6 ::..3. should be invalid", validator.isValidInet6Address("::..3."));
+        assertFalse("IPV6 ::..3.4 should be invalid", validator.isValidInet6Address("::..3.4"));
+        assertFalse("IPV6 ::...4 should be invalid", validator.isValidInet6Address("::...4"));
+        // Extra : in front
+        assertFalse("IPV6 :1111:2222:3333:4444:5555:6666:7777:: should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444:5555:6666:7777::"));
+        assertFalse("IPV6 :1111:2222:3333:4444:5555:6666:: should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444:5555:6666::"));
+        assertFalse("IPV6 :1111:2222:3333:4444:5555:: should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444:5555::"));
+        assertFalse("IPV6 :1111:2222:3333:4444:: should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444::"));
+        assertFalse("IPV6 :1111:2222:3333:: should be invalid", validator.isValidInet6Address(":1111:2222:3333::"));
+        assertFalse("IPV6 :1111:2222:: should be invalid", validator.isValidInet6Address(":1111:2222::"));
+        assertFalse("IPV6 :1111:: should be invalid", validator.isValidInet6Address(":1111::"));
+        assertFalse("IPV6 :1111:2222:3333:4444:5555:6666::8888 should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444:5555:6666::8888"));
+        assertFalse("IPV6 :1111:2222:3333:4444:5555::8888 should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444:5555::8888"));
+        assertFalse("IPV6 :1111:2222:3333:4444::8888 should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444::8888"));
+        assertFalse("IPV6 :1111:2222:3333::8888 should be invalid", validator.isValidInet6Address(":1111:2222:3333::8888"));
+        assertFalse("IPV6 :1111:2222::8888 should be invalid", validator.isValidInet6Address(":1111:2222::8888"));
+        assertFalse("IPV6 :1111::8888 should be invalid", validator.isValidInet6Address(":1111::8888"));
+        assertFalse("IPV6 :::8888 should be invalid", validator.isValidInet6Address(":::8888"));
+        assertFalse("IPV6 :1111:2222:3333:4444:5555::7777:8888 should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444:5555::7777:8888"));
+        assertFalse("IPV6 :1111:2222:3333:4444::7777:8888 should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444::7777:8888"));
+        assertFalse("IPV6 :1111:2222:3333::7777:8888 should be invalid", validator.isValidInet6Address(":1111:2222:3333::7777:8888"));
+        assertFalse("IPV6 :1111:2222::7777:8888 should be invalid", validator.isValidInet6Address(":1111:2222::7777:8888"));
+        assertFalse("IPV6 :1111::7777:8888 should be invalid", validator.isValidInet6Address(":1111::7777:8888"));
+        assertFalse("IPV6 :::7777:8888 should be invalid", validator.isValidInet6Address(":::7777:8888"));
+        assertFalse("IPV6 :1111:2222:3333:4444::6666:7777:8888 should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444::6666:7777:8888"));
+        assertFalse("IPV6 :1111:2222:3333::6666:7777:8888 should be invalid", validator.isValidInet6Address(":1111:2222:3333::6666:7777:8888"));
+        assertFalse("IPV6 :1111:2222::6666:7777:8888 should be invalid", validator.isValidInet6Address(":1111:2222::6666:7777:8888"));
+        assertFalse("IPV6 :1111::6666:7777:8888 should be invalid", validator.isValidInet6Address(":1111::6666:7777:8888"));
+        assertFalse("IPV6 :::6666:7777:8888 should be invalid", validator.isValidInet6Address(":::6666:7777:8888"));
+        assertFalse("IPV6 :1111:2222:3333::5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":1111:2222:3333::5555:6666:7777:8888"));
+        assertFalse("IPV6 :1111:2222::5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":1111:2222::5555:6666:7777:8888"));
+        assertFalse("IPV6 :1111::5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":1111::5555:6666:7777:8888"));
+        assertFalse("IPV6 :::5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":::5555:6666:7777:8888"));
+        assertFalse("IPV6 :1111:2222::4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":1111:2222::4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 :1111::4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":1111::4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 :::4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":::4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 :1111::3333:4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":1111::3333:4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 :::3333:4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":::3333:4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 :::2222:3333:4444:5555:6666:7777:8888 should be invalid", validator.isValidInet6Address(":::2222:3333:4444:5555:6666:7777:8888"));
+        assertFalse("IPV6 :1111:2222:3333:4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 :1111:2222:3333:4444:5555::1.2.3.4 should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444:5555::1.2.3.4"));
+        assertFalse("IPV6 :1111:2222:3333:4444::1.2.3.4 should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444::1.2.3.4"));
+        assertFalse("IPV6 :1111:2222:3333::1.2.3.4 should be invalid", validator.isValidInet6Address(":1111:2222:3333::1.2.3.4"));
+        assertFalse("IPV6 :1111:2222::1.2.3.4 should be invalid", validator.isValidInet6Address(":1111:2222::1.2.3.4"));
+        assertFalse("IPV6 :1111::1.2.3.4 should be invalid", validator.isValidInet6Address(":1111::1.2.3.4"));
+        assertFalse("IPV6 :::1.2.3.4 should be invalid", validator.isValidInet6Address(":::1.2.3.4"));
+        assertFalse("IPV6 :1111:2222:3333:4444::6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":1111:2222:3333:4444::6666:1.2.3.4"));
+        assertFalse("IPV6 :1111:2222:3333::6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":1111:2222:3333::6666:1.2.3.4"));
+        assertFalse("IPV6 :1111:2222::6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":1111:2222::6666:1.2.3.4"));
+        assertFalse("IPV6 :1111::6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":1111::6666:1.2.3.4"));
+        assertFalse("IPV6 :::6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":::6666:1.2.3.4"));
+        assertFalse("IPV6 :1111:2222:3333::5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":1111:2222:3333::5555:6666:1.2.3.4"));
+        assertFalse("IPV6 :1111:2222::5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":1111:2222::5555:6666:1.2.3.4"));
+        assertFalse("IPV6 :1111::5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":1111::5555:6666:1.2.3.4"));
+        assertFalse("IPV6 :::5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":::5555:6666:1.2.3.4"));
+        assertFalse("IPV6 :1111:2222::4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":1111:2222::4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 :1111::4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":1111::4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 :::4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":::4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 :1111::3333:4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":1111::3333:4444:5555:6666:1.2.3.4"));
+        assertFalse("IPV6 :::2222:3333:4444:5555:6666:1.2.3.4 should be invalid", validator.isValidInet6Address(":::2222:3333:4444:5555:6666:1.2.3.4"));
+        // Extra : at end
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666:7777::: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:7777:::"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666::: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666:::"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555::: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:::"));
+        assertFalse("IPV6 1111:2222:3333:4444::: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:::"));
+        assertFalse("IPV6 1111:2222:3333::: should be invalid", validator.isValidInet6Address("1111:2222:3333:::"));
+        assertFalse("IPV6 1111:2222::: should be invalid", validator.isValidInet6Address("1111:2222:::"));
+        assertFalse("IPV6 1111::: should be invalid", validator.isValidInet6Address("1111:::"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555:6666::8888: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555:6666::8888:"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555::8888: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555::8888:"));
+        assertFalse("IPV6 1111:2222:3333:4444::8888: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444::8888:"));
+        assertFalse("IPV6 1111:2222:3333::8888: should be invalid", validator.isValidInet6Address("1111:2222:3333::8888:"));
+        assertFalse("IPV6 1111:2222::8888: should be invalid", validator.isValidInet6Address("1111:2222::8888:"));
+        assertFalse("IPV6 1111::8888: should be invalid", validator.isValidInet6Address("1111::8888:"));
+        assertFalse("IPV6 ::8888: should be invalid", validator.isValidInet6Address("::8888:"));
+        assertFalse("IPV6 1111:2222:3333:4444:5555::7777:8888: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444:5555::7777:8888:"));
+        assertFalse("IPV6 1111:2222:3333:4444::7777:8888: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444::7777:8888:"));
+        assertFalse("IPV6 1111:2222:3333::7777:8888: should be invalid", validator.isValidInet6Address("1111:2222:3333::7777:8888:"));
+        assertFalse("IPV6 1111:2222::7777:8888: should be invalid", validator.isValidInet6Address("1111:2222::7777:8888:"));
+        assertFalse("IPV6 1111::7777:8888: should be invalid", validator.isValidInet6Address("1111::7777:8888:"));
+        assertFalse("IPV6 ::7777:8888: should be invalid", validator.isValidInet6Address("::7777:8888:"));
+        assertFalse("IPV6 1111:2222:3333:4444::6666:7777:8888: should be invalid", validator.isValidInet6Address("1111:2222:3333:4444::6666:7777:8888:"));
+        assertFalse("IPV6 1111:2222:3333::6666:7777:8888: should be invalid", validator.isValidInet6Address("1111:2222:3333::6666:7777:8888:"));
+        assertFalse("IPV6 1111:2222::6666:7777:8888: should be invalid", validator.isValidInet6Address("1111:2222::6666:7777:8888:"));
+        assertFalse("IPV6 1111::6666:7777:8888: should be invalid", validator.isValidInet6Address("1111::6666:7777:8888:"));
+        assertFalse("IPV6 ::6666:7777:8888: should be invalid", validator.isValidInet6Address("::6666:7777:8888:"));
+        assertFalse("IPV6 1111:2222:3333::5555:6666:7777:8888: should be invalid", validator.isValidInet6Address("1111:2222:3333::5555:6666:7777:8888:"));
+        assertFalse("IPV6 1111:2222::5555:6666:7777:8888: should be invalid", validator.isValidInet6Address("1111:2222::5555:6666:7777:8888:"));
+        assertFalse("IPV6 1111::5555:6666:7777:8888: should be invalid", validator.isValidInet6Address("1111::5555:6666:7777:8888:"));
+        assertFalse("IPV6 ::5555:6666:7777:8888: should be invalid", validator.isValidInet6Address("::5555:6666:7777:8888:"));
+        assertFalse("IPV6 1111:2222::4444:5555:6666:7777:8888: should be invalid", validator.isValidInet6Address("1111:2222::4444:5555:6666:7777:8888:"));
+        assertFalse("IPV6 1111::4444:5555:6666:7777:8888: should be invalid", validator.isValidInet6Address("1111::4444:5555:6666:7777:8888:"));
+        assertFalse("IPV6 ::4444:5555:6666:7777:8888: should be invalid", validator.isValidInet6Address("::4444:5555:6666:7777:8888:"));
+        assertFalse("IPV6 1111::3333:4444:5555:6666:7777:8888: should be invalid", validator.isValidInet6Address("1111::3333:4444:5555:6666:7777:8888:"));
+        assertFalse("IPV6 ::3333:4444:5555:6666:7777:8888: should be invalid", validator.isValidInet6Address("::3333:4444:5555:6666:7777:8888:"));
+        assertFalse("IPV6 ::2222:3333:4444:5555:6666:7777:8888: should be invalid", validator.isValidInet6Address("::2222:3333:4444:5555:6666:7777:8888:"));
+        assertTrue("IPV6 0:a:b:c:d:e:f:: should be valid", validator.isValidInet6Address("0:a:b:c:d:e:f::"));
+        assertTrue("IPV6 ::0:a:b:c:d:e:f should be valid", validator.isValidInet6Address("::0:a:b:c:d:e:f")); // syntactically correct, but bad form (::0:... could be combined)
+        assertTrue("IPV6 a:b:c:d:e:f:0:: should be valid", validator.isValidInet6Address("a:b:c:d:e:f:0::"));
+        assertFalse("IPV6 ':10.0.0.1 should be invalid", validator.isValidInet6Address("':10.0.0.1"));
+    }
+}
+
+

--- a/src/test/java/org/jenkinsci/remoting/org/apache/commons/validator/routines/RegexValidatorTest.java
+++ b/src/test/java/org/jenkinsci/remoting/org/apache/commons/validator/routines/RegexValidatorTest.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jenkinsci.remoting.org.apache.commons.validator.routines;
+
+import java.util.regex.PatternSyntaxException;
+
+import junit.framework.TestCase;
+
+/**
+ * Test Case for RegexValidatorTest.
+ *
+ * @version $Revision$
+ * @since Validator 1.4
+ */
+public class RegexValidatorTest extends TestCase {
+
+    private static final String REGEX         = "^([abc]*)(?:\\-)([DEF]*)(?:\\-)([123]*)$";
+
+    private static final String COMPONENT_1 = "([abc]{3})";
+    private static final String COMPONENT_2 = "([DEF]{3})";
+    private static final String COMPONENT_3 = "([123]{3})";
+    private static final String SEPARATOR_1  = "(?:\\-)";
+    private static final String SEPARATOR_2  = "(?:\\s)";
+    private static final String REGEX_1 = "^" + COMPONENT_1 + SEPARATOR_1 + COMPONENT_2 + SEPARATOR_1 + COMPONENT_3 + "$";
+    private static final String REGEX_2 = "^" + COMPONENT_1 + SEPARATOR_2 + COMPONENT_2 + SEPARATOR_2 + COMPONENT_3 + "$";
+    private static final String REGEX_3 = "^" + COMPONENT_1 + COMPONENT_2 + COMPONENT_3 + "$";
+    private static final String[] MULTIPLE_REGEX = new String[] {REGEX_1, REGEX_2, REGEX_3};
+
+    /**
+     * Constrct a new test case.
+     * @param name The name of the test
+     */
+    public RegexValidatorTest(String name) {
+        super(name);
+    }
+
+    /**
+     * Set Up.
+     */
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    /**
+     * Tear Down.
+     */
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    /**
+     * Test instance methods with single regular expression.
+     */
+    public void testSingle() {
+        RegexValidator sensitive   = new RegexValidator(REGEX);
+        RegexValidator insensitive = new RegexValidator(REGEX, false);
+
+        // isValid()
+        assertEquals("Sensitive isValid() valid",     true,   sensitive.isValid("ac-DE-1"));
+        assertEquals("Sensitive isValid() invalid",   false,  sensitive.isValid("AB-de-1"));
+        assertEquals("Insensitive isValid() valid",   true,   insensitive.isValid("AB-de-1"));
+        assertEquals("Insensitive isValid() invalid", false,  insensitive.isValid("ABd-de-1"));
+
+        // validate()
+        assertEquals("Sensitive validate() valid",     "acDE1", sensitive.validate("ac-DE-1"));
+        assertEquals("Sensitive validate() invalid",   null,    sensitive.validate("AB-de-1"));
+        assertEquals("Insensitive validate() valid",   "ABde1", insensitive.validate("AB-de-1"));
+        assertEquals("Insensitive validate() invalid", null,    insensitive.validate("ABd-de-1"));
+
+        // match()
+        checkArray("Sensitive match() valid",     new String[] {"ac", "DE", "1"}, sensitive.match("ac-DE-1"));
+        checkArray("Sensitive match() invalid",   null,                           sensitive.match("AB-de-1"));
+        checkArray("Insensitive match() valid",   new String[] {"AB", "de", "1"}, insensitive.match("AB-de-1"));
+        checkArray("Insensitive match() invalid", null,                           insensitive.match("ABd-de-1"));
+        assertEquals("validate one", "ABC", (new RegexValidator("^([A-Z]*)$")).validate("ABC"));
+        checkArray("match one", new String[] {"ABC"}, (new RegexValidator("^([A-Z]*)$")).match("ABC"));
+    }
+
+    /**
+     * Test with multiple regular expressions (case sensitive).
+     */
+    public void testMultipleSensitive() {
+
+        // ------------ Set up Sensitive Validators
+        RegexValidator multiple   = new RegexValidator(MULTIPLE_REGEX);
+        RegexValidator single1   = new RegexValidator(REGEX_1);
+        RegexValidator single2   = new RegexValidator(REGEX_2);
+        RegexValidator single3   = new RegexValidator(REGEX_3);
+
+        // ------------ Set up test values
+        String value = "aac FDE 321";
+        String expect = "aacFDE321";
+        String[] array = new String[] {"aac", "FDE", "321"};
+
+        // isValid()
+        assertEquals("Sensitive isValid() Multiple", true,  multiple.isValid(value));
+        assertEquals("Sensitive isValid() 1st",      false, single1.isValid(value));
+        assertEquals("Sensitive isValid() 2nd",      true,  single2.isValid(value));
+        assertEquals("Sensitive isValid() 3rd",      false, single3.isValid(value));
+
+        // validate()
+        assertEquals("Sensitive validate() Multiple", expect, multiple.validate(value));
+        assertEquals("Sensitive validate() 1st",      null,   single1.validate(value));
+        assertEquals("Sensitive validate() 2nd",      expect, single2.validate(value));
+        assertEquals("Sensitive validate() 3rd",      null,   single3.validate(value));
+
+        // match()
+        checkArray("Sensitive match() Multiple", array, multiple.match(value));
+        checkArray("Sensitive match() 1st",      null,  single1.match(value));
+        checkArray("Sensitive match() 2nd",      array, single2.match(value));
+        checkArray("Sensitive match() 3rd",      null,  single3.match(value));
+
+        // All invalid
+        value = "AAC*FDE*321";
+        assertEquals("isValid() Invalid",  false, multiple.isValid(value));
+        assertEquals("validate() Invalid", null,  multiple.validate(value));
+        assertEquals("match() Multiple",   null,  multiple.match(value));
+    }
+
+    /**
+     * Test with multiple regular expressions (case in-sensitive).
+     */
+    public void testMultipleInsensitive() {
+
+        // ------------ Set up In-sensitive Validators
+        RegexValidator multiple = new RegexValidator(MULTIPLE_REGEX, false);
+        RegexValidator single1   = new RegexValidator(REGEX_1, false);
+        RegexValidator single2   = new RegexValidator(REGEX_2, false);
+        RegexValidator single3   = new RegexValidator(REGEX_3, false);
+
+        // ------------ Set up test values
+        String value = "AAC FDE 321";
+        String expect = "AACFDE321";
+        String[] array = new String[] {"AAC", "FDE", "321"};
+
+        // isValid()
+        assertEquals("isValid() Multiple", true,  multiple.isValid(value));
+        assertEquals("isValid() 1st",      false, single1.isValid(value));
+        assertEquals("isValid() 2nd",      true,  single2.isValid(value));
+        assertEquals("isValid() 3rd",      false, single3.isValid(value));
+
+        // validate()
+        assertEquals("validate() Multiple", expect, multiple.validate(value));
+        assertEquals("validate() 1st",      null,   single1.validate(value));
+        assertEquals("validate() 2nd",      expect, single2.validate(value));
+        assertEquals("validate() 3rd",      null,   single3.validate(value));
+
+        // match()
+        checkArray("match() Multiple", array, multiple.match(value));
+        checkArray("match() 1st",      null,  single1.match(value));
+        checkArray("match() 2nd",      array, single2.match(value));
+        checkArray("match() 3rd",      null,  single3.match(value));
+
+        // All invalid
+        value = "AAC*FDE*321";
+        assertEquals("isValid() Invalid",  false, multiple.isValid(value));
+        assertEquals("validate() Invalid", null,  multiple.validate(value));
+        assertEquals("match() Multiple",   null,  multiple.match(value));
+    }
+
+    /**
+     * Test Null value
+     */
+    public void testNullValue() {
+
+        RegexValidator validator = new RegexValidator(REGEX);
+        assertEquals("Instance isValid()",  false, validator.isValid(null));
+        assertEquals("Instance validate()", null,  validator.validate(null));
+        assertEquals("Instance match()",    null,  validator.match(null));
+    }
+
+    /**
+     * Test exceptions
+     */
+    public void testMissingRegex() {
+
+        // Single Regular Expression - null
+        try {
+            new RegexValidator((String)null);
+            fail("Single Null - expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Single Null", "Regular expression[0] is missing", e.getMessage());
+        }
+
+        // Single Regular Expression - Zero Length
+        try {
+            new RegexValidator("");
+            fail("Single Zero Length - expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Single Zero Length", "Regular expression[0] is missing", e.getMessage());
+        }
+
+        // Multiple Regular Expression - Null array
+        try {
+            new RegexValidator((String[])null);
+            fail("Null Array - expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Null Array", "Regular expressions are missing", e.getMessage());
+        }
+
+        // Multiple Regular Expression - Zero Length array
+        try {
+            new RegexValidator(new String[0]);
+            fail("Zero Length Array - expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Zero Length Array", "Regular expressions are missing", e.getMessage());
+        }
+
+        // Multiple Regular Expression - Array has Null
+        String[] expressions = new String[] {"ABC", null};
+        try {
+            new RegexValidator(expressions);
+            fail("Array has Null - expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Array has Null", "Regular expression[1] is missing", e.getMessage());
+        }
+
+        // Multiple Regular Expression - Array has Zero Length
+        expressions = new String[] {"", "ABC"};
+        try {
+            new RegexValidator(expressions);
+            fail("Array has Zero Length - expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Array has Zero Length", "Regular expression[0] is missing", e.getMessage());
+        }
+    }
+
+    /**
+     * Test exceptions
+     */
+    public void testExceptions() {
+        String invalidRegex = "^([abCD12]*$";
+        try {
+            new RegexValidator(invalidRegex);
+        } catch (PatternSyntaxException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Test toString() method
+     */
+    public void testToString() {
+        RegexValidator single = new RegexValidator(REGEX);
+        assertEquals("Single", "RegexValidator{" + REGEX + "}", single.toString());
+
+        RegexValidator multiple = new RegexValidator(new String[] {REGEX, REGEX});
+        assertEquals("Multiple", "RegexValidator{" + REGEX + "," + REGEX + "}", multiple.toString());
+    }
+
+    /**
+     * Compare two arrays
+     * @param label Label for the test
+     * @param expect Expected array
+     * @param result Actual array
+     */
+    private void checkArray(String label, String[] expect, String[] result) {
+
+        // Handle nulls
+        if (expect == null || result == null) {
+            if (expect == null && result == null) {
+                return; // valid, both null
+            } else {
+                fail(label + " Null expect=" + expect + " result=" + result);
+            }
+            return; // not strictly necessary, but prevents possible NPE below
+        }
+
+        // Check Length
+        if (expect.length != result.length) {
+            fail(label + " Length expect=" + expect.length + " result=" + result.length);
+        }
+
+        // Check Values
+        for (int i = 0; i < expect.length; i++) {
+            assertEquals(label +" value[" + i + "]", expect[i], result[i]);
+        }
+    }
+
+}


### PR DESCRIPTION
Tweak the implementation to not draw in new dependencies.

For the changes to the no_proxy capability, I added a couple of dependencies for checking and handling ip addresses and subnets.
One of them was clearly the wrong one to use when I started integrating.
Rather, than add dependencies, we decided to copy in utilities. This same pattern was followed recently in Jenkins core to avoid introducing new dependencies into Jenkins core that plugins may become dependent on.