### PR TITLE
Addition to PR 286: Add Instance Identity Key to Support JNLP4

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -141,8 +141,13 @@ public class Engine extends Thread {
     private String tunnel;
     
     /**
-     * The base64 encoded byte array of the Instance Identities public key of the Jenkins master. 
-     * See https://wiki.jenkins.io/display/JENKINS/Instance+Identity
+     * The base64 encoded byte array of the <a href="https://wiki.jenkins.io/display/JENKINS/Instance+Identity">Instance Identities</a> public key of the Jenkins master.<br>
+     * This parameter is only required if the master does not expose an http(s) port. The correct value can be figured out by:
+     * <pre>
+     *   hudson.remoting.Base64.encode(org.jenkinsci.main.modules.instance_identity.InstanceIdentity.get().getPublic().getEncoded())
+     * </pre>
+     * @see <a href="https://wiki.jenkins.io/display/JENKINS/Instance+Identity">Instance Identity</a>
+     * @see #disableHttpEndpointCheck
      */
     @CheckForNull
     private String instanceIdentity;
@@ -221,8 +226,8 @@ public class Engine extends Thread {
         this.candidateUrls = hudsonUrls;
         this.secretKey = secretKey;
         this.slaveName = slaveName;
-        //if(candidateUrls.isEmpty())
-        //    throw new IllegalArgumentException("No URLs given");
+        if(candidateUrls.isEmpty() && !this.disableHttpEndpointCheck)
+            throw new IllegalArgumentException("No URLs given");
         setUncaughtExceptionHandler((t, e) -> {
             LOGGER.log(Level.SEVERE, "Uncaught exception in Engine thread " + t, e);
             interrupt();
@@ -344,13 +349,19 @@ public class Engine extends Thread {
     }
     
     /**
-     * @param instanceIdentity The base64 encoded byte array of the Instance Identities public key of the Jenkins master. 
-     *        See https://wiki.jenkins.io/display/JENKINS/Instance+Identity
+     * This parameter is only required if the master does not expose an http(s) port. 
+     * @param instanceIdentity The base64 encoded byte array of the <a href="https://wiki.jenkins.io/display/JENKINS/Instance+Identity">Instance Identities</a> public key of the Jenkins master.
+     *        The correct value can be figured out by:
+     *        <pre>
+     *          hudson.remoting.Base64.encode(org.jenkinsci.main.modules.instance_identity.InstanceIdentity.get().getPublic().getEncoded())
+     *        </pre>
+     * @see <a href="https://wiki.jenkins.io/display/JENKINS/Instance+Identity">Instance Identity</a>
+     * @see #disableHttpEndpointCheck
+     * @since TODO
      */
     public void setInstanceIdentity(@CheckForNull String instanceIdentity) {
         this.instanceIdentity = instanceIdentity;
     }
-        
 
     public void setCredentials(String creds) {
         this.credentials = creds;

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -226,8 +226,6 @@ public class Engine extends Thread {
         this.candidateUrls = hudsonUrls;
         this.secretKey = secretKey;
         this.slaveName = slaveName;
-        if(candidateUrls.isEmpty() && !this.disableHttpEndpointCheck)
-            throw new IllegalArgumentException("No URLs given");
         setUncaughtExceptionHandler((t, e) -> {
             LOGGER.log(Level.SEVERE, "Uncaught exception in Engine thread " + t, e);
             interrupt();
@@ -241,6 +239,8 @@ public class Engine extends Thread {
      * @since 3.9
      */
     public synchronized void startEngine() throws IOException {
+        if(candidateUrls.isEmpty() && !disableHttpEndpointCheck)
+            throw new IllegalArgumentException("No URLs given");
         startEngine(false);
     }
      

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -139,6 +139,13 @@ public class Engine extends Thread {
      */
     @CheckForNull
     private String tunnel;
+    
+    /**
+     * The base64 encoded byte array of the Instance Identities public key of the Jenkins master. 
+     * See https://wiki.jenkins.io/display/JENKINS/Instance+Identity
+     */
+    @CheckForNull
+    private String instanceIdentity;
 
     private boolean disableHttpsCertValidation;
 
@@ -214,8 +221,8 @@ public class Engine extends Thread {
         this.candidateUrls = hudsonUrls;
         this.secretKey = secretKey;
         this.slaveName = slaveName;
-        if(candidateUrls.isEmpty())
-            throw new IllegalArgumentException("No URLs given");
+        //if(candidateUrls.isEmpty())
+        //    throw new IllegalArgumentException("No URLs given");
         setUncaughtExceptionHandler((t, e) -> {
             LOGGER.log(Level.SEVERE, "Uncaught exception in Engine thread " + t, e);
             interrupt();
@@ -335,6 +342,15 @@ public class Engine extends Thread {
     public void setTunnel(@CheckForNull String tunnel) {
         this.tunnel = tunnel;
     }
+    
+    /**
+     * @param instanceIdentity The base64 encoded byte array of the Instance Identities public key of the Jenkins master. 
+     *        See https://wiki.jenkins.io/display/JENKINS/Instance+Identity
+     */
+    public void setInstanceIdentity(@CheckForNull String instanceIdentity) {
+        this.instanceIdentity = instanceIdentity;
+    }
+        
 
     public void setCredentials(String creds) {
         this.credentials = creds;
@@ -521,6 +537,7 @@ public class Engine extends Thread {
         resolver.setCredentials(credentials);
         resolver.setProxyCredentials(proxyCredentials);
         resolver.setTunnel(tunnel);
+        resolver.setInstanceIdentity(instanceIdentity);
         resolver.setDisableHttpEndpointCheck(disableHttpEndpointCheck);
         try {
             resolver.setSslSocketFactory(getSSLSocketFactory());

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -73,8 +73,14 @@ public class Main {
                   "in which case the missing portion will be auto-configured like the default behavior")
     public String tunnel;
 
+    @Option(name="-instanceIdentity",
+            usage="The Base64 encoded InstanceIdentity byte array of the Jenkins master. " +
+                  "This parameter is only required if the Jenkins master does not expose an http(s) endpoint" +
+                  "(see also parameter -noHttpEndpoint)")
+    public String instanceIdentity;
+    
     @Option(name="-headless",
-            usage="Run in headless mode, without GUI")
+            usage="Run agent in headless mode, without GUI")
     public boolean headlessMode = Boolean.getBoolean("hudson.agent.headless")
                     || Boolean.getBoolean("hudson.webstart.headless");
 
@@ -83,7 +89,7 @@ public class Main {
      * In such case Remoting will connect straight to the TCP endpoint using CLI arguments.
      * @since TODO
      */
-    @Option(name="-noHttpEndpoint",
+    @Option(name="-noHttpEndpoint", //TODO: -headlessMaster
             usage="Indicates that the master is running in the headless mode without TCP Agent Listener endpoint")
     public boolean disableHttpEndpointCheck = Boolean.getBoolean("jenkins.agent.disableHttpEndpointCheck");
 
@@ -254,6 +260,8 @@ public class Main {
                 urls, args.get(0), agentName);
         if(tunnel!=null)
             engine.setTunnel(tunnel);
+        if(instanceIdentity!=null)
+            engine.setInstanceIdentity(instanceIdentity);
         if(credentials!=null)
             engine.setCredentials(credentials);
         if(proxyCredentials!=null)

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -33,7 +33,6 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
 import org.jenkinsci.remoting.engine.WorkDirManager;
-import org.jenkinsci.remoting.util.IOUtils;
 import org.jenkinsci.remoting.util.PathUtils;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.CmdLineParser;
@@ -72,12 +71,6 @@ public class Main {
                   "Useful when connection to Jenkins needs to be tunneled. Can be also HOST: or :PORT, " +
                   "in which case the missing portion will be auto-configured like the default behavior")
     public String tunnel;
-
-    @Option(name="-instanceIdentity",
-            usage="The Base64 encoded InstanceIdentity byte array of the Jenkins master. " +
-                  "This parameter is only required if the Jenkins master does not expose an http(s) endpoint" +
-                  "(see also parameter -noHttpEndpoint)")
-    public String instanceIdentity;
     
     @Option(name="-headless",
             usage="Run agent in headless mode, without GUI")
@@ -89,9 +82,26 @@ public class Main {
      * In such case Remoting will connect straight to the TCP endpoint using CLI arguments.
      * @since TODO
      */
-    @Option(name="-noHttpEndpoint", //TODO: -headlessMaster
+    @Option(name="-noHttpEndpoint",
             usage="Indicates that the master is running in the headless mode without TCP Agent Listener endpoint")
     public boolean disableHttpEndpointCheck = Boolean.getBoolean("jenkins.agent.disableHttpEndpointCheck");
+
+    /**
+     * If the master does not expose an http(s) port the <a href="https://wiki.jenkins.io/display/JENKINS/Instance+Identity">instance identity</a>
+     * has to be explicitly passed as parameter.<br>
+     * To get the base64 encoded value manually the following code can be executed in the script console:
+     * <pre>
+     *   def key = org.jenkinsci.main.modules.instance_identity.InstanceIdentity.get().getPublic()
+     *   return hudson.remoting.Base64.encode(key.getEncoded())
+     * </pre>
+     * @see #disableHttpEndpointCheck -noHttpEndpoint
+     * @since TODO
+     */
+    @Option(name="-instanceIdentity",
+            usage="The base64 encoded InstanceIdentity byte array of the Jenkins master. " +
+                  "This parameter is only required if the Jenkins master does not expose an http(s) endpoint" +
+                  "(see also -noHttpEndpoint)")
+    public String instanceIdentity;
 
     @Option(name="-url",
             usage="Specify the Jenkins root URLs to connect to.")


### PR DESCRIPTION
This pull request adds changes on top of https://github.com/jenkinsci/remoting/pull/286. The changes here implement the missing
> support of Instance Identity key so that JNLP4 protocol can be used

Connecting to a Jenkins without http port now already works. You can test it with the command below. 

```sh
java -cp slave.jar hudson.remoting.jnlp.Main \
  -headless -noHttpEndpoint \
  -tunnel <jenkinsHost>:<jnlpPort> \
  -instanceIdentity <instanceIdentityString> \
  <secretString> <agentName>
```

- The agent needs to be prepared on the master  - copy the name and secret.  
- The instanceIdentityString is the base64 encoded byte array of the masters Instance Identity. You can get it via `hudson.remoting.Base64.encode(org.jenkinsci.main.modules.instance_identity.InstanceIdentity.get().getPublic().getEncoded())`.
