### PR TITLE
[JENKINS-51004] - Pass loggingConfigFilePath from CLI arguments to the workDirManager

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -301,6 +301,9 @@ public class Launcher {
         if (slaveLog != null) {
             workDirManager.disable(WorkDirManager.DirType.LOGS_DIR);
         }
+        if (loggingConfigFilePath != null) {
+            workDirManager.setLoggingConfig(loggingConfigFilePath);
+        }
         workDirManager.setupLogging(internalDirPath, slaveLog != null ? PathUtils.fileToPath(slaveLog) : null);
 
         if(auth!=null) {


### PR DESCRIPTION
Launcher was never passing the loggingConfigFilePath to the workDirManager
so the -loggingConfig setting didn't work.

https://issues.jenkins-ci.org/browse/JENKINS-51004