### PR TITLE
Update changelog for version 3.33.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This file also provides links to Jenkins versions,
 which bundle the specified remoting version.
 See [Jenkins changelog](https://jenkins.io/changelog/) for more details.
 
+##### 3.33
+
+Release date: June 20, 2019
+
+* [JENKINS-57959](https://issues.jenkins-ci.org/browse/JENKINS-50095) Upgrade args4j dependency to 2.33 (latest).
+
 ##### 3.32
 
 Release date: June 19, 2019


### PR DESCRIPTION
Since there is at least a suggestion of a connection between updating the args4j dependency in Remoting and in core, I decided to put the dependency in its own release, so there are more options in how it can be included in core. We don't think there are any actual issues if they're not updated simultaneously, but I'm giving the opportunity for us to make this clean.