### PR TITLE
[JENKINS-57959] Bump args4j from 2.0.31 to 2.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
-      <version>2.0.31</version>
+      <version>2.33</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -80,7 +80,7 @@ public class Main {
 
     @Option(name="-url",
             usage="Specify the Jenkins root URLs to connect to.")
-    public final List<URL> urls = new ArrayList<URL>();
+    public List<URL> urls = new ArrayList<URL>();
 
     @Option(name="-credentials",metaVar="USER:PASSWORD",
             usage="HTTP BASIC AUTH header to pass in for making HTTP requests.")
@@ -181,7 +181,7 @@ public class Main {
      * Two mandatory parameters: secret key, and agent name.
      */
     @Argument
-    public final List<String> args = new ArrayList<String>();
+    public List<String> args = new ArrayList<String>();
 
     public static void main(String[] args) throws IOException, InterruptedException {
         try {


### PR DESCRIPTION
Downstream of jenkinsci/remoting#326 (q.v. for an explanation of the main API change and the testing done). Depends on jenkinsci/jenkins#4063. Blocks jenkinsci/swarm-plugin#120.