### PR TITLE
[JENKINS-59047] - Use base64 from java

### DIFF
--- a/src/main/java/hudson/remoting/Base64.java
+++ b/src/main/java/hudson/remoting/Base64.java
@@ -15,6 +15,8 @@
  */
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
@@ -60,6 +62,8 @@ public final class  Base64 {
      * @return Array containing decoded data. {@code null} if the data cannot be decoded.
      */
     @CheckForNull
+    @SuppressFBWarnings(value = "PZLA_PREFER_ZERO_LENGTH_ARRAYS",
+            justification = "Null arrays are the part of the library API")
     public static byte[] decode(String encoded) {
 
         if (encoded == null)

--- a/src/main/java/hudson/remoting/Base64.java
+++ b/src/main/java/hudson/remoting/Base64.java
@@ -16,6 +16,7 @@
 package hudson.remoting;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
@@ -34,19 +35,14 @@ import javax.annotation.Nullable;
  * @author Jeffrey Rodriguez
  * @author Sandy Gao
  * @version $Id: Base64.java,v 1.4 2007/07/19 04:38:32 ofung Exp $
+ * @deprecated Use {@link java.util.Base64} instead
  */
+@Deprecated
 public final class  Base64 {
 
     static private final int  BASELENGTH         = 128;
     static private final int  LOOKUPLENGTH       = 64;
-    static private final int  TWENTYFOURBITGROUP = 24;
-    static private final int  EIGHTBIT           = 8;
-    static private final int  SIXTEENBIT         = 16;
-    static private final int  SIXBIT             = 6;
-    static private final int  FOURBYTE           = 4;
-    static private final int  SIGN               = -128;
     static private final char PAD                = '=';
-    static private final boolean fDebug          = false;
     static final private byte [] base64Alphabet        = new byte[BASELENGTH];
     static final private char [] lookUpBase64Alphabet  = new char[LOOKUPLENGTH];
 
@@ -110,84 +106,7 @@ public final class  Base64 {
         if (binaryData == null)
             return null;
 
-        int      lengthDataBits    = binaryData.length*EIGHTBIT;
-        if (lengthDataBits == 0) {
-            return "";
-        }
-
-        int      fewerThan24bits   = lengthDataBits%TWENTYFOURBITGROUP;
-        int      numberTriplets    = lengthDataBits/TWENTYFOURBITGROUP;
-        int      numberQuartet     = fewerThan24bits != 0 ? numberTriplets+1 : numberTriplets;
-        char     encodedData[]     = null;
-
-        encodedData = new char[numberQuartet*4];
-
-        byte k=0, l=0, b1=0,b2=0,b3=0;
-
-        int encodedIndex = 0;
-        int dataIndex   = 0;
-        if (fDebug) {
-            System.out.println("number of triplets = " + numberTriplets );
-        }
-
-        for (int i=0; i<numberTriplets; i++) {
-            b1 = binaryData[dataIndex++];
-            b2 = binaryData[dataIndex++];
-            b3 = binaryData[dataIndex++];
-
-            if (fDebug) {
-                System.out.println( "b1= " + b1 +", b2= " + b2 + ", b3= " + b3 );
-            }
-
-            l  = (byte)(b2 & 0x0f);
-            k  = (byte)(b1 & 0x03);
-
-            byte val1 = ((b1 & SIGN)==0)?(byte)(b1>>2):(byte)((b1)>>2^0xc0);
-
-            byte val2 = ((b2 & SIGN)==0)?(byte)(b2>>4):(byte)((b2)>>4^0xf0);
-            byte val3 = ((b3 & SIGN)==0)?(byte)(b3>>6):(byte)((b3)>>6^0xfc);
-
-            if (fDebug) {
-                System.out.println( "val2 = " + val2 );
-                System.out.println( "k4   = " + (k<<4));
-                System.out.println( "vak  = " + (val2 | (k<<4)));
-            }
-
-            encodedData[encodedIndex++] = lookUpBase64Alphabet[ val1 ];
-            encodedData[encodedIndex++] = lookUpBase64Alphabet[ val2 | ( k<<4 )];
-            encodedData[encodedIndex++] = lookUpBase64Alphabet[ (l <<2 ) | val3 ];
-            encodedData[encodedIndex++] = lookUpBase64Alphabet[ b3 & 0x3f ];
-        }
-
-        // form integral number of 6-bit groups
-        if (fewerThan24bits == EIGHTBIT) {
-            b1 = binaryData[dataIndex];
-            k = (byte) ( b1 &0x03 );
-            if (fDebug) {
-                System.out.println("b1=" + b1);
-                System.out.println("b1<<2 = " + (b1>>2) );
-            }
-            byte val1 = ((b1 & SIGN)==0)?(byte)(b1>>2):(byte)((b1)>>2^0xc0);
-            encodedData[encodedIndex++] = lookUpBase64Alphabet[ val1 ];
-            encodedData[encodedIndex++] = lookUpBase64Alphabet[ k<<4 ];
-            encodedData[encodedIndex++] = PAD;
-            encodedData[encodedIndex++] = PAD;
-        } else if (fewerThan24bits == SIXTEENBIT) {
-            b1 = binaryData[dataIndex];
-            b2 = binaryData[dataIndex +1 ];
-            l = ( byte ) ( b2 &0x0f );
-            k = ( byte ) ( b1 &0x03 );
-
-            byte val1 = ((b1 & SIGN)==0)?(byte)(b1>>2):(byte)((b1)>>2^0xc0);
-            byte val2 = ((b2 & SIGN)==0)?(byte)(b2>>4):(byte)((b2)>>4^0xf0);
-
-            encodedData[encodedIndex++] = lookUpBase64Alphabet[ val1 ];
-            encodedData[encodedIndex++] = lookUpBase64Alphabet[ val2 | ( k<<4 )];
-            encodedData[encodedIndex++] = lookUpBase64Alphabet[ l<<2 ];
-            encodedData[encodedIndex++] = PAD;
-        }
-
-        return new String(encodedData);
+        return java.util.Base64.getEncoder().encodeToString(binaryData);
     }
 
     /**
@@ -197,94 +116,14 @@ public final class  Base64 {
      * @return Array containing decoded data. {@code null} if the data cannot be decoded.
      */
     @CheckForNull
-    @SuppressFBWarnings(value = "PZLA_PREFER_ZERO_LENGTH_ARRAYS", 
+    @SuppressFBWarnings(value = "PZLA_PREFER_ZERO_LENGTH_ARRAYS",
             justification = "Null arrays are the part of the library API")
     public static byte[] decode(String encoded) {
 
         if (encoded == null)
             return null;
 
-        char[] base64Data = encoded.toCharArray();
-        // remove white spaces
-        int len = removeWhiteSpace(base64Data);
-
-        if (len%FOURBYTE != 0) {
-            return null;//should be divisible by four
-        }
-
-        int      numberQuadruple    = (len/FOURBYTE );
-
-        if (numberQuadruple == 0)
-            return new byte[0];
-
-        byte     decodedData[]      = null;
-        byte     b1=0,b2=0,b3=0,b4=0;
-        char     d1=0,d2=0,d3=0,d4=0;
-
-        int i = 0;
-        int encodedIndex = 0;
-        int dataIndex    = 0;
-        decodedData      = new byte[ (numberQuadruple)*3];
-
-        for (; i<numberQuadruple-1; i++) {
-
-            if (!isData( (d1 = base64Data[dataIndex++]) )||
-                !isData( (d2 = base64Data[dataIndex++]) )||
-                !isData( (d3 = base64Data[dataIndex++]) )||
-                !isData( (d4 = base64Data[dataIndex++]) ))
-                return null;//if found "no data" just return null
-
-            b1 = base64Alphabet[d1];
-            b2 = base64Alphabet[d2];
-            b3 = base64Alphabet[d3];
-            b4 = base64Alphabet[d4];
-
-            decodedData[encodedIndex++] = (byte)(  b1 <<2 | b2>>4 ) ;
-            decodedData[encodedIndex++] = (byte)(((b2 & 0xf)<<4 ) |( (b3>>2) & 0xf) );
-            decodedData[encodedIndex++] = (byte)( b3<<6 | b4 );
-        }
-
-        if (!isData( (d1 = base64Data[dataIndex++]) ) ||
-            !isData( (d2 = base64Data[dataIndex++]) )) {
-            return null;//if found "no data" just return null
-        }
-
-        b1 = base64Alphabet[d1];
-        b2 = base64Alphabet[d2];
-
-        d3 = base64Data[dataIndex++];
-        d4 = base64Data[dataIndex++];
-        if (!isData( (d3 ) ) ||
-            !isData( (d4 ) )) {//Check if they are PAD characters
-            if (isPad( d3 ) && isPad( d4)) {               //Two PAD e.g. 3c[Pad][Pad]
-                if ((b2 & 0xf) != 0)//last 4 bits should be zero
-                    return null;
-                byte[] tmp = new byte[ i*3 + 1 ];
-                System.arraycopy( decodedData, 0, tmp, 0, i*3 );
-                tmp[encodedIndex]   = (byte)(  b1 <<2 | b2>>4 ) ;
-                return tmp;
-            } else if (!isPad( d3) && isPad(d4)) {               //One PAD  e.g. 3cQ[Pad]
-                b3 = base64Alphabet[ d3 ];
-                if ((b3 & 0x3 ) != 0)//last 2 bits should be zero
-                    return null;
-                byte[] tmp = new byte[ i*3 + 2 ];
-                System.arraycopy( decodedData, 0, tmp, 0, i*3 );
-                tmp[encodedIndex++] = (byte)(  b1 <<2 | b2>>4 );
-                tmp[encodedIndex]   = (byte)(((b2 & 0xf)<<4 ) |( (b3>>2) & 0xf) );
-                return tmp;
-            } else {
-                return null;//an error  like "3c[Pad]r", "3cdX", "3cXd", "3cXX" where X is non data
-            }
-        } else { //No PAD e.g 3cQl
-            b3 = base64Alphabet[ d3 ];
-            b4 = base64Alphabet[ d4 ];
-            decodedData[encodedIndex++] = (byte)(  b1 <<2 | b2>>4 ) ;
-            decodedData[encodedIndex++] = (byte)(((b2 & 0xf)<<4 ) |( (b3>>2) & 0xf) );
-            decodedData[encodedIndex++] = (byte)( b3<<6 | b4 );
-
-        }
-
-        return decodedData;
+        return java.util.Base64.getDecoder().decode(encoded);
     }
 
     /**

--- a/src/main/java/hudson/remoting/Base64.java
+++ b/src/main/java/hudson/remoting/Base64.java
@@ -15,8 +15,6 @@
  */
 package hudson.remoting;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
@@ -40,60 +38,6 @@ import javax.annotation.Nullable;
 @Deprecated
 public final class  Base64 {
 
-    static private final int  BASELENGTH         = 128;
-    static private final int  LOOKUPLENGTH       = 64;
-    static private final char PAD                = '=';
-    static final private byte [] base64Alphabet        = new byte[BASELENGTH];
-    static final private char [] lookUpBase64Alphabet  = new char[LOOKUPLENGTH];
-
-    static {
-
-        for (int i = 0; i < BASELENGTH; ++i) {
-            base64Alphabet[i] = -1;
-        }
-        for (int i = 'Z'; i >= 'A'; i--) {
-            base64Alphabet[i] = (byte) (i-'A');
-        }
-        for (int i = 'z'; i>= 'a'; i--) {
-            base64Alphabet[i] = (byte) ( i-'a' + 26);
-        }
-
-        for (int i = '9'; i >= '0'; i--) {
-            base64Alphabet[i] = (byte) (i-'0' + 52);
-        }
-
-        base64Alphabet['+']  = 62;
-        base64Alphabet['/']  = 63;
-
-        for (int i = 0; i<=25; i++)
-            lookUpBase64Alphabet[i] = (char)('A'+i);
-
-        for (int i = 26,  j = 0; i<=51; i++, j++)
-            lookUpBase64Alphabet[i] = (char)('a'+ j);
-
-        for (int i = 52,  j = 0; i<=61; i++, j++)
-            lookUpBase64Alphabet[i] = (char)('0' + j);
-        lookUpBase64Alphabet[62] = (char)'+';
-        lookUpBase64Alphabet[63] = (char)'/';
-
-    }
-
-    protected static boolean isWhiteSpace(char octect) {
-        return (octect == 0x20 || octect == 0xd || octect == 0xa || octect == 0x9);
-    }
-
-    protected static boolean isPad(char octect) {
-        return (octect == PAD);
-    }
-
-    protected static boolean isData(char octect) {
-        return (octect < BASELENGTH && base64Alphabet[octect] != -1);
-    }
-
-    protected static boolean isBase64(char octect) {
-        return (isWhiteSpace(octect) || isPad(octect) || isData(octect));
-    }
-
     /**
      * Encodes hex octects into Base64
      *
@@ -116,33 +60,11 @@ public final class  Base64 {
      * @return Array containing decoded data. {@code null} if the data cannot be decoded.
      */
     @CheckForNull
-    @SuppressFBWarnings(value = "PZLA_PREFER_ZERO_LENGTH_ARRAYS",
-            justification = "Null arrays are the part of the library API")
     public static byte[] decode(String encoded) {
 
         if (encoded == null)
             return null;
 
         return java.util.Base64.getDecoder().decode(encoded);
-    }
-
-    /**
-     * remove WhiteSpace from MIME containing encoded Base64 data.
-     *
-     * @param data  the byte array of base64 data (with WS)
-     * @return      the new length
-     */
-    protected static int removeWhiteSpace(char[] data) {
-        if (data == null)
-            return 0;
-
-        // count characters that's not whitespace
-        int newSize = 0;
-        int len = data.length;
-        for (int i = 0; i < len; i++) {
-            if (!isWhiteSpace(data[i]))
-                data[newSize++] = data[i];
-        }
-        return newSize;
     }
 }

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -90,6 +90,7 @@ import java.security.cert.CertificateException;
 import java.security.NoSuchAlgorithmException;
 import java.security.KeyManagementException;
 import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -477,11 +478,11 @@ public class Launcher {
                     HttpURLConnection http = (HttpURLConnection) con;
                     if  (slaveJnlpCredentials != null) {
                         String userPassword = slaveJnlpCredentials;
-                        String encoding = Base64.encode(userPassword.getBytes("UTF-8"));
+                        String encoding = Base64.getEncoder().encodeToString(userPassword.getBytes("UTF-8"));
                         http.setRequestProperty("Authorization", "Basic " + encoding);
                     }
                     if (System.getProperty("proxyCredentials", proxyCredentials) != null) {
-                        String encoding = Base64.encode(System.getProperty("proxyCredentials", proxyCredentials).getBytes("UTF-8"));
+                        String encoding = Base64.getEncoder().encodeToString(System.getProperty("proxyCredentials", proxyCredentials).getBytes("UTF-8"));
                         http.setRequestProperty("Proxy-Authorization", "Basic " + encoding);
                     }
                 }

--- a/src/main/java/hudson/remoting/Util.java
+++ b/src/main/java/hudson/remoting/Util.java
@@ -21,6 +21,7 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 
 /**
  * Misc. I/O utilities
@@ -120,11 +121,11 @@ public class Util {
             con = url.openConnection();
         }
         if (credentials != null) {
-            String encoding = Base64.encode(credentials.getBytes("UTF-8"));
+            String encoding = Base64.getEncoder().encodeToString(credentials.getBytes("UTF-8"));
             con.setRequestProperty("Authorization", "Basic " + encoding);
         }
         if (proxyCredentials != null) {
-            String encoding = Base64.encode(proxyCredentials.getBytes("UTF-8"));
+            String encoding = Base64.getEncoder().encodeToString(proxyCredentials.getBytes("UTF-8"));
             con.setRequestProperty("Proxy-Authorization", "Basic " + encoding);
         }
         if (con instanceof HttpsURLConnection && sslSocketFactory != null) {

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -23,7 +23,6 @@
  */
 package org.jenkinsci.remoting.engine;
 
-import hudson.remoting.Base64;
 import hudson.remoting.Launcher;
 import hudson.remoting.NoProxyEvaluator;
 
@@ -51,6 +50,7 @@ import java.security.SecureRandom;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.util.*;
+import java.util.Base64;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -94,7 +94,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
      */
     private static String PROTOCOL_NAMES_TO_TRY =
             System.getProperty(JnlpAgentEndpointResolver.class.getName() + ".protocolNamesToTry");
-    
+
     public JnlpAgentEndpointResolver(String... jenkinsUrls) {
         this.jenkinsUrls = new ArrayList<String>(Arrays.asList(jenkinsUrls));
     }
@@ -183,7 +183,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
             if (jenkinsUrl == null) {
                 continue;
             }
-            
+
             final URL selectedJenkinsURL;
             final URL salURL;
             try {
@@ -244,7 +244,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
                             }
                         }
                     }
-                    
+
                     if (agentProtocolNames.isEmpty()) {
                         LOGGER.log(Level.WARNING, "Received the empty list of supported protocols from the server. " +
                                 "All protocols are disabled on the master side OR the 'X-Jenkins-Agent-Protocols' header is corrupted (JENKINS-41730). " +
@@ -255,7 +255,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
                         LOGGER.log(Level.INFO, "Remoting server accepts the following protocols: {0}", agentProtocolNames);
                     }
                 }
-                
+
                 if (PROTOCOL_NAMES_TO_TRY != null) {
                     // Take a list of protocols to try from the system property
                     agentProtocolNames = new HashSet<String>();
@@ -265,10 +265,10 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
                         name = name.trim();
                         if (!name.isEmpty()) {
                             agentProtocolNames.add(name);
-                        } 
+                        }
                     }
                 }
