### PR TITLE
Fix typo in Selector wakeup thread messages

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/protocol/IOHub.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/IOHub.java
@@ -152,7 +152,7 @@ public class IOHub implements Executor, Closeable, Runnable, ByteBufferPool {
     public static IOHub create(Executor executor) throws IOException {
         IOHub result = new IOHub(executor);
         executor.execute(result);
-        LOGGER.log(Level.FINE, "Staring an additional Selector wakeup thread. See JENKINS-47965 for more info");
+        LOGGER.log(Level.FINE, "Starting an additional Selector wakeup thread. See JENKINS-47965 for more information.");
         executor.execute(new IOHubSelectorWatcher(result));
         return result;
     }


### PR DESCRIPTION
While debugging an unrelated issue, I noticed a typo in a common log statement ("staring" instead of "starting"). I fixed that, and also replaced "info" with the more proper "information" (and added a period to the sentence).