### PR TITLE
Code Cleanup

### DIFF
--- a/src/main/java/hudson/remoting/AbstractByteArrayCommandTransport.java
+++ b/src/main/java/hudson/remoting/AbstractByteArrayCommandTransport.java
@@ -1,6 +1,5 @@
 package hudson.remoting;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
@@ -20,10 +19,10 @@ import org.jenkinsci.remoting.util.AnonymousClassWarnings;
  */
 public abstract class AbstractByteArrayCommandTransport extends CommandTransport {
     protected Channel channel;
-    
+
     /**
      * Writes a byte[] to the transport.
-     * 
+     *
      * The block boundary is significant. A transport needs to ensure that that the same byte[] is
      * read by the peer (unlike TCP, where a single write can
      * be split into multiple read()s on the other side.)
@@ -32,17 +31,17 @@ public abstract class AbstractByteArrayCommandTransport extends CommandTransport
 
     /**
      * Starts the transport.
-     * 
+     *
      * See {@link #setup(Channel, CommandReceiver)} for more details.
-     * 
+     *
      * In this subtype, we pass in {@link ByteArrayReceiver} that uses byte[] instead of {@link Command}
      */
     public abstract void setup(@Nonnull ByteArrayReceiver receiver);
-    
+
     public static interface ByteArrayReceiver {
         /**
          * Notifies the {@link Channel} that the transport has received a new block.
-         * 
+         *
          * As discussed in {@link AbstractByteArrayCommandTransport#writeBlock(Channel, byte[])},
          * the block boundary is significant.
          */
@@ -53,7 +52,7 @@ public abstract class AbstractByteArrayCommandTransport extends CommandTransport
          */
         void terminate(IOException e);
     }
-    
+
     @Override
     public final void setup(final Channel channel, final CommandReceiver receiver) {
         this.channel = channel;

--- a/src/main/java/hudson/remoting/AbstractSynchronousByteArrayCommandTransport.java
+++ b/src/main/java/hudson/remoting/AbstractSynchronousByteArrayCommandTransport.java
@@ -1,6 +1,5 @@
 package hudson.remoting;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
@@ -8,10 +7,10 @@ import org.jenkinsci.remoting.util.AnonymousClassWarnings;
 
 /**
  * {@link SynchronousCommandTransport} that works with {@code byte[]} instead of command object.
- * 
+ *
  * This base class hides away some of the {@link Command} serialization details. One less thing
  * for transport implementers to worry about.
- * 
+ *
  * @author Kohsuke Kawaguchi
  * @since 2.13
  */
@@ -23,7 +22,7 @@ public abstract class AbstractSynchronousByteArrayCommandTransport extends Synch
 
     /**
      * Writes a byte[] to the transport.
-     * 
+     *
      * The block boundary is significant. A transport needs to ensure that that the same byte[] is
      * read by the peer through {@link #readBlock(Channel)} (unlike TCP, where a single write can
      * be split into multiple read()s on the other side.)

--- a/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
+++ b/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
@@ -5,7 +5,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import org.jenkinsci.remoting.util.ExecutorServiceUtils.FatalRejectedExecutionException;

--- a/src/main/java/hudson/remoting/Callable.java
+++ b/src/main/java/hudson/remoting/Callable.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,8 +28,6 @@ import org.jenkinsci.remoting.RoleSensitive;
 import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 
 import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.io.NotSerializableException;
 import java.io.Serializable;
 
 //TODO: Make it SerializableOnlyOverRemoting?
@@ -75,7 +73,7 @@ public interface Callable<V,T extends Throwable> extends Serializable, RoleSensi
      *
      * It is a convenience method for cases, when a callable needs to invoke call backs on the master.
      * In such case the requests will be likely failed by {@linkplain UserRequest} logic anyway, but it is better to fail fast.
-     * 
+     *
      * @return Channel instance
      * @throws ChannelStateException The channel is closing down or has been closed.
      *          Also happens if the channel is not associated with the thread at all.

--- a/src/main/java/hudson/remoting/Capability.java
+++ b/src/main/java/hudson/remoting/Capability.java
@@ -1,6 +1,5 @@
 package hudson.remoting;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.remoting.Channel.Mode;
 import java.io.IOException;
 import java.io.InputStream;
@@ -9,7 +8,6 @@ import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import org.jenkinsci.remoting.util.AnonymousClassWarnings;
 
@@ -164,8 +162,8 @@ public final class Capability implements Serializable {
 
                 @Override
                 public void close() throws IOException {
-                    // Do not close the stream since we continue reading from the input stream "is" 
-                }   
+                    // Do not close the stream since we continue reading from the input stream "is"
+                }
             }) {
             return (Capability)ois.readObject();
         } catch (ClassNotFoundException e) {
@@ -186,11 +184,11 @@ public final class Capability implements Serializable {
      * the new {@link MultiClassLoaderSerializer} code.
      * <p>
      * If we ever use up all 64bits of long, we can probably come back and reuse this bit, as by then
-     * hopefully any such remoting.jar deployment is long gone. 
+     * hopefully any such remoting.jar deployment is long gone.
      */
     @SuppressWarnings("PointlessBitwiseExpression")
     private static final long MASK_UNUSED1 = 1L << 0;
-    
+
     /**
      * Bit that indicates the use of {@link MultiClassLoaderSerializer}.
      */

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,7 +24,6 @@
 package hudson.remoting;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 import hudson.remoting.CommandTransport.CommandReceiver;
 import hudson.remoting.PipeWindow.Key;
 import hudson.remoting.PipeWindow.Real;
@@ -44,7 +43,6 @@ import java.io.InputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
 import java.net.URL;
@@ -93,13 +91,13 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * In this sense, {@link Channel} is a mechanism to delegate/offload computation
  * to other JVMs and somewhat like an agent system. This is bit different from
  * remoting technologies like CORBA or web services, where the server exposes a
- * certain functionality that clients invoke. 
+ * certain functionality that clients invoke.
  *
  * <p>
  * {@link Callable} object, as well as the return value / exceptions,
  * are transported by using Java serialization. All the necessary class files
  * are also shipped over {@link Channel} on-demand, so there's no need to
- * pre-deploy such classes on both JVMs. 
+ * pre-deploy such classes on both JVMs.
  *
  *
  * <h2>Implementor's Note</h2>
@@ -212,7 +210,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     private final Ref reference;
 
     /**
-     * Registered listeners. 
+     * Registered listeners.
      */
     private final List<Listener> listeners = new CopyOnWriteArrayList<>();
     private int gcCounter;
@@ -343,19 +341,19 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * When the value is {@code true}, it does not make sense to execute new user-space commands like {@link UserRequest}.
      */
     private boolean closeRequested = false;
-    
+
     /**
      * Stores cause of the close Request.
-     * 
-     * In the case of race condition between multiple close operations, 
+     *
+     * In the case of race condition between multiple close operations,
      * this field stores just one of them.
      */
     @CheckForNull
     private Throwable closeRequestCause = null;
-    
+
     /**
      * Communication mode used in conjunction with {@link ClassicCommandTransport}.
-     * 
+     *
      * @since 1.161
      */
     public enum Mode {
@@ -526,7 +524,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         this.arbitraryCallableAllowed = settings.isArbitraryCallableAllowed();
         this.remoteClassLoadingAllowed = settings.isRemoteClassLoadingAllowed();
         this.underlyingOutput = transport.getUnderlyingStream();
-        
+
         // JAR Cache resolution
         this.jarCache = settings.getJarCache();
         if (this.jarCache == null) {
@@ -654,7 +652,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     public boolean isOutClosed() {
         return outClosed!=null;
     }
-    
+
     /**
      * Get why the sender side of the channel has been closed.
      * @return Close cause or {@code null} if the sender side is active.
@@ -665,13 +663,13 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     public final Throwable getSenderCloseCause() {
         return outClosed;
     }
-    
+
     /**
      * Returns {@code true} if the channel is either in the process of closing down or has closed down.
-     * 
+     *
      * If the result is {@code true}, it means that the channel will be closed at some point by Remoting,
      * and that it makes no sense to send any new {@link UserRequest}s to the remote side.
-     * Invocations like {@link #call(hudson.remoting.Callable)} and {@link #callAsync(hudson.remoting.Callable)} 
+     * Invocations like {@link #call(hudson.remoting.Callable)} and {@link #callAsync(hudson.remoting.Callable)}
      * will just fail as well.
      * @since 2.33
      */
@@ -681,9 +679,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 
     /**
      * Gets cause of the close request.
-     * 
+     *
      * @return {@link #outClosed} if not {@code null}, value of the transient cache
-     *         {@link #closeRequestCause} otherwise. 
+     *         {@link #closeRequestCause} otherwise.
      *         The latter one may show random cause in the case of race conditions.
      * @since 3.11
      */
@@ -691,7 +689,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     public Throwable getCloseRequestCause() {
         return outClosed != null ? outClosed : closeRequestCause;
     }
-    
+
     /**
      * Creates the {@link ExecutorService} for writing to pipes.
      *
@@ -742,10 +740,10 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *      so it's not usable for implementing lower-layer services that are
      *      used by {@link RemoteClassLoader}.
      *
-     *      To create proxies for objects inside remoting, pass in false. 
+     *      To create proxies for objects inside remoting, pass in false.
      * @param recordCreatedAt as in {@link Command#Command(boolean)}
-     * @return Reference to the exported instance wrapped by {@link RemoteInvocationHandler}. 
-     *      {@code null} if the input instance is {@code null}.     
+     * @return Reference to the exported instance wrapped by {@link RemoteInvocationHandler}.
+     *      {@code null} if the input instance is {@code null}.
      */
     @Nullable
     /*package*/ <T> T export(Class<T> type, @CheckForNull T instance, boolean userProxy, boolean userScope, boolean recordCreatedAt) {
@@ -781,20 +779,20 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /*package*/ @Nonnull Object getExportedObject(int oid) throws ExecutionException {
         return exportedObjects.get(oid);
     }
-    
+
     @CheckForNull
     /*package*/ Object getExportedObjectOrNull(int oid)  {
         return exportedObjects.getOrNull(oid);
     }
 
-    /*package*/ @Nonnull Class[] getExportedTypes(int oid) throws ExecutionException {
+    /*package*/ @Nonnull Class<?>[] getExportedTypes(int oid) throws ExecutionException {
         return exportedObjects.type(oid);
     }
 
     /*package*/ void unexport(int id, @CheckForNull Throwable cause) {
         unexport(id, cause, false);
     }
-    
+
     /**
      * Unexports object.
      * @param id Object ID
@@ -876,11 +874,11 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * @throws IOException
      *      if the preloading fails.
      */
-    public boolean preloadJar(Callable<?,?> classLoaderRef, Class... classesInJar) throws IOException, InterruptedException {
+    public boolean preloadJar(Callable<?,?> classLoaderRef, Class<?>... classesInJar) throws IOException, InterruptedException {
         return preloadJar(UserRequest.getClassLoader(classLoaderRef), classesInJar);
     }
 
-    public boolean preloadJar(ClassLoader local, Class... classesInJar) throws IOException, InterruptedException {
+    public boolean preloadJar(ClassLoader local, Class<?>... classesInJar) throws IOException, InterruptedException {
         URL[] jars = new URL[classesInJar.length];
         for (int i = 0; i < classesInJar.length; i++)
             jars[i] = Which.jarFile(classesInJar[i]).toURI().toURL();
@@ -946,10 +944,10 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     V call(Callable<V,T> callable) throws IOException, T, InterruptedException {
         if (isClosingOrClosed()) {
             // No reason to even try performing a user request
-            throw new ChannelClosedException("Remote call on " + name + " failed. "
+            throw new ChannelClosedException(this, "Remote call on " + name + " failed. "
                     + "The channel is closing down or has closed down", getCloseRequestCause());
         }
-        
+
         UserRequest<V,T> request=null;
         try {
             request = new UserRequest<V, T>(this, callable);
@@ -980,10 +978,10 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     Future<V> callAsync(final Callable<V,T> callable) throws IOException {
         if (isClosingOrClosed()) {
             // No reason to even try performing a user request
-            throw new ChannelClosedException("Remote call on " + name + " failed. "
+            throw new ChannelClosedException(this, "Remote call on " + name + " failed. "
                     + "The channel is closing down or has closed down", getCloseRequestCause());
         }
-        
+
         final Future<UserRequest.ResponseToUserRequest<V, T>> f = new UserRequest<V, T>(this, callable).callAsync(this);
         return new FutureAdapter<V, UserRequest.ResponseToUserRequest<V, T>>(f) {
             @Override
@@ -1002,7 +1000,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *
      * This is an SPI for {@link CommandTransport} implementation to notify
      * {@link Channel} when the underlying connection is severed.
-     * 
+     *
      * Once the call is called {@link #closeRequested} will be set immediately to prevent further executions
      * of {@link UserRequest}s.
      *
@@ -1010,9 +1008,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *      The error that caused the connection to be aborted. Never null.
      */
     @java.lang.SuppressWarnings("ToArrayCallWithZeroLengthArrayArgument")
-    @SuppressWarnings("ITA_INEFFICIENT_TO_ARRAY") // intentionally; race condition on listeners otherwise
+    @SuppressFBWarnings("ITA_INEFFICIENT_TO_ARRAY") // intentionally; race condition on listeners otherwise
     public void terminate(@Nonnull IOException e) {
-        
+
         if (e == null) {
             throw new IllegalArgumentException("Cause is null. Channel cannot be closed properly in such case");
         }
@@ -1021,9 +1019,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
             // Cache the cause value just in case it takes long to acquire the lock
             closeRequestCause = e;
         }
-        
+
         try {
-            synchronized (this) {  
+            synchronized (this) {
                 outClosed = inClosed = e;
                 // we need to clear these out early in order to ensure that a GC operation while
                 // proceding with the close does not result in a batch of UnexportCommand instances
@@ -1123,7 +1121,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     public void removeLocalExecutionInterceptor(CallableFilter filter) {
         removeLocalExecutionInterceptor(new CallableDecoratorAdapter(filter));
     }
-    
+
     /**
      * Waits for this {@link Channel} to be closed down.
      *
@@ -1381,9 +1379,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * </dl>
      * @param w Output destination
      * @throws IOException Error while creating or writing the channel information
-     * 
+     *
      * @since 2.62.3 - stable 2.x (restricted)
-     * @since TODO 3.x - public version 
+     * @since TODO 3.x - public version
      */
     @Restricted(NoExternalUse.class)
     public void dumpDiagnostics(@Nonnull PrintWriter w) throws IOException {
@@ -1393,7 +1391,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         w.printf("  Commands received=%d%n", commandsReceived);
         w.printf("  Last command sent=%s%n", new Date(lastCommandSentAt));
         w.printf("  Last command received=%s%n", new Date(lastCommandReceivedAt));
-        
+
         // TODO: Synchronize when Hashtable gets replaced by a modern collection.
         w.printf("  Pending calls=%d%n", pendingCalls.size());
     }
@@ -1407,7 +1405,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 
     /**
      * Closes the channel.
-     * 
+     *
      * Once the call is called {@link #closeRequested} will be set immediately to prevent further executions
      * of {@link UserRequest}s.
      *
@@ -1427,13 +1425,13 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
             // TODO: This IOException wrapper is copy-pasted from the original logic, but do we actually need it when diagnosis is non-null?
             closeRequestCause = new IOException(diagnosis);
         }
-        
+
         synchronized(this) {
             if(outClosed!=null) {
                 // It has been closed while we were waiting for the lock
                 return;
             }
-            
+
             try {
                 send(new CloseCommand(this, diagnosis));
             } catch (ChannelClosedException e) {
@@ -1615,7 +1613,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * @param recvPort
      *      The port on this local machine that we'll listen to. 0 to let
      *      OS pick a random available port. If you specify 0, use
-     *      {@link ListeningPort#getPort()} to figure out the actual assigned port. 
+     *      {@link ListeningPort#getPort()} to figure out the actual assigned port.
      * @param forwardHost
      *      The remote host that the connection will be forwarded to.
      *      Connection to this host will be made from the other JVM that
@@ -1794,7 +1792,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * This method can be invoked during the serialization/deserialization of
      * objects when they are transferred to the remote {@link Channel},
-     * as well as during {@link Callable#call()} is invoked. 
+     * as well as during {@link Callable#call()} is invoked.
      *
      * @return {@code null}
      *      if the calling thread is not performing serialization.
@@ -1829,9 +1827,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * Used for diagnostics.
      *
      * @param w Output destination
-     * 
+     *
      * @since 2.62.3 - stable 2.x (restricted)
-     * @since TODO 3.x - public version 
+     * @since TODO 3.x - public version
      */
     @Restricted(NoExternalUse.class)
     public static void dumpDiagnosticsForAll(@Nonnull PrintWriter w) {
@@ -1840,14 +1838,14 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         for (Ref ref : channels) {
             // Check if we can still write the output
             if (w.checkError()) {
-                logger.log(Level.WARNING, 
+                logger.log(Level.WARNING,
                         String.format("Cannot dump diagnostics for all channels, because output stream encountered an error. "
                                 + "Processed %d of %d channels, first unprocessed channel reference is %s.",
                                 processedCount, channels.length, ref
-                        )); 
+                        ));
                 break;
             }
-            
+
             // Dump channel info if the reference still points to it
             final Channel ch = ref.channel();
             if (ch != null) {
@@ -1857,9 +1855,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
                     if (ex instanceof Error) {
                         throw (Error)ex;
                     }
-                    w.printf("Cannot dump diagnostics for the channel %s. %s. See Error stacktrace in system logs", 
+                    w.printf("Cannot dump diagnostics for the channel %s. %s. See Error stacktrace in system logs",
                             ch.getName(), ex.getMessage());
-                    logger.log(Level.WARNING, 
+                    logger.log(Level.WARNING,
                             String.format("Cannot dump diagnostics for the channel %s", ch.getName()), ex);
                 }
             }
@@ -1961,7 +1959,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      */
     private static final Map<Channel,Ref> ACTIVE_CHANNELS = Collections.synchronizedMap(new WeakHashMap<Channel, Ref>());
 
-    static final Class jarLoaderProxy;
+    static final Class<?> jarLoaderProxy;
 
     static {
         // dead-lock prevention.
@@ -1994,7 +1992,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * @see #reference
      */
     /*package*/ static final class Ref {
-        
+
         /**
          * Cached name of the channel.
          * @see Channel#getName()
@@ -2024,7 +2022,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 
         /**
          * Returns the {@link Channel} or {@code null} if the the {@link Channel} has been closed/terminated.
-         * @return the {@link Channel} or {@code null} 
+         * @return the {@link Channel} or {@code null}
          */
         @CheckForNull
         public Channel channel() {

--- a/src/main/java/hudson/remoting/ChannelClosedException.java
+++ b/src/main/java/hudson/remoting/ChannelClosedException.java
@@ -2,7 +2,6 @@ package hudson.remoting;
 
 import org.jenkinsci.remoting.ChannelStateException;
 
-import java.io.IOException;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
@@ -39,12 +38,12 @@ public class ChannelClosedException extends ChannelStateException {
     public ChannelClosedException(@CheckForNull Channel channel, @CheckForNull Throwable cause) {
         super(channel, "channel is already closed", cause);
     }
-    
+
     /**
      * Constructor.
-     * 
+     *
      * @param message Message
-     * @param cause Cause of the channel close/termination. 
+     * @param cause Cause of the channel close/termination.
      *              May be {@code null} if it cannot be determined when the exception is constructed.
      * @since 3.11
      * @deprecated Use {@link #ChannelClosedException(Channel, String, Throwable)}

--- a/src/main/java/hudson/remoting/ClassFilter.java
+++ b/src/main/java/hudson/remoting/ClassFilter.java
@@ -154,7 +154,7 @@ public abstract class ClassFilter {
 
     /**
      * Adds an additional exclusion to {@link #STANDARD}.
-     * 
+     *
      * Does nothing if the default list has already been customized via {@link #FILE_OVERRIDE_LOCATION_PROPERTY}.
      * This API is not supposed to be used anywhere outside Jenkins core, calls for other sources may be rejected later.
      * @param filter a regular expression for {@link Class#getName} which, if matched according to {@link Matcher#matches}, will blacklist the class

--- a/src/main/java/hudson/remoting/DiagnosedStreamCorruptionException.java
+++ b/src/main/java/hudson/remoting/DiagnosedStreamCorruptionException.java
@@ -1,10 +1,8 @@
 package hudson.remoting;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.PrintWriter;
 import java.io.StreamCorruptedException;
 import java.io.StringWriter;
-import java.util.Arrays;
 import javax.annotation.Nonnull;
 
 /**
@@ -14,14 +12,14 @@ import javax.annotation.Nonnull;
  */
 public class DiagnosedStreamCorruptionException extends StreamCorruptedException {
     private final Exception diagnoseFailure;
-    
+
     @Nonnull
     private final byte[] readBack;
-    
+
     @Nonnull
     private final byte[] readAhead;
 
-    DiagnosedStreamCorruptionException(Exception cause, Exception diagnoseFailure, 
+    DiagnosedStreamCorruptionException(Exception cause, Exception diagnoseFailure,
             @Nonnull byte[] readBack, @Nonnull byte[] readAhead) {
         initCause(cause);
         this.diagnoseFailure = diagnoseFailure;
@@ -37,7 +35,7 @@ public class DiagnosedStreamCorruptionException extends StreamCorruptedException
     public byte[] getReadBack() {
         return readBack.clone();
     }
-  
+
     @Nonnull
     public byte[] getReadAhead() {
         return readAhead.clone();

--- a/src/main/java/hudson/remoting/GCCommand.java
+++ b/src/main/java/hudson/remoting/GCCommand.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,11 +25,11 @@ package hudson.remoting;
 
 /**
  * Performs GC.
- * 
+ *
  * @author Kohsuke Kawaguchi
  */
 class GCCommand extends Command {
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_GC")
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("DM_GC")
     protected void execute(Channel channel) {
         System.gc();
     }

--- a/src/main/java/hudson/remoting/JarCache.java
+++ b/src/main/java/hudson/remoting/JarCache.java
@@ -2,7 +2,6 @@ package hudson.remoting;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URL;
 import javax.annotation.Nonnull;
 
@@ -20,7 +19,7 @@ import javax.annotation.Nonnull;
  * @since 2.24
  */
 public abstract class JarCache {
-    
+
     /**
      * Default JAR cache location for disabled workspace Manager.
      */
@@ -41,7 +40,7 @@ public abstract class JarCache {
             throw new IOException("Failed to initialize the default JAR Cache location", ex);
         }
     }
-    
+
     /**
      * Looks up the jar in cache, and if not found, use {@link JarLoader} to retrieve it
      * from the other side.

--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -21,14 +21,14 @@ import java.util.logging.Logger;
  *
  * @author Kohsuke Kawaguchi
  */
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_BAD_FIELD")
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings("SE_BAD_FIELD")
 class JarLoaderImpl implements JarLoader, SerializableOnlyOverRemoting {
 
     private static final Logger LOGGER = Logger.getLogger(JarLoaderImpl.class.getName());
 
     private final ConcurrentMap<Checksum,URL> knownJars = new ConcurrentHashMap<>();
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DMI_COLLECTION_OF_URLS") // TODO: fix this
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("DMI_COLLECTION_OF_URLS") // TODO: fix this
     private final ConcurrentMap<URL,Checksum> checksums = new ConcurrentHashMap<>();
 
     private final Set<Checksum> presentOnRemote = Collections.synchronizedSet(new HashSet<Checksum>());

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -60,9 +60,6 @@ import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509TrustManager;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -73,7 +70,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.FileWriter;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLConnection;
@@ -90,7 +86,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.security.cert.X509Certificate;
 import java.security.cert.CertificateException;
 import java.security.NoSuchAlgorithmException;
 import java.security.KeyManagementException;
@@ -186,7 +181,7 @@ public class Launcher {
     @CheckForNull
     @Option(name="-loggingConfig",usage="Path to the property file with java.util.logging settings")
     public File loggingConfigFilePath = null;
-    
+
     @Option(name = "-cert",
             usage = "Specify additional X.509 encoded PEM certificates to trust when connecting to Jenkins " +
                     "root URLs. If starting with @ then the remainder is assumed to be the name of the " +
@@ -289,7 +284,7 @@ public class Launcher {
         }
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_DEFAULT_ENCODING")    // log file, just like console output, should be in platform default encoding
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("DM_DEFAULT_ENCODING")    // log file, just like console output, should be in platform default encoding
     public void run() throws Exception {
 
         // Create and verify working directory and logging
@@ -308,7 +303,7 @@ public class Launcher {
 
         if(auth!=null) {
             final int idx = auth.indexOf(':');
-            if(idx<0)   throw new CmdLineException(null, "No ':' in the -auth option");
+            if(idx<0)   throw new CmdLineException(null, "No ':' in the -auth option", null);
             Authenticator.setDefault(new Authenticator() {
                 @Override public PasswordAuthentication getPasswordAuthentication() {
                     return new PasswordAuthentication(auth.substring(0,idx), auth.substring(idx+1).toCharArray());
@@ -597,7 +592,7 @@ public class Launcher {
      * Listens on an ephemeral port, record that port number in a port file,
      * then accepts one TCP connection.
      */
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_DEFAULT_ENCODING")    // port number file should be in platform default encoding
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("DM_DEFAULT_ENCODING")    // port number file should be in platform default encoding
     private void runAsTcpServer() throws IOException, InterruptedException {
         // if no one connects for too long, assume something went wrong
         // and avoid hanging forever
@@ -611,7 +606,7 @@ public class Launcher {
         } finally {
             w.close();
         }
-        
+
         // accept just one connection and that's it.
         // when we are done, remove the port file to avoid stale port file
         Socket s;
@@ -660,7 +655,7 @@ public class Launcher {
                 To prevent the dead lock between GetFileType from _ioinit in C runtime and blocking read that ChannelReaderThread
                 would do on stdin, load the crypto DLL first.
 
-                This is a band-aid solution to the problem. Still searching for more fundamental fix. 
+                This is a band-aid solution to the problem. Still searching for more fundamental fix.
 
                 02f1e750 7c90d99a ntdll!KiFastSystemCallRet
                 02f1e754 7c810f63 ntdll!NtQueryVolumeInformationFile+0xc
@@ -727,7 +722,7 @@ public class Launcher {
         main(is, os, mode, performPing, null);
     }
     /**
-     * 
+     *
      * @param cache JAR cache to be used.
      *              If {@code null}, a default value will be used.
      * @since 2.24
@@ -745,7 +740,7 @@ public class Launcher {
 
         Channel channel = cb.build(is, os);
         System.err.println("channel started");
-        
+
         // Both settings are available since remoting-2.0
         long timeout = 1000 * Long.parseLong(
                 System.getProperty("hudson.remoting.Launcher.pingTimeoutSec", "240")),
@@ -784,7 +779,7 @@ public class Launcher {
                     JENKINS_VERSION_PROP_FILE);
             return UNKNOWN_JENKINS_VERSION_STR;
         }
-      
+
         try {
             props.load(is);
         } catch (IOException e) {
@@ -794,7 +789,7 @@ public class Launcher {
         }
         return props.getProperty("version", UNKNOWN_JENKINS_VERSION_STR);
     }
-    
+
     private static void closeWithLogOnly(Closeable stream, String name) {
         try {
             stream.close();
@@ -807,9 +802,9 @@ public class Launcher {
      * Version number of Hudson this agent.jar is from.
      */
     public static final String VERSION = computeVersion();
-    
+
     private static final String JENKINS_VERSION_PROP_FILE = "hudson-version.properties";
     private static final String UNKNOWN_JENKINS_VERSION_STR = "?";
-    
+
     private static final Logger LOGGER = Logger.getLogger(Launcher.class.getName());
 }

--- a/src/main/java/hudson/remoting/MimicException.java
+++ b/src/main/java/hudson/remoting/MimicException.java
@@ -1,6 +1,5 @@
 package hudson.remoting;
 
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.kohsuke.accmod.Restricted;

--- a/src/main/java/hudson/remoting/MultiClassLoaderSerializer.java
+++ b/src/main/java/hudson/remoting/MultiClassLoaderSerializer.java
@@ -15,8 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import org.jenkinsci.remoting.util.AnonymousClassWarnings;
 
@@ -30,7 +28,7 @@ import org.jenkinsci.remoting.util.AnonymousClassWarnings;
  * described in the comment from huybrechts in HUDSON-4293.
  *
  * @author Kohsuke Kawaguchi
- * @see Capability#supportsMultiClassLoaderRPC() 
+ * @see Capability#supportsMultiClassLoaderRPC()
  */
 class MultiClassLoaderSerializer {
     static final class Output extends ObjectOutputStream {
@@ -143,7 +141,7 @@ class MultiClassLoaderSerializer {
         protected Class<?> resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
             ClassLoader cl = readClassLoader();
 
-            Class[] classes = new Class[interfaces.length];
+            Class<?>[] classes = new Class[interfaces.length];
             for (int i = 0; i < interfaces.length; i++)
                 // TODO: handle null classloader as a System one?
                 classes[i] = Class.forName(interfaces[i], false, cl);
@@ -165,7 +163,7 @@ class MultiClassLoaderSerializer {
 
                  So this is somewhat hack-ish, but in this change we look for a specific
                  proxy type that we use and resolve them outside Proxy.getProxyClass.
-             */
+            */
             if (classes.length==2 && classes[0]==JarLoader.class && classes[1]==IReadResolve.class)
                 return Channel.jarLoaderProxy;
 

--- a/src/main/java/hudson/remoting/ObjectInputStreamEx.java
+++ b/src/main/java/hudson/remoting/ObjectInputStreamEx.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -49,7 +49,7 @@ public class ObjectInputStreamEx extends ObjectInputStream {
         super(in);
         this.cl = cl;
         this.filter = filter;
-        
+
         // by default, the resolveObject is not called
         enableResolveObject(true);
     }
@@ -71,9 +71,9 @@ public class ObjectInputStreamEx extends ObjectInputStream {
         boolean hasNonPublicInterface = false;
 
         // define proxy in class loader of non-public interface(s), if any
-        Class[] classObjs = new Class[interfaces.length];
+        Class<?>[] classObjs = new Class[interfaces.length];
         for (int i = 0; i < interfaces.length; i++) {
-            Class cl = Class.forName(interfaces[i], false, latestLoader);
+            Class<?> cl = Class.forName(interfaces[i], false, latestLoader);
             if ((cl.getModifiers() & Modifier.PUBLIC) == 0) {
                 if (hasNonPublicInterface) {
                     if (nonPublicLoader != cl.getClassLoader()) {
@@ -95,8 +95,8 @@ public class ObjectInputStreamEx extends ObjectInputStream {
             throw new ClassNotFoundException(null, e);
         }
     }
-    
-    @Override 
+
+    @Override
     protected Object resolveObject(Object obj) throws IOException {
         if(obj instanceof URL){
             // SECURITY-637, URL deserialization could lead to DNS query

--- a/src/main/java/hudson/remoting/PingThread.java
+++ b/src/main/java/hudson/remoting/PingThread.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import java.util.logging.Level;
 
 /**
@@ -75,11 +74,11 @@ public abstract class PingThread extends Thread {
     }
 
     public PingThread(Channel channel, long interval) {
-        this(channel, 4*60*1000/*4 mins*/, interval);
+        this(channel, TimeUnit.MINUTES.toMillis(4), interval);
     }
 
     public PingThread(Channel channel) {
-        this(channel,10*60*1000/*10 mins*/);
+        this(channel, TimeUnit.MINUTES.toMillis(10));
     }
 
     public void run() {

--- a/src/main/java/hudson/remoting/PipeWindow.java
+++ b/src/main/java/hudson/remoting/PipeWindow.java
@@ -26,7 +26,6 @@ package hudson.remoting;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.logging.Logger;

--- a/src/main/java/hudson/remoting/PreloadJarTask.java
+++ b/src/main/java/hudson/remoting/PreloadJarTask.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,7 +23,6 @@
  */
 package hudson.remoting;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkinsci.remoting.Role;
 import org.jenkinsci.remoting.RoleChecker;
 

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -65,7 +65,7 @@ import javax.annotation.Nonnull;
  *
  * @author Kohsuke Kawaguchi
  */
-@edu.umd.cs.findbugs.annotations.SuppressWarnings({"DMI_COLLECTION_OF_URLS","DMI_BLOCKING_METHODS_ON_URL"}) // TODO: fix this
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"DMI_COLLECTION_OF_URLS","DMI_BLOCKING_METHODS_ON_URL"}) // TODO: fix this
 final class RemoteClassLoader extends URLClassLoader {
 
     private static final Logger LOGGER = Logger.getLogger(RemoteClassLoader.class.getName());
@@ -393,12 +393,12 @@ final class RemoteClassLoader extends URLClassLoader {
     /**
      * Defining a package is necessary to make {@link Class#getPackage()} work,
      * which is often used to retrieve package-level annotations.
-     * (for example, JAXB RI and Hadoop use them.) 
+     * (for example, JAXB RI and Hadoop use them.)
      */
     private void definePackage(String name) {
         int idx = name.lastIndexOf('.');
         if (idx<0)  return; // not in a package
-        
+
         String packageName = name.substring(0,idx);
         if (getPackage(packageName) != null)    // already defined
             return;
@@ -520,7 +520,7 @@ final class RemoteClassLoader extends URLClassLoader {
      *      and doesn't point to anything meaningful locally.
      * @return
      *      true if the prefetch happened. false if the jar is already prefetched.
-     * @see Channel#preloadJar(Callable, Class[]) 
+     * @see Channel#preloadJar(Callable, Class[])
      */
     /*package*/ boolean prefetch(URL jar) throws IOException {
         synchronized (prefetchedJars) {
@@ -584,7 +584,7 @@ final class RemoteClassLoader extends URLClassLoader {
 
         private static final long serialVersionUID = 1L;
 
-        public ClassFile2 upconvert(ClassFile2 referer, Class clazz, URL local) {
+        public ClassFile2 upconvert(ClassFile2 referer, Class<?> clazz, URL local) {
             return new ClassFile2(classLoader,new ResourceImageDirect(classImage),referer,clazz,local);
         }
     }
@@ -660,9 +660,9 @@ final class RemoteClassLoader extends URLClassLoader {
          * class that this {@link ClassFile2} represents.
          */
         @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "We're fine with the default null on the recipient side")
-        transient final Class clazz;
+        transient final Class<?> clazz;
 
-        ClassFile2(int classLoader, ResourceImageRef image, ClassFile2 referer, Class clazz, URL local) {
+        ClassFile2(int classLoader, ResourceImageRef image, ClassFile2 referer, Class<?> clazz, URL local) {
             super(image,local);
             this.classLoader = classLoader;
             this.clazz = clazz;
@@ -698,7 +698,7 @@ final class RemoteClassLoader extends URLClassLoader {
          */
         @CheckForNull
         byte[] getResource(String name) throws IOException;
-        
+
         @Nonnull
         byte[][] getResources(String name) throws IOException;
 
@@ -802,7 +802,7 @@ final class RemoteClassLoader extends URLClassLoader {
         	if (!USE_BOOTSTRAP_CLASSLOADER && cl==PSEUDO_BOOTSTRAP) {
         		throw new ClassNotFoundException("Classloading from bootstrap classloader disabled");
         	}
-        	
+
             InputStream in = cl.getResourceAsStream(className.replace('.', '/') + ".class");
             if(in==null)
                 throw new ClassNotFoundException(className);
@@ -961,7 +961,7 @@ final class RemoteClassLoader extends URLClassLoader {
         }
 
         @Override
-        @SuppressFBWarnings(value = "PZLA_PREFER_ZERO_LENGTH_ARRAYS", 
+        @SuppressFBWarnings(value = "PZLA_PREFER_ZERO_LENGTH_ARRAYS",
                 justification = "Null return value is a part of the public interface")
         @CheckForNull
         public byte[] getResource(String name) throws IOException {
@@ -1119,7 +1119,7 @@ final class RemoteClassLoader extends URLClassLoader {
             return Collections.emptySet();
         }
     }
- 
+
     /**
      * If set to true, classes loaded by the bootstrap classloader will be also remoted to the remote JVM.
      * By default, classes that belong to the bootstrap classloader will NOT be remoted, as each JVM gets its own JRE

--- a/src/main/java/hudson/remoting/RemoteInvocationHandler.java
+++ b/src/main/java/hudson/remoting/RemoteInvocationHandler.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -85,7 +85,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
      * <p>
      * This field is null when a {@link RemoteInvocationHandler} is just
      * created and not working as a remote proxy. Once tranferred to the
-     * remote system, this field is set to non-null. 
+     * remote system, this field is set to non-null.
      * @since FIXME after merge
      */
     @CheckForNull
@@ -135,7 +135,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
      */
     private RemoteInvocationHandler(Channel channel, int id, boolean userProxy,
                             boolean autoUnexportByCaller, boolean userSpace,
-                            Class proxyType, boolean recordCreatedAt) {
+                            Class<?> proxyType, boolean recordCreatedAt) {
         this.channel = channel == null ? null : channel.ref();
         this.oid = id;
         this.userProxy = userProxy;
@@ -178,8 +178,8 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
     /*package*/ static void notifyChannelTermination(Channel channel) {
         UNEXPORTER.onChannelTermination(channel);
     }
-    
-    /*package*/ static Class getProxyClass(Class type) {
+
+    /*package*/ static Class<?> getProxyClass(Class<?> type) {
         return Proxy.getProxyClass(type.getClassLoader(), new Class[]{type,IReadResolve.class});
     }
 
@@ -194,7 +194,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         final Ref ch = this.channel;
         return ch == null ? null : ch.channel();
     }
-    
+
     /**
      * Returns the backing channel or throws an {@link IOException} if the channel is disconnected or
      * otherwise unavailable.
@@ -221,7 +221,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
      * return its object ID. Otherwise return -1.
      * <p>
      * This method can be used to get back the original reference when
-     * a proxy is sent back to the channel it came from. 
+     * a proxy is sent back to the channel it came from.
      */
     public static int unwrap(Object proxy, Channel src) {
         InvocationHandler h = Proxy.getInvocationHandler(proxy);
@@ -324,7 +324,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
     }
 
     /**
-     * Two proxies are the same iff they represent the same remote object. 
+     * Two proxies are the same iff they represent the same remote object.
      */
     public boolean equals(Object o) {
         if(o!=null && Proxy.isProxyClass(o.getClass()))
@@ -487,7 +487,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         /**
          * The "live" {@link PhantomReferenceImpl} instances for each active {@link Channel}.
          */
-        private final ConcurrentMap<Channel.Ref,List<PhantomReferenceImpl>> referenceLists 
+        private final ConcurrentMap<Channel.Ref,List<PhantomReferenceImpl>> referenceLists
                 = new ConcurrentHashMap<Channel.Ref, List<PhantomReferenceImpl>>();
         /**
          * The 1 minute rolling average.
@@ -797,7 +797,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         /**
          * Watch the specified {@link RemoteInvocationHandler} for garbage collection so that it can be unexported
          * when collected.
-         * 
+         *
          * @param handler the {@link RemoteInvocationHandler} instance to watch.
          */
         private void watch(RemoteInvocationHandler handler) {
@@ -837,7 +837,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
             cleanList(referenceLists.remove(channel.ref()));
         }
     }
-    
+
     private static final long serialVersionUID = 1L;
 
     /**
@@ -918,7 +918,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
 
         protected Serializable perform(@Nonnull Channel channel) throws Throwable {
             Object o = channel.getExportedObject(oid);
-            Class[] clazz = channel.getExportedTypes(oid);
+            Class<?>[] clazz = channel.getExportedTypes(oid);
             try {
                 Method m = choose(clazz);
                 if(m==null)
@@ -978,7 +978,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
             return b.toString();
         }
 
-        private static final long serialVersionUID = 1L; 
+        private static final long serialVersionUID = 1L;
     }
 
     /**
@@ -1007,7 +1007,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
 
             // We also do not want to run UserRequests when the channel is being closed
             if (channel.isClosingOrClosed()) {
-                throw new ChannelClosedException("The request cannot be executed on channel " + channel + ". "
+                throw new ChannelClosedException(channel, "The request cannot be executed on channel " + channel + ". "
                         + "The channel is closing down or has closed down", channel.getCloseRequestCause());
             }
         }

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -117,9 +117,9 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
 
     /**
      * Checks if the request can be executed on the channel.
-     * 
+     *
      * @param channel Channel
-     * @throws IOException Error with explanation if the request cannot be executed. 
+     * @throws IOException Error with explanation if the request cannot be executed.
      * @since 3.11
      */
     void checkIfCanBeExecutedOnChannel(@Nonnull Channel channel) throws IOException {
@@ -129,7 +129,7 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
             throw new ChannelClosedException(channel, senderCloseCause);
         }
     }
-    
+
     /**
      * Sends this request to a remote system, and blocks until we receives a response.
      *
@@ -229,7 +229,7 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
      */
     final hudson.remoting.Future<RSP> callAsync(final Channel channel) throws IOException {
         checkIfCanBeExecutedOnChannel(channel);
-        
+
         response=null;
         lastIoId = channel.lastIoId();
 
@@ -334,7 +334,7 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
     }
 
     /**
-     * Aborts the processing. The calling thread will receive an exception. 
+     * Aborts the processing. The calling thread will receive an exception.
      */
     /*package*/ void abort(IOException e) {
         onCompleted(new Response(this, id, 0, new RequestAbortedException(e)));

--- a/src/main/java/hudson/remoting/Which.java
+++ b/src/main/java/hudson/remoting/Which.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Ullrich Hafner
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -56,7 +56,7 @@ public class Which {
      * @since 2.24
      */
     @Nonnull
-    public static URL classFileUrl(Class clazz) throws IOException {
+    public static URL classFileUrl(Class<?> clazz) throws IOException {
         ClassLoader cl = clazz.getClassLoader();
         if(cl==null)
             cl = ClassLoader.getSystemClassLoader();
@@ -70,7 +70,7 @@ public class Which {
      * @deprecated Use {@link #classFileUrl(Class)}
      */
     @Deprecated
-    public static URL jarURL(Class clazz) throws IOException {
+    public static URL jarURL(Class<?> clazz) throws IOException {
         return classFileUrl(clazz);
     }
 
@@ -88,7 +88,7 @@ public class Which {
      *      JAR File, which contains the class.
      */
     @Nonnull
-    public static File jarFile(Class clazz) throws IOException {
+    public static File jarFile(Class<?> clazz) throws IOException {
         return jarFile(classFileUrl(clazz),clazz.getName().replace('.','/')+".class");
     }
 
@@ -120,7 +120,7 @@ public class Which {
             resURL = resURL.substring("code-source:/".length(), resURL.lastIndexOf('!')); // cut off jar: and the file name portion
             return new File(decode(new URL("file:/"+resURL).getPath()));
         }
-        
+
         if(resURL.startsWith("zip:")){
             // weblogic uses this. See http://www.nabble.com/patch-to-get-Hudson-working-on-weblogic-td23997258.html
             // also see http://www.nabble.com/Re%3A-Hudson-on-Weblogic-10.3-td25038378.html#a25043415

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,7 +33,6 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
 import org.jenkinsci.remoting.engine.WorkDirManager;
-import org.jenkinsci.remoting.util.IOUtils;
 import org.jenkinsci.remoting.util.PathUtils;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.CmdLineParser;
@@ -122,7 +121,7 @@ public class Main {
     @Option(name="-agentLog", usage="Local agent error log destination (overrides workDir)")
     @CheckForNull
     public File agentLog = null;
-    
+
     /**
      * Specified location of the property file with JUL settings.
      * @since 3.8
@@ -130,7 +129,7 @@ public class Main {
     @CheckForNull
     @Option(name="-loggingConfig",usage="Path to the property file with java.util.logging settings")
     public File loggingConfigFile = null;
-    
+
     /**
      * Specifies a default working directory of the remoting instance.
      * If specified, this directory will be used to store logs, JAR cache, etc.
@@ -215,9 +214,9 @@ public class Main {
         CmdLineParser p = new CmdLineParser(m);
         p.parseArgument(args);
         if(m.args.size()!=2)
-            throw new CmdLineException("two arguments required, but got "+m.args);
+            throw new CmdLineException(p, "two arguments required, but got "+m.args, null);
         if(m.urls.isEmpty())
-            throw new CmdLineException("At least one -url option is required.");
+            throw new CmdLineException(p, "At least one -url option is required.", null);
 
         m.main();
     }
@@ -258,7 +257,7 @@ public class Main {
         }
         engine.setDisableHttpsCertValidation(disableHttpsCertValidation);
 
-        
+
         // TODO: ideally logging should be initialized before the "Setting up agent" entry
         if (agentLog != null) {
             try {
@@ -274,7 +273,7 @@ public class Main {
                 throw new IllegalStateException("Logging config file is invalid", ex);
             }
         }
-        
+
         if (candidateCertificates != null && !candidateCertificates.isEmpty()) {
             CertificateFactory factory;
             try {

--- a/src/main/java/org/jenkinsci/remoting/Role.java
+++ b/src/main/java/org/jenkinsci/remoting/Role.java
@@ -55,7 +55,7 @@ public final class Role {
         this.name = name;
     }
 
-    public Role(Class name) {
+    public Role(Class<?> name) {
         this(name.getName());
     }
 

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
@@ -25,12 +25,15 @@ package org.jenkinsci.remoting.engine;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URL;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -40,7 +43,6 @@ import javax.annotation.Nonnull;
 import org.jenkinsci.remoting.util.KeyUtils;
 import org.jenkinsci.remoting.util.ThrowableUtils;
 
-import static org.jenkinsci.remoting.engine.EngineUtil.readLine;
 
 /**
  * Represents a {@code TcpSlaveAgentListener} endpoint details.
@@ -217,12 +219,13 @@ public class JnlpAgentEndpoint {
                         .write(connectCommand.getBytes("UTF-8")); // TODO: internationalized domain names
 
                 BufferedInputStream is = new BufferedInputStream(socket.getInputStream());
-                String line = readLine(is);
+                BufferedReader r = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+                String line = r.readLine();
                 String[] responseLineParts = line.split(" ");
                 if (responseLineParts.length < 2 || !responseLineParts[1].equals("200")) {
                     throw new IOException("Got a bad response from proxy: " + line);
                 }
-                while (!readLine(is).isEmpty()) {
+                while (r.readLine().isEmpty()) {
                     // Do nothing, scrolling through headers returned from proxy
                 }
             }

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
@@ -25,8 +25,6 @@ package org.jenkinsci.remoting.engine;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedInputStream;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -43,6 +41,7 @@ import javax.annotation.Nonnull;
 import org.jenkinsci.remoting.util.KeyUtils;
 import org.jenkinsci.remoting.util.ThrowableUtils;
 
+import static org.jenkinsci.remoting.engine.EngineUtil.readLine;
 
 /**
  * Represents a {@code TcpSlaveAgentListener} endpoint details.
@@ -219,13 +218,12 @@ public class JnlpAgentEndpoint {
                         .write(connectCommand.getBytes("UTF-8")); // TODO: internationalized domain names
 
                 BufferedInputStream is = new BufferedInputStream(socket.getInputStream());
-                BufferedReader r = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
-                String line = r.readLine();
+                String line = readLine(is);
                 String[] responseLineParts = line.split(" ");
                 if (responseLineParts.length < 2 || !responseLineParts[1].equals("200")) {
                     throw new IOException("Got a bad response from proxy: " + line);
                 }
-                while (r.readLine().isEmpty()) {
+                while (!readLine(is).isEmpty()) {
                     // Do nothing, scrolling through headers returned from proxy
                 }
             }

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
@@ -66,7 +66,7 @@ public class JnlpAgentEndpoint {
      */
     @CheckForNull
     private final Set<String> protocols;
-    
+
     /**
      * Jenkins URL for the discovered endpoint.
      */
@@ -81,7 +81,7 @@ public class JnlpAgentEndpoint {
                              @CheckForNull Set<String> protocols) {
         this(host, port, publicKey, protocols, null);
     }
-    
+
     /**
      * Constructor for a remote {@code Jenkins} instance.
      *
@@ -123,7 +123,7 @@ public class JnlpAgentEndpoint {
     public URL getServiceUrl() {
         return serviceUrl;
     }
-    
+
     /**
      * Gets the hostname.
      *
@@ -232,7 +232,7 @@ public class JnlpAgentEndpoint {
                 try {
                     channel.close();
                 } catch (IOException suppressed) {
-                    e = ThrowableUtils.addSuppressed(e, suppressed);
+                    e = ThrowableUtils.chain(e, suppressed);
                 }
             }
             String suffix = "";

--- a/src/main/java/org/jenkinsci/remoting/engine/LegacyJnlpConnectionState.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/LegacyJnlpConnectionState.java
@@ -24,7 +24,6 @@
 package org.jenkinsci.remoting.engine;
 
 import hudson.remoting.SocketChannelStream;
-import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
 import java.io.DataInputStream;

--- a/src/main/java/org/jenkinsci/remoting/engine/LegacyJnlpProtocolHandler.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/LegacyJnlpProtocolHandler.java
@@ -128,7 +128,7 @@ abstract class LegacyJnlpProtocolHandler<STATE extends LegacyJnlpConnectionState
                     try {
                         socket.close();
                     } catch (IOException e1) {
-                        ThrowableUtils.addSuppressed(e, e1);
+                        ThrowableUtils.chain(e, e1);
                     }
                     state.fireAfterDisconnect();
                     throw e;
@@ -136,7 +136,7 @@ abstract class LegacyJnlpProtocolHandler<STATE extends LegacyJnlpConnectionState
                     try {
                         socket.close();
                     } catch (IOException e1) {
-                        ThrowableUtils.addSuppressed(e, e1);
+                        ThrowableUtils.chain(e, e1);
                     }
                     state.fireAfterDisconnect();
                     throw new IOException(e);
@@ -182,7 +182,7 @@ abstract class LegacyJnlpProtocolHandler<STATE extends LegacyJnlpConnectionState
                     try {
                         socket.close();
                     } catch (IOException e1) {
-                        ThrowableUtils.addSuppressed(e, e1);
+                        ThrowableUtils.chain(e, e1);
                     }
                     state.fireAfterDisconnect();
                     throw e;
@@ -190,7 +190,7 @@ abstract class LegacyJnlpProtocolHandler<STATE extends LegacyJnlpConnectionState
                     try {
                         socket.close();
                     } catch (IOException e1) {
-                        ThrowableUtils.addSuppressed(e, e1);
+                        ThrowableUtils.chain(e, e1);
                     }
                     state.fireAfterDisconnect();
                     throw new IOException(e);

--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -46,9 +46,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.ConsoleHandler;
 import java.util.logging.FileHandler;
-import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
@@ -78,7 +76,7 @@ public class WorkDirManager {
      * Regular expression, which declares restrictions of the remoting internal directory symbols
      */
     public static final String SUPPORTED_INTERNAL_DIR_NAME_MASK = "[a-zA-Z0-9._-]*";
-    
+
     /**
      * Name of the standard System Property, which points to the {@code java.util.logging} config file.
      */
@@ -86,20 +84,20 @@ public class WorkDirManager {
 
     // Status data
     boolean loggingInitialized;
-    
+
     @CheckForNull
     private File loggingConfigFile = null;
-    
+
     /**
      * Provides a list of directories, which should not be initialized in the Work Directory.
      */
     private final Set<DirType> disabledDirectories = new HashSet<>();
-    
+
     /**
      * Cache of initialized directory locations.
      */
     private final Map<DirType, File> directories = new HashMap<>();
-    
+
 
     private WorkDirManager() {
         // Cannot be instantiated outside
@@ -114,16 +112,16 @@ public class WorkDirManager {
     public static WorkDirManager getInstance() {
         return INSTANCE;
     }
-    
+
     /*package*/ static void reset() {
         INSTANCE = new WorkDirManager();
         LogManager.getLogManager().reset();
     }
-    
+
     public void disable(@Nonnull DirType dir) {
         disabledDirectories.add(dir);
     }
-    
+
     @CheckForNull
     public File getLocation(@Nonnull DirType type) {
         return directories.get(type);
@@ -141,13 +139,13 @@ public class WorkDirManager {
         File location = directories.get(type);
         return location != null ? PathUtils.fileToPath(location) : null;
     }
-    
+
     /**
      * Sets path to the Logging JUL property file with logging settings.
      * @param configFile config file
      */
     public void setLoggingConfig(@Nonnull File configFile) {
-        this.loggingConfigFile = configFile;   
+        this.loggingConfigFile = configFile;
     }
 
     /**
@@ -162,15 +160,15 @@ public class WorkDirManager {
         if (loggingConfigFile != null) {
             return loggingConfigFile;
         }
-        
+
         String property = System.getProperty(JUL_CONFIG_FILE_SYSTEM_PROPERTY_NAME);
         if (property != null && !property.trim().isEmpty()) {
             return new File(property);
         }
-        
+
         return null;
     }
-    
+
     //TODO: New interfaces should ideally use Path instead of File
     /**
      * Initializes the working directory for the agent.
@@ -180,7 +178,7 @@ public class WorkDirManager {
      *                    The range of the supported symbols is restricted to {@link #SUPPORTED_INTERNAL_DIR_NAME_MASK}.
      * @param failIfMissing Fail the initialization if the workDir or internalDir are missing.
      *                      This option presumes that the workspace structure gets initialized previously in order to ensure that we do not start up with a borked instance
-     *                      (e.g. if a mount gets disconnected).                 
+     *                      (e.g. if a mount gets disconnected).
      * @return Initialized directory for internal files within workDir or {@code null} if it is disabled
      * @throws IOException Workspace allocation issue (e.g. the specified directory is not writable).
      *                     In such case Remoting should not start up at all.
@@ -211,11 +209,11 @@ public class WorkDirManager {
             final Path internalDirPath = PathUtils.fileToPath(internalDirFile);
             Files.createDirectories(internalDirPath);
             LOGGER.log(Level.INFO, "Using {0} as a remoting work directory", internalDirPath);
-            
+
             // Create components of the internal directory
             createInternalDirIfRequired(internalDirFile, DirType.JAR_CACHE_DIR);
             createInternalDirIfRequired(internalDirFile, DirType.LOGS_DIR);
-            
+
             return internalDirPath;
         }
     }
@@ -231,7 +229,7 @@ public class WorkDirManager {
             LOGGER.log(Level.FINE, "Skipping the disabled directory: {0}", type.getName());
         }
     }
-    
+
     /**
      * Verifies that the directory is compliant with the specified requirements.
      * The directory is expected to have {@code RWX} permissions if exists.
@@ -280,7 +278,7 @@ public class WorkDirManager {
                 LogManager.getLogManager().readConfiguration(fis);
             }
         }
-        
+
         if (overrideLogPath != null) { // Legacy behavior
             LOGGER.log(Level.INFO, "Using {0} as an agent error log destination; output log will not be generated", overrideLogPath);
             System.out.flush(); // Just in case the channel
@@ -300,10 +298,10 @@ public class WorkDirManager {
             if (configFile == null) {
                 final Logger rootLogger = Logger.getLogger("");
                 final File julLog = new File(logsDir, "remoting.log");
-                final FileHandler logHandler = new FileHandler(julLog.getAbsolutePath(), 
-                                         10*1024*1024, 5, false); 
-                logHandler.setFormatter(new SimpleFormatter()); 
-                logHandler.setLevel(Level.INFO); 
+                final FileHandler logHandler = new FileHandler(julLog.getAbsolutePath(),
+                                         10*1024*1024, 5, false);
+                logHandler.setFormatter(new SimpleFormatter());
+                logHandler.setLevel(Level.INFO);
                 rootLogger.addHandler(logHandler);
             }
 
@@ -318,7 +316,7 @@ public class WorkDirManager {
     private PrintStream legacyCreateTeeStream(OutputStream ostream, Path destination) throws FileNotFoundException {
         return new PrintStream(new TeeOutputStream(ostream, new FileOutputStream(destination.toFile())));
     }
-    
+
     /**
      * Defines components of the Working directory.
      * @since 3.8
@@ -334,23 +332,23 @@ public class WorkDirManager {
          * This directory is located within {@link #WORK_DIR}.
          */
         INTERNAL_DIR("remoting internal directory", "remoting", WORK_DIR),
-        
+
         /**
          * Directory, which stores the JAR Cache.
          */
         JAR_CACHE_DIR("JAR Cache directory", "jarCache", INTERNAL_DIR),
-        
+
         /**
          * Directory, which stores logs.
          */
         LOGS_DIR("Log directory", "logs", INTERNAL_DIR);
-        
+
         @Nonnull
         private final String name;
 
         @Nonnull
         private final String defaultLocation;
-        
+
         @CheckForNull
         private final DirType parentDir;
 

--- a/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
@@ -12,8 +12,6 @@ import java.nio.channels.WritableByteChannel;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnegative;
 import javax.annotation.concurrent.GuardedBy;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * FIFO buffer for a reader thread and a writer thread to collaborate.
@@ -170,14 +168,14 @@ public class FifoBuffer implements Closeable {
      */
     @GuardedBy("lock")
     private boolean closed;
-    
+
     /**
      * Contains the reason why the buffer has been closed.
      * The cause also stores the stacktrace of the close command.
      */
     @CheckForNull
     private CloseCause closeCause;
-    
+
     private boolean closeRequested = false;
 
     public FifoBuffer(int pageSize, int limit) {
@@ -263,7 +261,7 @@ public class FifoBuffer implements Closeable {
     public CloseCause getCloseCause() {
         return closeCause;
     }
-    
+
     /**
      * Read from this buffer write as much as possible to the channel until
      * the channel gets filled up.
@@ -348,13 +346,13 @@ public class FifoBuffer implements Closeable {
                 int chunk = writable();
                 if (chunk==0)
                     return written; // no more space to write
-                
+
                 // If the buffer gets closed before we acquire lock, we are at risk of null "w" and NPE.
                 // So in such case we just interrupt the receive process
                 if (closed) {
                     throw new IOException("closed during the receive() operation");
                 }
-                
+
                 try {
                     int received = w.receive(ch, chunk);
                     if (received==0)
@@ -390,8 +388,7 @@ public class FifoBuffer implements Closeable {
         while (len>0) {
             int chunk;
 
-            final boolean shouldWaitToCleanTheBuffer;
-            synchronized (lock) { 
+            synchronized (lock) {
                 while ((chunk = Math.min(len,writable()))==0) {
                     if (closeRequested) {
                         handleCloseRequest();
@@ -409,8 +406,8 @@ public class FifoBuffer implements Closeable {
 
                 lock.notifyAll();
             }
-            
-            // 
+
+            //
         }
     }
 
@@ -424,11 +421,11 @@ public class FifoBuffer implements Closeable {
         // Async modification of the field in order to notify other threads that we are about closing this buffer
         closeRequested = true;
         closeCause = new CloseCause("Buffer close has been requested");
-        
+
         // Now perform close operation
         handleCloseRequest();
     }
-    
+
     /**
      * This is a close operation, which is guarded by the instance lock.
      * Actually this method may be invoked by multiple threads, not only by {@link #close()} when it requests it.
@@ -615,7 +612,7 @@ public class FifoBuffer implements Closeable {
             }
         };
     }
-    
+
     /**
      * Explains the reason of the buffer close.
      * @since 3.3
@@ -627,9 +624,9 @@ public class FifoBuffer implements Closeable {
         /*package*/ CloseCause(String message) {
             super(message);
         }
-        
+
         /*package*/ CloseCause(String message, Throwable cause) {
             super(message, cause);
-        }  
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
@@ -11,11 +11,8 @@ import hudson.remoting.ChunkHeader;
 import hudson.remoting.CommandTransport;
 import hudson.remoting.SingleLaneExecutorService;
 import org.jenkinsci.remoting.RoleChecker;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.Closeable;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
@@ -536,7 +533,7 @@ public class NioChannelHub implements Runnable, Closeable {
         private Object readResolve() throws ObjectStreamException {
             throw new NotSerializableException("The class should not be serialized over Remoting");
         }
-        
+
         private Object writeReplace() throws ObjectStreamException {
             throw new NotSerializableException("The class should not be serialized over Remoting");
         }

--- a/src/main/java/org/jenkinsci/remoting/protocol/ApplicationLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/ApplicationLayer.java
@@ -228,7 +228,7 @@ public abstract class ApplicationLayer<T> implements ProtocolLayer, ProtocolLaye
                 doCloseWrite();
             } catch (IOException e) {
                 if (ioe != null) {
-                    throw ThrowableUtils.chain(ioe, e);
+                    e = ThrowableUtils.chain(ioe, e);
                 }
                 throw e;
             }

--- a/src/main/java/org/jenkinsci/remoting/protocol/ApplicationLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/ApplicationLayer.java
@@ -228,7 +228,7 @@ public abstract class ApplicationLayer<T> implements ProtocolLayer, ProtocolLaye
                 doCloseWrite();
             } catch (IOException e) {
                 if (ioe != null) {
-                    throw ThrowableUtils.addSuppressed(ioe, e);
+                    throw ThrowableUtils.chain(ioe, e);
                 }
                 throw e;
             }

--- a/src/main/java/org/jenkinsci/remoting/protocol/ApplicationLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/ApplicationLayer.java
@@ -31,7 +31,6 @@ import java.nio.channels.SocketChannel;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.GuardedBy;
-import org.jenkinsci.remoting.util.ThrowableUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -228,7 +227,8 @@ public abstract class ApplicationLayer<T> implements ProtocolLayer, ProtocolLaye
                 doCloseWrite();
             } catch (IOException e) {
                 if (ioe != null) {
-                    e = ThrowableUtils.chain(ioe, e);
+                    ioe.addSuppressed(e);
+                    throw ioe;
                 }
                 throw e;
             }

--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/ChannelApplicationLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/ChannelApplicationLayer.java
@@ -155,7 +155,7 @@ public class ChannelApplicationLayer extends ApplicationLayer<Future<Channel>> {
                     try {
                         doCloseWrite();
                     } catch (IOException suppressed) {
-                        ThrowableUtils.addSuppressed(e, suppressed);
+                        ThrowableUtils.chain(e, suppressed);
                     }
                     transport = null;
                     futureChannel.setException(e);

--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/ConnectionHeadersFilterLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/ConnectionHeadersFilterLayer.java
@@ -425,13 +425,13 @@ public class ConnectionHeadersFilterLayer extends FilterLayer {
         if (aborted != null && !(cause instanceof ConnectionRefusalException)) {
             // handle the case where we have refuseded the incoming headers and actually aborted
             ConnectionRefusalException newCause = newAbortCause(aborted);
-            super.onRecvClosed(ThrowableUtils.addSuppressed(newCause, cause));
+            super.onRecvClosed(ThrowableUtils.chain(newCause, cause));
             return;
         }
         if (abortCause != null) {
             // handle the case where waiting on acknowledgement of the abort
             ConnectionRefusalException newCause = newAbortCause(abortCause);
-            super.onRecvClosed(ThrowableUtils.addSuppressed(newCause, cause));
+            super.onRecvClosed(ThrowableUtils.chain(newCause, cause));
             return;
         }
         if (cause instanceof ClosedChannelException) {
@@ -439,7 +439,7 @@ public class ConnectionHeadersFilterLayer extends FilterLayer {
             // the remote end has closed because it refused our end before flushing the streams
             ConnectionRefusalException newCause = new ConnectionRefusalException(
                     "Remote closed connection without specifying reason");
-            super.onRecvClosed(ThrowableUtils.addSuppressed(newCause, cause));
+            super.onRecvClosed(ThrowableUtils.chain(newCause, cause));
         } else {
             super.onRecvClosed(cause);
         }

--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/SSLEngineFilterLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/SSLEngineFilterLayer.java
@@ -172,7 +172,7 @@ public class SSLEngineFilterLayer extends FilterLayer {
                     super.onRecvClosed(cause);
                 } catch (IOException e) {
                     if (ioe != null) {
-                        ThrowableUtils.addSuppressed(e, ioe);
+                        ThrowableUtils.chain(e, ioe);
                     }
                     throw e;
                 }
@@ -219,7 +219,7 @@ public class SSLEngineFilterLayer extends FilterLayer {
                     super.doCloseSend();
                 } catch (IOException e) {
                     if (ioe != null) {
-                        ThrowableUtils.addSuppressed(e, ioe);
+                        ThrowableUtils.chain(e, ioe);
                     }
                     throw e;
                 }

--- a/src/main/java/org/jenkinsci/remoting/util/ByteBufferQueueOutputStream.java
+++ b/src/main/java/org/jenkinsci/remoting/util/ByteBufferQueueOutputStream.java
@@ -25,7 +25,6 @@ package org.jenkinsci.remoting.util;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
 
 /**
  * An {@link OutputStream} backed by a {@link ByteBufferQueue}.

--- a/src/main/java/org/jenkinsci/remoting/util/ByteBufferUtils.java
+++ b/src/main/java/org/jenkinsci/remoting/util/ByteBufferUtils.java
@@ -28,7 +28,6 @@ import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
-import org.jenkinsci.remoting.protocol.ProtocolLayer;
 
 /**
  * Utility methods to help working with {@link ByteBuffer}s.

--- a/src/main/java/org/jenkinsci/remoting/util/Charsets.java
+++ b/src/main/java/org/jenkinsci/remoting/util/Charsets.java
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Local implementation of standard charsets as the remoting library currently needs to be compiled against Java 6

--- a/src/main/java/org/jenkinsci/remoting/util/FastByteBufferQueueInputStream.java
+++ b/src/main/java/org/jenkinsci/remoting/util/FastByteBufferQueueInputStream.java
@@ -25,8 +25,6 @@ package org.jenkinsci.remoting.util;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.BufferUnderflowException;
-import java.nio.ByteBuffer;
 
 /**
  * An {@link InputStream} backed by a set number of bytes from the head of a {@link ByteBufferQueue}.

--- a/src/main/java/org/jenkinsci/remoting/util/ThrowableUtils.java
+++ b/src/main/java/org/jenkinsci/remoting/util/ThrowableUtils.java
@@ -24,9 +24,6 @@
 package org.jenkinsci.remoting.util;
 
 import javax.annotation.CheckForNull;
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Utility methods to help when working with {@link Throwable} instances.
@@ -43,27 +40,6 @@ public class ThrowableUtils {
     }
 
     /**
-     * Helper to access {@link Throwable#addSuppressed(Throwable)} easily in code that is checked against the Java 1.6
-     * signatures.
-     *
-     * @param primary    the main {@link Throwable}.
-     * @param suppressed the suppressed {@link Throwable} to attach.
-     * @param <T>        the type of the main {@link Throwable}.
-     * @return the main {@link Throwable}.
-     */
-    @SuppressWarnings("Since15")
-    @IgnoreJRERequirement // TODO remove and inline method once Java 7 is baseline
-    @Restricted(NoExternalUse.class)
-    public static <T extends Throwable> T addSuppressed(T primary, Throwable suppressed) {
-        try {
-            primary.addSuppressed(suppressed);
-        } catch (LinkageError e) {
-            // best effort only
-        }
-        return primary;
-    }
-
-    /**
      * Allows building a chain of exceptions.
      *
      * @param e1   The first exception (or {@code null}).
@@ -75,6 +51,9 @@ public class ThrowableUtils {
      */
     @CheckForNull
     public static <T extends Throwable, T1 extends T, T2 extends T> T chain(@CheckForNull T1 e1, @CheckForNull T2 e2) {
-        return e1 == null ? e2 : e2 == null ? e1 : addSuppressed(e1, e2);
+        if (e1 == null) return e2;
+        if (e2 == null) return e1;
+        e1.addSuppressed(e2);
+        return e1;
     }
 }

--- a/src/main/java/org/jenkinsci/remoting/util/VersionNumber.java
+++ b/src/main/java/org/jenkinsci/remoting/util/VersionNumber.java
@@ -303,8 +303,8 @@ public class VersionNumber implements Comparable<VersionNumber> {
         }
 
         void normalize() {
-            for (ListIterator iterator = listIterator(size()); iterator.hasPrevious(); ) {
-                Item item = (Item) iterator.previous();
+            for (ListIterator<Item> iterator = listIterator(size()); iterator.hasPrevious(); ) {
+                Item item = iterator.previous();
                 if (item.isNull()) {
                     iterator.remove(); // remove null trailing items: 0, "", empty list
                 } else {
@@ -331,12 +331,12 @@ public class VersionNumber implements Comparable<VersionNumber> {
 
                 case LIST_ITEM:
                     if (item instanceof ListItem) {
-                        Iterator left = iterator();
-                        Iterator right = ((ListItem) item).iterator();
+                        Iterator<Item> left = iterator();
+                        Iterator<Item> right = ((ListItem) item).iterator();
 
                         while (left.hasNext() || right.hasNext()) {
-                            Item l = left.hasNext() ? (Item) left.next() : null;
-                            Item r = right.hasNext() ? (Item) right.next() : null;
+                            Item l = left.hasNext() ? left.next() : null;
+                            Item r = right.hasNext() ? right.next() : null;
 
                             // if this is shorter, then invert the compare and mul with -1
                             int result;
@@ -559,11 +559,11 @@ public class VersionNumber implements Comparable<VersionNumber> {
             return -1;
         }
 
-        Iterator it = items.iterator();
+        Iterator<Item> it = items.iterator();
         int i = 0;
         Item item = null;
         while (i <= idx && it.hasNext()) {
-            item  = (Item) it.next();
+            item = it.next();
             if (item instanceof IntegerItem) {
                 i++;
             } else {

--- a/src/test/java/Driver8703.java
+++ b/src/test/java/Driver8703.java
@@ -21,9 +21,9 @@ public class Driver8703 {
 //            System.out.println(i++);
 //            foo();
 //        }
-        
+
         ExecutorService es = Executors.newCachedThreadPool();
-        List<Future> flist = new ArrayList<Future>();
+        List<Future<Object>> flist = new ArrayList<Future<Object>>();
         for (int i=0; i<10000; i++) {
             flist.add(es.submit(new Callable<Object>() {
                 public Object call() throws Exception {
@@ -44,7 +44,7 @@ public class Driver8703 {
             }));
         }
 
-        for (Future ff : flist) {
+        for (Future<Object> ff : flist) {
             ff.get();
         }
 

--- a/src/test/java/org/jenkinsci/remoting/engine/HandlerLoopbackLoadStress.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/HandlerLoopbackLoadStress.java
@@ -87,7 +87,7 @@ import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.asn1.x509.X509Extension;
+import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
@@ -177,7 +177,7 @@ public class HandlerLoopbackLoadStress {
 
         JcaX509ExtensionUtils instance = new JcaX509ExtensionUtils();
 
-        certGen.addExtension(X509Extension.subjectKeyIdentifier,
+        certGen.addExtension(Extension.subjectKeyIdentifier,
                 false,
                 instance.createSubjectKeyIdentifier(subjectPublicKeyInfo)
         );

--- a/src/test/java/org/jenkinsci/remoting/nio/SocketClientMain.java
+++ b/src/test/java/org/jenkinsci/remoting/nio/SocketClientMain.java
@@ -1,20 +1,10 @@
 package org.jenkinsci.remoting.nio;
 
-import hudson.remoting.Callable;
 import hudson.remoting.CallableBase;
-import hudson.remoting.Capability;
 import hudson.remoting.Channel;
 import hudson.remoting.Channel.Mode;
 import hudson.remoting.ChannelBuilder;
-import hudson.remoting.CommandTransport;
-import hudson.remoting.SocketInputStream;
-import hudson.remoting.SocketOutputStream;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.net.Socket;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/src/test/java/org/jenkinsci/remoting/protocol/IOBufferMatcherLayer.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/IOBufferMatcherLayer.java
@@ -49,7 +49,7 @@ public class IOBufferMatcherLayer extends ApplicationLayer<IOBufferMatcher> {
             @Override
             public void close() throws IOException {
                 doCloseWrite();
-                super.close();
+                super.close(null);
             }
 
         };

--- a/src/test/java/org/jenkinsci/remoting/protocol/IOHubTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/IOHubTest.java
@@ -138,10 +138,12 @@ public class IOHubTest {
         Socket client = new Socket();
         client.connect(srv.getLocalAddress(), 100);
         assertThat(IOUtils.toString(client.getInputStream()), is("Go away #1"));
+        client.close();
         client = new Socket();
         client.connect(srv.getLocalAddress(), 100);
         assertThat(IOUtils.toString(client.getInputStream()), is("Go away #2"));
         assertThat("Only ever called ready with accept true", oops.get(), is(false));
+        client.close();
     }
 
     @Test
@@ -188,6 +190,7 @@ public class IOHubTest {
         client.setSoTimeout(100);
         client.connect(srv.getLocalAddress(), 100);
         assertThat(IOUtils.toString(client.getInputStream()), is("Go away #1"));
+        client.close();
         client = new Socket();
         client.setSoTimeout(100);
         client.connect(srv.getLocalAddress(), 100);
@@ -200,6 +203,7 @@ public class IOHubTest {
         hub.hub().addInterestAccept(key.get());
         assertThat(IOUtils.toString(client.getInputStream()), is("Go away #2"));
         assertThat("Only ever called ready with accept true", oops.get(), is(false));
+        client.close();
     }
 
     @Test
@@ -243,16 +247,17 @@ public class IOHubTest {
 
             }
         });
-        
+
         // Wait for registration, in other case we get unpredictable timing related results due to late registration
         while (key.get() == null) {
             Thread.sleep(10);
         }
-        
+
         Socket client = new Socket();
         client.setSoTimeout(100);
         client.connect(srv.getLocalAddress(), 100);
         assertThat(IOUtils.toString(client.getInputStream()), is("Go away #1"));
+        client.close();
         hub.hub().removeInterestAccept(key.get());
         // wait for the interest accept to be removed
         while ((key.get().interestOps() & SelectionKey.OP_ACCEPT) != 0) {
@@ -270,5 +275,6 @@ public class IOHubTest {
         hub.hub().addInterestAccept(key.get());
         assertThat(IOUtils.toString(client.getInputStream()), is("Go away #2"));
         assertThat("Only ever called ready with accept true", oops.get(), is(false));
+        client.close();
     }
 }

--- a/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackImplTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackImplTest.java
@@ -214,7 +214,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close();
+        west.get().close(null);
         east.get().awaitClose();
     }
 
@@ -239,7 +239,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close();
+        west.get().close(null);
         east.get().awaitClose();
     }
 
@@ -265,7 +265,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close();
+        west.get().close(null);
         east.get().awaitClose();
     }
 
@@ -294,7 +294,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close();
+        west.get().close(null);
         east.get().awaitClose();
     }
 
@@ -328,7 +328,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close();
+        west.get().close(null);
         east.get().awaitClose();
     }
 
@@ -365,7 +365,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close();
+        west.get().close(null);
         east.get().awaitClose();
     }
 
@@ -415,7 +415,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close();
+        west.get().close(null);
         east.get().awaitClose();
     }
 
@@ -468,7 +468,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close();
+        west.get().close(null);
         east.get().awaitClose();
     }
 

--- a/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackImplTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackImplTest.java
@@ -214,7 +214,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close(null);
+        west.get().close();
         east.get().awaitClose();
     }
 
@@ -239,7 +239,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close(null);
+        west.get().close();
         east.get().awaitClose();
     }
 
@@ -265,7 +265,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close(null);
+        west.get().close();
         east.get().awaitClose();
     }
 
@@ -294,7 +294,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close(null);
+        west.get().close();
         east.get().awaitClose();
     }
 
@@ -328,7 +328,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close(null);
+        west.get().close();
         east.get().awaitClose();
     }
 
@@ -365,7 +365,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close(null);
+        west.get().close();
         east.get().awaitClose();
     }
 
@@ -415,7 +415,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close(null);
+        west.get().close();
         east.get().awaitClose();
     }
 
@@ -468,7 +468,7 @@ public class ProtocolStackImplTest {
         west.get().send(data);
         east.get().awaitByteContent(is(expected));
         assertThat(east.get().asByteArray(), is(expected));
-        west.get().close(null);
+        west.get().close();
         east.get().awaitClose();
     }
 

--- a/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackLoopbackLoadStress.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackLoopbackLoadStress.java
@@ -65,7 +65,7 @@ import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.asn1.x509.X509Extension;
+import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
@@ -143,7 +143,7 @@ public class ProtocolStackLoopbackLoadStress {
 
         JcaX509ExtensionUtils instance = new JcaX509ExtensionUtils();
 
-        certGen.addExtension(X509Extension.subjectKeyIdentifier,
+        certGen.addExtension(Extension.subjectKeyIdentifier,
                 false,
                 instance.createSubjectKeyIdentifier(subjectPublicKeyInfo)
         );

--- a/src/test/java/org/jenkinsci/remoting/protocol/cert/X509CertificateRule.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/cert/X509CertificateRule.java
@@ -38,7 +38,7 @@ import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.asn1.x509.X509Extension;
+import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
@@ -134,7 +134,7 @@ public class X509CertificateRule implements TestRule {
 
                 JcaX509ExtensionUtils instance = new JcaX509ExtensionUtils();
 
-                certGen.addExtension(X509Extension.subjectKeyIdentifier,
+                certGen.addExtension(Extension.subjectKeyIdentifier,
                         false,
                         instance.createSubjectKeyIdentifier(subjectPublicKeyInfo)
                 );

--- a/src/test/java/org/jenkinsci/remoting/protocol/impl/SSLEngineFilterLayerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/impl/SSLEngineFilterLayerTest.java
@@ -206,7 +206,7 @@ public class SSLEngineFilterLayerTest {
         server.get().send(data);
         client.get().awaitByteContent(is(expected));
         assertThat(client.get().asByteArray(), is(expected));
-        server.get().close();
+        server.get().close(null);
         client.get().awaitClose();
     }
 
@@ -506,8 +506,8 @@ public class SSLEngineFilterLayerTest {
         client.awaitByteContent(SequentialSender.matcher(serverLimit));
         server.awaitByteContent(SequentialSender.matcher(clientLimit));
 
-        client.close();
-        server.close();
+        client.close(null);
+        server.close(null);
 
         client.awaitClose();
         server.awaitClose();
@@ -556,8 +556,8 @@ public class SSLEngineFilterLayerTest {
 
         client.awaitByteContent(SequentialSender.matcher(amount));
 
-        client.close();
-        server.close();
+        client.close(null);
+        server.close(null);
 
         client.awaitClose();
         server.awaitClose();

--- a/src/test/java/org/jenkinsci/remoting/protocol/impl/SSLEngineFilterLayerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/impl/SSLEngineFilterLayerTest.java
@@ -206,7 +206,7 @@ public class SSLEngineFilterLayerTest {
         server.get().send(data);
         client.get().awaitByteContent(is(expected));
         assertThat(client.get().asByteArray(), is(expected));
-        server.get().close(null);
+        server.get().close();
         client.get().awaitClose();
     }
 
@@ -506,8 +506,8 @@ public class SSLEngineFilterLayerTest {
         client.awaitByteContent(SequentialSender.matcher(serverLimit));
         server.awaitByteContent(SequentialSender.matcher(clientLimit));
 
-        client.close(null);
-        server.close(null);
+        client.close();
+        server.close();
 
         client.awaitClose();
         server.awaitClose();
@@ -556,8 +556,8 @@ public class SSLEngineFilterLayerTest {
 
         client.awaitByteContent(SequentialSender.matcher(amount));
 
-        client.close(null);
-        server.close(null);
+        client.close();
+        server.close();
 
         client.awaitClose();
         server.awaitClose();

--- a/src/test/java/org/jenkinsci/remoting/util/ByteBufferQueueInputStreamTest.java
+++ b/src/test/java/org/jenkinsci/remoting/util/ByteBufferQueueInputStreamTest.java
@@ -84,6 +84,7 @@ public class ByteBufferQueueInputStreamTest {
         assertThat(new String(bytes, StandardCharsets.UTF_8), is("KlMnOpQrSt"));
         assertThat(instance.read(bytes), is(6));
         assertThat(new String(bytes, StandardCharsets.UTF_8), is("UvWxYzQrSt"));
+        instance.close();
     }
 
     @Test
@@ -105,6 +106,7 @@ public class ByteBufferQueueInputStreamTest {
         assertThat(new String(bytes, StandardCharsets.UTF_8), is("dEnOpQrStU"));
         assertThat(instance.read(bytes, 2, 8), is(5));
         assertThat(new String(bytes, StandardCharsets.UTF_8), is("dEvWxYzStU"));
+        instance.close();
     }
 
     @Test
@@ -127,6 +129,7 @@ public class ByteBufferQueueInputStreamTest {
                 }
             }
         } while (b != -1);
+        instance.close();
 
         assertThat(buf.toString(), is("bdfhjlnprtvxz"));
     }

--- a/src/test/java/org/jenkinsci/remoting/util/ByteBufferQueueOutputStreamTest.java
+++ b/src/test/java/org/jenkinsci/remoting/util/ByteBufferQueueOutputStreamTest.java
@@ -40,6 +40,7 @@ public class ByteBufferQueueOutputStreamTest {
         ByteBufferQueueOutputStream instance = new ByteBufferQueueOutputStream(queue);
 
         instance.write(str.getBytes(StandardCharsets.UTF_8));
+        instance.close();
 
         assertThat(read(queue), is(str));
     }
@@ -52,6 +53,7 @@ public class ByteBufferQueueOutputStreamTest {
         ByteBufferQueueOutputStream instance = new ByteBufferQueueOutputStream(queue);
 
         instance.write(str.getBytes(StandardCharsets.UTF_8), 0, 10);
+        instance.close();
         assertThat(read(queue), is("AbCdEfGhIj"));
     }
 
@@ -64,6 +66,7 @@ public class ByteBufferQueueOutputStreamTest {
         for (int i = 1; i < str.length(); i += 2) {
             instance.write(str.charAt(i));
         }
+        instance.close();
 
         assertThat(read(queue), is("bdfhjlnprtvxz"));
     }

--- a/src/test/java/org/jenkinsci/remoting/util/FastByteBufferQueueInputStreamTest.java
+++ b/src/test/java/org/jenkinsci/remoting/util/FastByteBufferQueueInputStreamTest.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeThat;
 
 public class FastByteBufferQueueInputStreamTest {
     @Test
@@ -84,6 +83,7 @@ public class FastByteBufferQueueInputStreamTest {
         assertThat(new String(bytes, StandardCharsets.UTF_8), is("KlMnOpQrSt"));
         assertThat(instance.read(bytes), is(6));
         assertThat(new String(bytes, StandardCharsets.UTF_8), is("UvWxYzQrSt"));
+        instance.close();
     }
 
     @Test
@@ -105,6 +105,7 @@ public class FastByteBufferQueueInputStreamTest {
         assertThat(new String(bytes, StandardCharsets.UTF_8), is("dEnOpQrStU"));
         assertThat(instance.read(bytes, 2, 8), is(5));
         assertThat(new String(bytes, StandardCharsets.UTF_8), is("dEvWxYzStU"));
+        instance.close();
     }
 
     @Test
@@ -127,6 +128,7 @@ public class FastByteBufferQueueInputStreamTest {
                 }
             }
         } while (b != -1);
+        instance.close();
 
         assertThat(buf.toString(), is("bdfhjlnprtvxz"));
     }
@@ -139,6 +141,7 @@ public class FastByteBufferQueueInputStreamTest {
         queue.put(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
         FastByteBufferQueueInputStream instance = new FastByteBufferQueueInputStream(queue,26);
         assertThat(instance.markSupported(), is(false));
+        instance.close();
     }
 
     private static String read(InputStream is) throws IOException {


### PR DESCRIPTION
- Strip trailing spaces
- Remove old code for java 6 and below
- Add some parameters to generics to reduce warnings and to others to remove pointless casts
- Remove unused imports
- Use non-deprecated code