-                
+
                 String idHeader = first(header(con, "X-Instance-Identity"));
                 RSAPublicKey identity;
                 try {
@@ -523,11 +523,11 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
             con = url.openConnection();
         }
         if (credentials != null) {
-            String encoding = Base64.encode(credentials.getBytes("UTF-8"));
+            String encoding = Base64.getEncoder().encodeToString(credentials.getBytes("UTF-8"));
             con.setRequestProperty("Authorization", "Basic " + encoding);
         }
         if (proxyCredentials != null) {
-            String encoding = Base64.encode(proxyCredentials.getBytes("UTF-8"));
+            String encoding = Base64.getEncoder().encodeToString(proxyCredentials.getBytes("UTF-8"));
             con.setRequestProperty("Proxy-Authorization", "Basic " + encoding);
         }
 

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpEndpointResolver.java
@@ -23,14 +23,13 @@
  */
 package org.jenkinsci.remoting.engine;
 
-import hudson.remoting.Base64;
-
 import java.io.IOException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
 
 public abstract class JnlpEndpointResolver {
 
@@ -41,7 +40,7 @@ public abstract class JnlpEndpointResolver {
     protected RSAPublicKey getIdentity(String base64EncodedIdentity) throws InvalidKeySpecException {
         if (base64EncodedIdentity == null) return null;
         try {
-            byte[] encodedKey = Base64.decode(base64EncodedIdentity);
+            byte[] encodedKey = Base64.getDecoder().decode(base64EncodedIdentity);
             if (encodedKey == null) return null;
             X509EncodedKeySpec spec = new X509EncodedKeySpec(encodedKey);
             KeyFactory kf = KeyFactory.getInstance("RSA");

--- a/src/test/java/hudson/remoting/BinarySafeStreamTest.java
+++ b/src/test/java/hudson/remoting/BinarySafeStreamTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Random;
 
 /**
@@ -55,7 +56,7 @@ public class BinarySafeStreamTest extends TestCase {
 
     public void testSingleWrite() throws IOException {
         byte[] ds = getDataSet(65536);
-        String master = Base64.encode(ds);
+        String master = Base64.getEncoder().encodeToString(ds);
 
         ByteArrayOutputStream buf = new ByteArrayOutputStream();
         OutputStream o = BinarySafeStream.wrap(buf);
@@ -66,7 +67,7 @@ public class BinarySafeStreamTest extends TestCase {
 
     public void testChunkedWrites() throws IOException {
         byte[] ds = getDataSet(65536);
-        String master = Base64.encode(ds);
+        String master = Base64.getEncoder().encodeToString(ds);
 
         Random r = new Random(0);
         for( int i=0; i<16; i++) {
@@ -123,7 +124,7 @@ public class BinarySafeStreamTest extends TestCase {
         int ptr=0;
 
         for( int i=0; i<s.length(); i+=4 ) {
-            byte[] buf = Base64.decode(s.substring(i,i+4));
+            byte[] buf = Base64.getDecoder().decode(s.substring(i,i+4));
             for (int j = 0; j < buf.length; j++) {
                 if(buf[j]!=dataSet[ptr])
                     fail("encoding error at offset "+ptr);


### PR DESCRIPTION
Replaced existing base64 implementation with the one provided by java and deprecated the class.
Using the RFC 4648 encoder instead of the RFC 2045 encoder. The RFC 2045 encoder contains linefeeds unlike RFC 4648 which is what the current implementation does.