### PR TITLE
Switch to SpotBugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.50</version>
+    <version>1.52</version>
     <relativePath />
   </parent>
 
@@ -162,9 +162,9 @@ THE SOFTWARE.
       <version>1.2</version>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <version>3.0.1</version>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>3.1.12</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -164,8 +164,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>3.1.12</version>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -168,7 +168,7 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserRequest.R
                 {
                     workaroundDone = true;
                     try {
-                        final Class<?> loaded = Class.forName( clazz, true, cl );
+                        Class.forName(clazz, true, cl);
                     } catch (final ClassNotFoundException cnfe) {
                         // not big deal, elevate log to warning and swallow exception
                         eventMsg = "Couldn't find";


### PR DESCRIPTION
Updated the parent POM to [the latest version](https://github.com/jenkinsci/pom/releases), which has SpotBugs support, and migrated the annotations dependency from FindBugs to SpotBugs. This exposed the following new SpotBugs error:

```
[ERROR] Dead store to $L4 in hudson.remoting.UserRequest.perform(Channel) [hudson.remoting.UserRequest] At UserRequest.java:[line 171] DLS_DEAD_LOCAL_STORE
```

I fixed this by removing the unnecessary variable declaration and assignment.