### PR TITLE
[JENKINS-59094] Jenkins connection failure with tunneling

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
@@ -15,13 +15,10 @@ class HostPort {
             return;
         }
         int portSeparator = hostPortValue.lastIndexOf(':');
-        if (portSeparator <= 0) {
+        if (portSeparator < 0) {
             throw new IllegalArgumentException("Invalid HOST:PORT value: " + value);
         }
         host = hostPortValue.substring(0, portSeparator).trim();
-        if (host.isEmpty()) {
-            throw new IllegalArgumentException("Invalid HOST:PORT value: " + value);
-        }
         String portString = hostPortValue.substring(portSeparator + 1).trim();
         if (portString.length() > 0) {
             port = Integer.parseInt(portString);

--- a/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
@@ -3,7 +3,7 @@ package org.jenkinsci.remoting.engine;
 class HostPort {
 
     private static final int PORT_MIN = 0;
-    private static final int PORT_MAX = (1 << 16) -1;
+    private static final int PORT_MAX = (1 << 16) - 1;
 
     private String host;
     private int port;

--- a/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
@@ -1,6 +1,10 @@
 package org.jenkinsci.remoting.engine;
 
 class HostPort {
+
+    private static final int PORT_MIN = 0;
+    private static final int PORT_MAX = (1 << 16) -1;
+
     private String host;
     private int port;
 
@@ -22,6 +26,9 @@ class HostPort {
         String portString = hostPortValue.substring(portSeparator + 1).trim();
         if (portString.length() > 0) {
             port = Integer.parseInt(portString);
+            if (port < PORT_MIN || port > PORT_MAX) {
+                throw new IllegalArgumentException("Invalid port value: " + value);
+            }
         }
     }
 
@@ -45,4 +52,5 @@ class HostPort {
     public int getPort() {
         return port;
     }
+
 }

--- a/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
@@ -22,7 +22,10 @@ class HostPort {
         if (host.isEmpty()) {
             throw new IllegalArgumentException("Invalid HOST:PORT value: " + value);
         }
-        port = Integer.parseInt(hostPortValue.substring(portSeparator + 1).trim());
+        String portString = hostPortValue.substring(portSeparator + 1).trim();
+        if (portString.length() > 0) {
+            port = Integer.parseInt(portString);
+        }
     }
 
     private void extractIPv6(String hostPortValue) {

--- a/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
@@ -8,11 +8,11 @@ class HostPort {
     private String host;
     private int port;
 
-    public HostPort(String value) {
-        splitHostPort(value);
+    public HostPort(String value, String defaultHost, int defaultPort) {
+        splitHostPort(value, defaultHost, defaultPort);
     }
 
-    private void splitHostPort(String value) {
+    private void splitHostPort(String value, String defaultHost, int defaultPort) {
         String hostPortValue = value.trim();
         if (hostPortValue.charAt(0) == '[') {
             extractIPv6(hostPortValue);
@@ -22,13 +22,16 @@ class HostPort {
         if (portSeparator < 0) {
             throw new IllegalArgumentException("Invalid HOST:PORT value: " + value);
         }
-        host = hostPortValue.substring(0, portSeparator).trim();
+        String hostValue = hostPortValue.substring(0, portSeparator).trim();
+        host = hostValue.length() > 0 ? hostValue : defaultHost;
         String portString = hostPortValue.substring(portSeparator + 1).trim();
         if (portString.length() > 0) {
             port = Integer.parseInt(portString);
-            if (port < PORT_MIN || port > PORT_MAX) {
+            if (port <= PORT_MIN || port > PORT_MAX) {
                 throw new IllegalArgumentException("Invalid port value: " + value);
             }
+        } else {
+            port = defaultPort;
         }
     }
 

--- a/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
@@ -8,6 +8,10 @@ class HostPort {
     private String host;
     private int port;
 
+    public HostPort(String value) {
+        splitHostPort(value, null, 0);
+    }
+
     public HostPort(String value, String defaultHost, int defaultPort) {
         splitHostPort(value, defaultHost, defaultPort);
     }

--- a/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/HostPort.java
@@ -28,7 +28,7 @@ class HostPort {
         if (portString.length() > 0) {
             port = Integer.parseInt(portString);
             if (port <= PORT_MIN || port > PORT_MAX) {
-                throw new IllegalArgumentException("Invalid port value: " + value);
+                throw new IllegalArgumentException("Port " + value + " out of valid range [" + PORT_MIN + ", " + PORT_MAX + ")");
             }
         } else {
             port = defaultPort;

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointConfigurator.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointConfigurator.java
@@ -55,7 +55,7 @@ public class JnlpAgentEndpointConfigurator extends JnlpEndpointResolver {
         } catch (InvalidKeySpecException e) {
             throw new IOException("Invalid instanceIdentity.");
         }
-        HostPort hostPort = new HostPort(directionConnection);
+        HostPort hostPort = new HostPort(directionConnection, null, 0);
 
         return new JnlpAgentEndpoint(hostPort.getHost(), hostPort.getPort(), identity, protocols);
     }

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointConfigurator.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointConfigurator.java
@@ -55,7 +55,7 @@ public class JnlpAgentEndpointConfigurator extends JnlpEndpointResolver {
         } catch (InvalidKeySpecException e) {
             throw new IOException("Invalid instanceIdentity.");
         }
-        HostPort hostPort = new HostPort(directionConnection, null, 0);
+        HostPort hostPort = new HostPort(directionConnection);
 
         return new JnlpAgentEndpoint(hostPort.getHost(), hostPort.getPort(), identity, protocols);
     }

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -326,7 +326,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
                     }
                 });
                 if (tunnel != null) {
-                    HostPort hostPort = new HostPort(tunnel);
+                    HostPort hostPort = new HostPort(tunnel, host, port);
                     host = hostPort.getHost();
                     port = hostPort.getPort();
                 }

--- a/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
@@ -121,4 +121,9 @@ public class HostPortTest {
         assertThat(hostPort.getPort(), is( 7777));
     }
 
+    @Test(expected = NumberFormatException.class)
+    public void testPortNotANumber() {
+        new HostPort("hostname:notAPort");
+    }
+
 }

--- a/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
@@ -9,71 +9,71 @@ public class HostPortTest {
 
     @Test
     public void testHostname() {
-        HostPort hostPort = new HostPort("hostname:5555", null, -1);
+        HostPort hostPort = new HostPort("hostname:5555");
         assertThat(hostPort.getHost(), is("hostname"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testFqdn() {
-        HostPort hostPort = new HostPort("hostname.example.com:5555", null, -1);
+        HostPort hostPort = new HostPort("hostname.example.com:5555");
         assertThat(hostPort.getHost(), is("hostname.example.com"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testIPv4() {
-        HostPort hostPort = new HostPort("1.2.3.4:5555", null, -1);
+        HostPort hostPort = new HostPort("1.2.3.4:5555");
         assertThat(hostPort.getHost(), is("1.2.3.4"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testHostWhitespace() {
-        HostPort hostPort = new HostPort("  1.2.3.4  :5555", null, -1);
+        HostPort hostPort = new HostPort("  1.2.3.4  :5555");
         assertThat(hostPort.getHost(), is("1.2.3.4"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testPortWhitespace() {
-        HostPort hostPort = new HostPort("1.2.3.4:   5555  ", null, -1);
+        HostPort hostPort = new HostPort("1.2.3.4:   5555  ");
         assertThat(hostPort.getHost(), is("1.2.3.4"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testIPv6() {
-        HostPort hostPort = new HostPort("[1:2::3:4]:5555", null, -1);
+        HostPort hostPort = new HostPort("[1:2::3:4]:5555");
         assertThat(hostPort.getHost(), is("1:2::3:4"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testIPv6Whitespace() {
-        HostPort hostPort = new HostPort("[  1:2::3:4  ]:5555", null, -1);
+        HostPort hostPort = new HostPort("[  1:2::3:4  ]:5555");
         assertThat(hostPort.getHost(), is("1:2::3:4"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIPv6NoPort() {
-        new HostPort("[1:2::3:4]", null, -1);
+        new HostPort("[1:2::3:4]");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testUnclosedIPv6() {
-        new HostPort("[1:2::3:4:5555", null, -1);
+        new HostPort("[1:2::3:4:5555");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidPort() {
-        new HostPort("[1:2::3:4]:host", null, -1);
+        new HostPort("[1:2::3:4]:host");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNoSeparator() {
-        new HostPort("hostname", null, -1);
+        new HostPort("hostname");
     }
 
     @Test
@@ -106,12 +106,12 @@ public class HostPortTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testNegativePort() {
-        new HostPort("hostname:-4", null, -1);
+        new HostPort("hostname:-4");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testPortTooHigh() {
-        new HostPort("hostname:100000", null, -1);
+        new HostPort("hostname:100000");
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
@@ -88,7 +88,7 @@ public class HostPortTest {
 
     @Test
     public void testEmptyPort() {
-        HostPort hostPort = new HostPort("hostname:");
+        HostPort hostPort = new HostPort("hostname:   ");
         assertThat(hostPort.getHost(), is("hostname"));
         assertThat(hostPort.getPort(), is(0));
     }

--- a/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
@@ -9,109 +9,116 @@ public class HostPortTest {
 
     @Test
     public void testHostname() {
-        HostPort hostPort = new HostPort("hostname:5555");
+        HostPort hostPort = new HostPort("hostname:5555", null, -1);
         assertThat(hostPort.getHost(), is("hostname"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testFqdn() {
-        HostPort hostPort = new HostPort("hostname.example.com:5555");
+        HostPort hostPort = new HostPort("hostname.example.com:5555", null, -1);
         assertThat(hostPort.getHost(), is("hostname.example.com"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testIPv4() {
-        HostPort hostPort = new HostPort("1.2.3.4:5555");
+        HostPort hostPort = new HostPort("1.2.3.4:5555", null, -1);
         assertThat(hostPort.getHost(), is("1.2.3.4"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testHostWhitespace() {
-        HostPort hostPort = new HostPort("  1.2.3.4  :5555");
+        HostPort hostPort = new HostPort("  1.2.3.4  :5555", null, -1);
         assertThat(hostPort.getHost(), is("1.2.3.4"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testPortWhitespace() {
-        HostPort hostPort = new HostPort("1.2.3.4:   5555  ");
+        HostPort hostPort = new HostPort("1.2.3.4:   5555  ", null, -1);
         assertThat(hostPort.getHost(), is("1.2.3.4"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testIPv6() {
-        HostPort hostPort = new HostPort("[1:2::3:4]:5555");
+        HostPort hostPort = new HostPort("[1:2::3:4]:5555", null, -1);
         assertThat(hostPort.getHost(), is("1:2::3:4"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testIPv6Whitespace() {
-        HostPort hostPort = new HostPort("[  1:2::3:4  ]:5555");
+        HostPort hostPort = new HostPort("[  1:2::3:4  ]:5555", null, -1);
         assertThat(hostPort.getHost(), is("1:2::3:4"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIPv6NoPort() {
-        new HostPort("[1:2::3:4]");
+        new HostPort("[1:2::3:4]", null, -1);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testUnclosedIPv6() {
-        new HostPort("[1:2::3:4:5555");
+        new HostPort("[1:2::3:4:5555", null, -1);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidPort() {
-        new HostPort("[1:2::3:4]:host");
+        new HostPort("[1:2::3:4]:host", null, -1);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNoSeparator() {
-        new HostPort("hostname");
+        new HostPort("hostname", null, -1);
     }
 
     @Test
     public void testNoHost() {
-        HostPort hostPort = new HostPort(":5555");
-        assertThat(hostPort.getHost(), is(""));
+        HostPort hostPort = new HostPort(":5555", "hostname", -1);
+        assertThat(hostPort.getHost(), is("hostname"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testEmptyHost() {
-        HostPort hostPort = new HostPort("    :5555");
-        assertThat(hostPort.getHost(), is(""));
+        HostPort hostPort = new HostPort("    :5555", "hostname", -1);
+        assertThat(hostPort.getHost(), is("hostname"));
         assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test
     public void testEmptyPort() {
-        HostPort hostPort = new HostPort("hostname:   ");
+        HostPort hostPort = new HostPort("hostname:   ", null, 7777);
         assertThat(hostPort.getHost(), is("hostname"));
-        assertThat(hostPort.getPort(), is(0));
+        assertThat(hostPort.getPort(), is(7777));
     }
 
     @Test
     public void testSeparatorNoPort() {
-        HostPort hostPort = new HostPort("hostname:");
+        HostPort hostPort = new HostPort("hostname:", null, 7777);
         assertThat(hostPort.getHost(), is("hostname"));
-        assertThat(hostPort.getPort(), is(0));
+        assertThat(hostPort.getPort(), is( 7777));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNegativePort() {
-        new HostPort("hostname:-4");
+        new HostPort("hostname:-4", null, -1);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testPortTooHigh() {
-        new HostPort("hostname:100000");
+        new HostPort("hostname:100000", null, -1);
+    }
+
+    @Test
+    public void testOnlySeparator() {
+        HostPort hostPort = new HostPort(":", "hostname", 7777);
+        assertThat(hostPort.getHost(), is("hostname"));
+        assertThat(hostPort.getPort(), is( 7777));
     }
 
 }

--- a/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
@@ -104,4 +104,14 @@ public class HostPortTest {
         assertThat(hostPort.getPort(), is(0));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativePort() {
+        new HostPort("hostname:-4");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPortTooHigh() {
+        new HostPort("hostname:100000");
+    }
+
 }

--- a/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
@@ -86,14 +86,18 @@ public class HostPortTest {
         new HostPort("    :5555");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testEmptyPort() {
-        new HostPort("hostname:   ");
+        HostPort hostPort = new HostPort("hostname:");
+        assertThat(hostPort.getHost(), is("hostname"));
+        assertThat(hostPort.getPort(), is(0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSeparatorNoPort() {
-        new HostPort("hostname:");
+        HostPort hostPort = new HostPort("hostname:");
+        assertThat(hostPort.getHost(), is("hostname"));
+        assertThat(hostPort.getPort(), is(0));
     }
 
 }

--- a/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
@@ -72,18 +72,22 @@ public class HostPortTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testNoPort() {
+    public void testNoSeparator() {
         new HostPort("hostname");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoHost() {
-        new HostPort(":5555");
+        HostPort hostPort = new HostPort(":5555");
+        assertThat(hostPort.getHost(), is(""));
+        assertThat(hostPort.getPort(), is(5555));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testEmptyHost() {
-        new HostPort("    :5555");
+        HostPort hostPort = new HostPort("    :5555");
+        assertThat(hostPort.getHost(), is(""));
+        assertThat(hostPort.getPort(), is(5555));
     }
 
     @Test


### PR DESCRIPTION
See [JENKINS-59094](https://issues.jenkins-ci.org/browse/JENKINS-59094)

Under some conditions, agents using tunneling have failed to connect after changes in the 3.34 Remoting release. I haven't been able to reproduce it or isolate it yet, but this change restores the host:port parsing logic to previous behavior for handling an empty port. At a minimum, this should at least get us past the exception. It may well solve the problem.