### PR TITLE
Remove engineutil usage

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
@@ -219,12 +219,17 @@ public class JnlpAgentEndpoint {
 
                 BufferedInputStream is = new BufferedInputStream(socket.getInputStream());
                 BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
-                String line = reader.readLine().trim();
-                String[] responseLineParts = line.split(" ");
+                String line = reader.readLine();
+                if (line == null)
+                    throw new IOException("Proxy socket closed");
+                String[] responseLineParts = line.trim().split(" ");
                 if (responseLineParts.length < 2 || !responseLineParts[1].equals("200")) {
                     throw new IOException("Got a bad response from proxy: " + line);
                 }
-                while (!reader.readLine().trim().isEmpty()) {
+                while (!line.trim().isEmpty()) {
+                    line = reader.readLine();
+                    if (line == null)
+                        throw new IOException("Proxy socket closed");
                     // Do nothing, scrolling through headers returned from proxy
                 }
             }

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
@@ -226,10 +226,7 @@ public class JnlpAgentEndpoint {
                 if (responseLineParts.length < 2 || !responseLineParts[1].equals("200")) {
                     throw new IOException("Got a bad response from proxy: " + line);
                 }
-                while (!line.trim().isEmpty()) {
-                    line = reader.readLine();
-                    if (line == null)
-                        throw new IOException("Proxy socket closed");
+                while ((line = reader.readLine()) != null && !line.trim().isEmpty()) {
                     // Do nothing, scrolling through headers returned from proxy
                 }
             }

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpoint.java
@@ -25,12 +25,15 @@ package org.jenkinsci.remoting.engine;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URL;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -39,8 +42,6 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.jenkinsci.remoting.util.KeyUtils;
 import org.jenkinsci.remoting.util.ThrowableUtils;
-
-import static org.jenkinsci.remoting.engine.EngineUtil.readLine;
 
 /**
  * Represents a {@code TcpSlaveAgentListener} endpoint details.
@@ -217,12 +218,13 @@ public class JnlpAgentEndpoint {
                         .write(connectCommand.getBytes("UTF-8")); // TODO: internationalized domain names
 
                 BufferedInputStream is = new BufferedInputStream(socket.getInputStream());
-                String line = readLine(is);
+                BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+                String line = reader.readLine().trim();
                 String[] responseLineParts = line.split(" ");
                 if (responseLineParts.length < 2 || !responseLineParts[1].equals("200")) {
                     throw new IOException("Got a bad response from proxy: " + line);
                 }
-                while (!readLine(is).isEmpty()) {
+                while (!reader.readLine().trim().isEmpty()) {
                     // Do nothing, scrolling through headers returned from proxy
                 }
             }


### PR DESCRIPTION
- Use input stream reader instead. The one situation I think this is different is that `readline()` from stream reader returns null on EOF but `EngineUtil.readline()` returns a blank string. I'm not sure if that matters but it seems like that behaviour masks issues.

EDIT: Turns out spotbugs complains about it so I throw an exception in the case the socket stream EOFs