### PR TITLE
[JENKINS-57959] Remove final from args4j fields

### DIFF
--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -80,7 +80,7 @@ public class Main {
 
     @Option(name="-url",
             usage="Specify the Jenkins root URLs to connect to.")
-    public final List<URL> urls = new ArrayList<URL>();
+    public List<URL> urls = new ArrayList<URL>();
 
     @Option(name="-credentials",metaVar="USER:PASSWORD",
             usage="HTTP BASIC AUTH header to pass in for making HTTP requests.")
@@ -181,7 +181,7 @@ public class Main {
      * Two mandatory parameters: secret key, and agent name.
      */
     @Argument
-    public final List<String> args = new ArrayList<String>();
+    public List<String> args = new ArrayList<String>();
 
     public static void main(String[] args) throws IOException, InterruptedException {
         try {


### PR DESCRIPTION
# Problem

After an attempted upgrade of args4j in jenkinsci/swarm-plugin#120, the following exception was thrown:

```
java.lang.IllegalStateException: Cannot set value to a final field 'hudson.remoting.jnlp.Main.urls'.
        at org.kohsuke.args4j.spi.Setters.create(Setters.java:32)
        at org.kohsuke.args4j.ClassParser.parse(ClassParser.java:34)
        at org.kohsuke.args4j.CmdLineParser.<init>(CmdLineParser.java:96)
        at org.kohsuke.args4j.CmdLineParser.<init>(CmdLineParser.java:71)
        at hudson.remoting.jnlp.Main._main(Main.java:215)
        at hudson.remoting.jnlp.Main.main(Main.java:188)
        at hudson.plugins.swarm.SwarmClient.connect(SwarmClient.java:325)
        at hudson.plugins.swarm.Client.run(Client.java:193)
        at hudson.plugins.swarm.Client.main(Client.java:130)
```

# Evaluation

As of args4j 2.32, "[final fields can no longer be set](https://github.com/kohsuke/args4j/commit/6e11f89d40dcc518c0e5eb9eef5d74f05d58e6af)." If an args4j field is marked with the `final` keyword, an `IllegalStateException` is thrown.

# Solution

Remove the `final` keyword from the fields that we expect args4j to set.

# Testing Done

1. Built Remoting with this change and the args4j bump and deployed to my local Maven repository, including running tests.
2. Built Jenkins core with the args4j bump and a Remoting bump to the Remoting version built in step 1, including running tests.
3. Built Swarm with the args4j bump and a Remoting bump to the Remoting version built in step 1, including running tests.

Before this change, the Swarm tests in step 3 failed with the stack trace shown above. After this change, the Swarm tests passed.

# Next Steps

Once this change is merged and released, we can proceed with updating args4j in Jenkins core, which [also involves updating the args4j dependency in Remoting](https://github.com/jenkinsci/jenkins/blob/3ba5ca46c3b8e3df79b0550ff17e652006beef05/core/pom.xml#L207-L211). I'm explicitly postponing that work to a future PR, since at the present time Jenkins core is not using the latest version of Remoting due to a Remoting bug (see jenkinsci/jenkins#4047).