### PR TITLE
Remove FindBugs filter for hudson.util.VersionNumber

### DIFF
--- a/src/findbugs/excludeFilter.xml
+++ b/src/findbugs/excludeFilter.xml
@@ -6,9 +6,6 @@
   <Match>
     <Package name="~org\.jenkinsci\.constant_pool_scanner.*"/>
   </Match>
-  <Match>
-    <Class name="~.*hudson.util.VersionNumber.*"/>
-  </Match>
   
   <Match>
     <!--We do not want do break API by converting potentially usefull classes-->


### PR DESCRIPTION
This filter is no longer needed since https://github.com/jenkinsci/remoting/pull/331/