### PR TITLE
Avoid System.out/err.println in anything that might be called from a Surefire JVM

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -282,13 +282,13 @@ public class WorkDirManager {
         }
         
         if (overrideLogPath != null) { // Legacy behavior
-            System.out.println("Using " + overrideLogPath + " as an agent Error log destination. 'Out' log won't be generated");
+            LOGGER.log(Level.INFO, "Using {0} as an agent error log destination; output log will not be generated", overrideLogPath);
             System.out.flush(); // Just in case the channel
             System.err.flush();
             System.setErr(legacyCreateTeeStream(System.err, overrideLogPath));
             this.loggingInitialized = true;
         } else if (internalDirPath != null) { // New behavior
-            System.out.println("Both error and output logs will be printed to " + internalDirPath);
+            LOGGER.log(Level.INFO, "Both error and output logs will be printed to {0}", internalDirPath);
             System.out.flush();
             System.err.flush();
 


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/3804/commits/f966a8917046c5fc1f31ed109f7d9333278135d2 caught [this](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-3804/3/artifact/test/target/surefire-reports/2018-12-12T14-11-05_283-jvmRun1.dumpstream/*view*/):

```
Corrupted stdin stream in forked JVM 1. Stream 'Both error and output logs will be printed to /mnt/agent-workspace/workspace/Core_jenkins_PR-3804-BDA3623DFIXRNF67IWW63OZ647EEFX6OR7LH5CV7JUQJB5ANAMKA/test/target/test/remoting'.
java.lang.IllegalArgumentException: Stream stdin corrupted. Expected comma after third character in command 'Both error and output logs will be printed to /mnt/agent-workspace/workspace/Core_jenkins_PR-3804-BDA3623DFIXRNF67IWW63OZ647EEFX6OR7LH5CV7JUQJB5ANAMKA/test/target/test/remoting'.
	at org.apache.maven.plugin.surefire.booterclient.output.ForkClient$OperationalData.<init>(ForkClient.java:469)
	at org.apache.maven.plugin.surefire.booterclient.output.ForkClient.processLine(ForkClient.java:191)
	at org.apache.maven.plugin.surefire.booterclient.output.ForkClient.consumeLine(ForkClient.java:158)
	at org.apache.maven.plugin.surefire.booterclient.output.ThreadedStreamConsumer$Pumper.run(ThreadedStreamConsumer.java:87)
	at java.lang.Thread.run(Thread.java:748)
```

Not sure if this will solve the issue (I am not sure even sure which test case triggers this), but at least the rest of the class is using `Logger` so this should too.