### PR TITLE
Incorrect Javadoc for Main.args

### DIFF
--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -178,8 +178,7 @@ public class Main {
 
 
     /**
-     * 4 mandatory parameters.
-     * Host name (deprecated), Jenkins URL, secret key, and agent name.
+     * Two mandatory parameters: secret key, and agent name.
      */
     @Argument
     public final List<String> args = new ArrayList<String>();


### PR DESCRIPTION
See size check below, and the indexing inside `createEngine`. Not sure how long this Javadoc has been wrong. Perhaps it would be better to use

```java
@Argument(index = 0) public String secretKey;
@Argument(index = 1) public String agentName;
```

but I will leave that for another day.