### PR TITLE
Clean up "slave" term from documentation.

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -101,7 +101,7 @@ Release date: (Aug 5, 2016) => Jenkins 2.17, 2.19.1 LTS
 
 Fixed issues:
 * [JENKINS-37140](https://issues.jenkins-ci.org/browse/JENKINS-37140) -
-JNLP Slave connection issue with *JNLP3-connect* protocol when the generated encrypted cookie contains a newline symbols.
+JNLP Agent connection issue with *JNLP3-connect* protocol when the generated encrypted cookie contains a newline symbols.
 (https://github.com/jenkinsci/remoting/pull/95)
 * [JENKINS-36991](https://issues.jenkins-ci.org/browse/JENKINS-36991) -
 Unable to load class when remote classloader gets interrupted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -629,7 +629,7 @@ Release date: (Aug 5, 2016) => Jenkins 2.17, 2.19.1 LTS
 
 Fixed issues:
 * [JENKINS-37140](https://issues.jenkins-ci.org/browse/JENKINS-37140) -
-JNLP Slave connection issue with *JNLP3-connect* protocol when the generated encrypted cookie contains a newline symbols.
+JNLP Agent connection issue with *JNLP3-connect* protocol when the generated encrypted cookie contains a newline symbols.
 (https://github.com/jenkinsci/remoting/pull/95)
 * [JENKINS-36991](https://issues.jenkins-ci.org/browse/JENKINS-36991) -
 Unable to load class when remote classloader gets interrupted.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Jenkins Remoting layer
 
 Jenkins remoting is an executable JAR, 
 which implements communication layer in [Jenkins](https://jenkins.io) automation server. 
-It's being used for master <=> agent(fka "slave") and master <=> CLI communications.
+It's being used for master <=> agent and master <=> CLI communications.
 
 In general, this library contains the bootstrap code to bridge separate JVMs into a single semi-shared space.
 It includes: TCP-based communication protocols, data serialization, Java classloading.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ These properties require independent configuration on both sides of the channel.
       <td>2.0</td>
       <td>1.367</td>
       <td><a href="https://issues.jenkins-ci.org/browse/JENKINS-35190">JENKINS-35190</a></td>
-      <td>Seconds between ping checks to monitor health of slave nodes; 
+      <td>Seconds between ping checks to monitor health of agent nodes; 
       0 to disable ping</td>
     </tr>
     <tr>
@@ -47,7 +47,7 @@ These properties require independent configuration on both sides of the channel.
       <td>2.0</td>
       <td>1.367</td>
       <td>N/A</td>
-      <td>If ping of slave node takes longer than this, consider it dead; 
+      <td>If ping of agent node takes longer than this, consider it dead; 
       0 to disable ping</td>
     </tr>
     <tr>

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -6,7 +6,7 @@ In Remoting logging is powered by the standard `java.util.logging` engine.
 The default behavior depends on the [Work Directory](workDir.md) mode.
 
 :exclamation: Note that `-loggingConfig` option and [Work directories](workDir.md) are available starting from [Remoting 3.8](../CHANGELOG.md#38). 
-Before this release you have to use the `-slaveLog` option or to redirect STDOUT/STDERR streams.
+Before this release you have to use the `-agentLog` option or to redirect STDOUT/STDERR streams.
 
 ### Configuration
 
@@ -33,16 +33,16 @@ Logging destinations:
   * Logs are being automatically rotated.
     By default, Remoting keeps 5 10MB files
   * Default logging level - `INFO`
-  * If the legacy `-agentLog` or `-slaveLog` option is enabled, this file logging will be disabled.
+  * If the legacy `-agentLog` option is enabled, this file logging will be disabled.
 
-If `-agentLog` or `-slaveLog` are not specified, `${workDir}/${internalDir}/logs` directory will be created during the work directory initialization (if required).
+If `-agentLog` are not specified, `${workDir}/${internalDir}/logs` directory will be created during the work directory initialization (if required).
 
 <!--TODO: Mention conflict with early initialization by java.util.logging.config.file?-->
 
 ### Default behavior without work directory (legacy mode)
 
 * By default, all logs within the system are being sent to _STDOUT/STDERR_ using `java.util.logging`.
-* If `-agentLog` or `-slaveLog` option is specified, the log will be also forwarded to the specified file
+* If `-agentLog` option is specified, the log will be also forwarded to the specified file
   * The existing file will be overridden on startup
   * Remoting does not perform automatic log rotation of this log file
   

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -41,7 +41,7 @@ but confirmed protocol-specific issues will be closed and added to Errata.
 
 * Status: Replaced by `JNLP2-connect`
 
-The slave sends the master the slave name it wants to register as and the computed HMAC of the slave name.
+The agent sends the master the name it wants to register as and the computed HMAC of the agent name.
 If accepted the master will reply with a confirmation response.
 Then the channel gets established.
 
@@ -55,9 +55,9 @@ It may cause performance issues on large-scale instances.
 * Status: Replaced by `JNLP4-connect`
 
 This is the advanced versions of the <code>JNLP1-connect</code> protocol. 
-On successful connection to the master the slave will receive a cookie from the master, which the slave stores.
+On successful connection to the master the agent will receive a cookie from the master, which the agent stores.
  
-If the slave needs to reconnect it will send the same cookie as part of the new connection request. 
+If the agent needs to reconnect it will send the same cookie as part of the new connection request. 
 The master can use the cookie to determine if the incoming request is an initial connection request 
   or a reconnection and take appropriate action.
   
@@ -78,8 +78,8 @@ Check the bugtracker for more issues.
 * The protocol is disabled by default in Jenkins
 * **Not recommended** for use since the <code>JNLP4-connect</code> release
 
-This protocol aims to improve security of JNLP-based slaves. 
-Both the master and the slave securely authenticate each other and then setup an encrypted channel.
+This protocol aims to improve security of JNLP-based agent. 
+Both the master and the agent securely authenticate each other and then setup an encrypted channel.
 
 The protocol does not support non-blocking IO.
 For each connection a new thread is being created, and it leads to the performance degradation or
@@ -94,7 +94,7 @@ There is no plan to fix these issues, usage of `JNLP4-connect` is the recommende
 * [JENKINS-37302](https://issues.jenkins-ci.org/browse/JENKINS-37302) - 
 JNLP3 challenge response generates invalid string encoding, the check may fail randomly.
 * [JENKINS-33886](https://issues.jenkins-ci.org/browse/JENKINS-33886) -
-On some configurations only one JNLP3 slave per IP address can be connected.
+On some configurations only one JNLP3 agent per IP address can be connected.
 * [JENKINS-34121](https://issues.jenkins-ci.org/browse/JENKINS-34121) -
 JNLP3 cannot be used on IBM Java, which doesn't support AES/CTR/PKCS5Padding.
 

--- a/docs/remoting-3-compatibility.md
+++ b/docs/remoting-3-compatibility.md
@@ -23,8 +23,8 @@ In Remoting 3 the required Java version is updated from Java 6 to Java 7.
 In **Jenkins** project:
 
 * Nothing changes, starting from <code>1.610</code> Java 6 is not supported in Jenkins, 
-  on both master and slaves/agents
-* In particular cases it was possible to run Jenkins slaves/agents on Java 6 with Remoting <code>2.x</code>, 
+  on both master and agents
+* In particular cases it was possible to run Jenkins agents on Java 6 with Remoting <code>2.x</code>, 
   but this configuration was not officially supported
 
 In other projects:

--- a/docs/tcpAgent.md
+++ b/docs/tcpAgent.md
@@ -96,7 +96,7 @@ This allows the Windows Service infrastructure to manage the process lifecycle.
 
 To configure the agent this way, first launch the agent using one of the other mechanisms that doesn't run as headless. 
 In the agent GUI, select "File -> Install as a service". 
-Additional descriptions of configuring this mechanism are located at [Installing Jenkins as a Windows service](https://wiki.jenkins.io/display/JENKINS/Installing+Jenkins+as+a+Windows+service) or [How to Install Several Windows Slaves as a Service?](https://support.cloudbees.com/hc/en-us/articles/217423827-How-to-Install-Several-Windows-Slaves-as-a-Service-)
+Additional descriptions of configuring this mechanism are located at [Installing Jenkins as a Windows service](https://wiki.jenkins.io/display/JENKINS/Installing+Jenkins+as+a+Windows+service) or [How to Install Several Windows Agents as a Service?](https://support.cloudbees.com/hc/en-us/articles/217423827-How-to-Install-Several-Windows-Slaves-as-a-Service-)
 
 ## Parameters
 

--- a/docs/workDir.md
+++ b/docs/workDir.md
@@ -10,7 +10,7 @@ all operations were managed by library users (e.g. Jenkins agent workspaces).
 ### Before Remoting 3.8 (Jenkins 2.68)
 
 * There is no work directory management in Remoting itself
-* Logs are not being persisted to the disk unless `-slaveLog` option is specified
+* Logs are not being persisted to the disk unless `-agentLog` option is specified
 * JAR Cache is being stored in `${user.home}/.jenkins` unless `-jarCache` option is specified
 
 ### After Remoting 3.8 (Jenkins 2.68)

--- a/src/main/java/org/jenkinsci/remoting/engine/HandshakeCiphers.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/HandshakeCiphers.java
@@ -98,12 +98,12 @@ class HandshakeCiphers {
      * Create a pair of AES symmetric key {@link Cipher}s that
      * will be used during the handshake process.
      *
-     * <p>The slave name and slave secret are used to create a
+     * <p>The agent name and agent secret are used to create a
      * {@link PBEKeySpec} and an {@link IvParameterSpec}which is then used to
      * create the ciphers.
      *
-     * @param salt The slave for which the handshake is taking place.
-     * @param secret The slave secret.
+     * @param salt The agent for which the handshake is taking place.
+     * @param secret The agent secret.
      */
     public static HandshakeCiphers create(String salt, String secret) {
         try {

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol1Handler.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol1Handler.java
@@ -43,11 +43,11 @@ import org.jenkinsci.remoting.protocol.impl.ConnectionRefusalException;
 /**
  * Implementation of the JNLP-connect protocol.
  *
- * The slave sends the master the slave name it wants to register as and the
- * computed HMAC of the slave name. If accepted the master will reply with a
+ * The agent sends the master the agent name it wants to register as and the
+ * computed HMAC of the agent name. If accepted the master will reply with a
  * confirmation response.
  *
- * This was the first protocol supported by Jenkins. JNLP slaves will use this
+ * This was the first protocol supported by Jenkins. JNLP agents will use this
  * as a last resort when connecting to old versions of Jenkins masters.
  *
  * @since 3.0

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol2Handler.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol2Handler.java
@@ -47,10 +47,10 @@ import org.jenkinsci.remoting.protocol.impl.ConnectionRefusalException;
  * Implementation of the JNLP2-connect protocol.
  *
  * This is an extension of the JNLP1-connect protocol. On successful
- * connection to the master the slave will receive a cookie from the master,
- * which the slave stores.
+ * connection to the master the agent will receive a cookie from the master,
+ * which the agent stores.
  *
- * If the slave needs to reconnect it will send the same cookie as part of
+ * If the agent needs to reconnect it will send the same cookie as part of
  * the new connection request. The master can use the cookie to determine if
  * the incoming request is an initial connection request or a reconnection
  * and take appropriate action.

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol3Handler.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol3Handler.java
@@ -59,29 +59,29 @@ import static org.jenkinsci.remoting.engine.Jnlp3Util.createChallengeResponse;
  * Implementation of the JNLP3-connect protocol.
  *
  * <p>This protocol aims to provide a basic level of security for JNLP based
- * slaves. Both the master and the slave securely authenticate each other and
+ * agents. Both the master and the agent securely authenticate each other and
  * then setup an encrypted {@link Channel}.
  *
- * <p>The slave secret is never exchanged, but instead used as a shared secret
+ * <p>The agent secret is never exchanged, but instead used as a shared secret
  * to generate matching symmetric key {@link javax.crypto.Cipher}s by both
  * sides which are used to perform a secure handshake. During the handshake
- * both the slave and the master send each other challenge phrases which can
- * only be decrypted with the matching cipher created with the slave secret.
+ * both the agent and the master send each other challenge phrases which can
+ * only be decrypted with the matching cipher created with the agent secret.
  * Once decrypted the SHA-256 hash of the challenge is computed and sent back
  * to authenticate.
  *
  * <p>Once the handshake is successful another pair of symmetric key ciphers
- * are created by the slave using random keys. These are then shared with the
+ * are created by the agent using random keys. These are then shared with the
  * master. These ciphers are used to create an encrypted channel by both sides.
  *
  * <p>The following goes over the handshake in more detail:
  * <pre>
  * {@code
  * Client                                                                Master
- *           handshake ciphers = createFrom(slave name, slave secret)
+ *           handshake ciphers = createFrom(agent name, agent secret)
  *
  *   |                                                                     |
- *   |      initiate(slave name, encrypt(challenge), encrypt(cookie))      |
+ *   |      initiate(agent name, encrypt(challenge), encrypt(cookie))      |
  *   |  -------------------------------------------------------------->>>  |
  *   |                                                                     |
  *   |                       encrypt(hash(challenge))                      |
@@ -111,8 +111,8 @@ import static org.jenkinsci.remoting.engine.Jnlp3Util.createChallengeResponse;
  * }
  *  </pre>
  *
- * <p>The entire process assumes the slave secret has not been leaked
- * beforehand and the slave obtains it in a secure manner.
+ * <p>The entire process assumes the agent secret has not been leaked
+ * beforehand and the agent obtains it in a secure manner.
  *
  * <p>The key sizes are only 128bit since it cannot be assumed everyone has
  * the <a href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">
@@ -266,7 +266,7 @@ public class JnlpProtocol3Handler extends LegacyJnlpProtocolHandler<Jnlp3Connect
         PrintWriter out = state.getPrintWriter();
         out.println(NEGOTIATE_LINE);
 
-        // Get initiation information from slave.
+        // Get initiation information from agent.
         Properties request = new Properties();
         DataInputStream in = state.getDataInputStream();
         request.load(new ByteArrayInputStream(in.readUTF().getBytes(StandardCharsets.UTF_8)));
@@ -291,7 +291,7 @@ public class JnlpProtocol3Handler extends LegacyJnlpProtocolHandler<Jnlp3Connect
         out.print(encryptedChallengeResponse);
         out.flush();
 
-        // If the slave accepted our challenge response send our challenge.
+        // If the agent accepted our challenge response send our challenge.
         String challengeVerificationMessage = null;
         try {
             challengeVerificationMessage = in.readUTF();

--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -265,8 +265,8 @@ public class WorkDirManager {
     public void setupLogging(@CheckForNull Path internalDirPath, @CheckForNull Path overrideLogPath) throws IOException {
         if (loggingInitialized) {
             // Do nothing, in Remoting initialization there may be two calls due to the
-            // legacy -slaveLog behavior implementation.
-            LOGGER.log(Level.CONFIG, "Logging susystem has been already initialized");
+            // legacy -agentLog behavior implementation.
+            LOGGER.log(Level.CONFIG, "Logging system has been already initialized");
             return;
         }
 
@@ -308,7 +308,7 @@ public class WorkDirManager {
             this.loggingInitialized = true;
         } else {
             // TODO: This message is suspected to break the CI
-            // System.err.println("WARNING: Log location is not specified (neither -workDir nor -slaveLog/-agentLog set)");
+            // System.err.println("WARNING: Log location is not specified (neither -workDir nor -agentLog set)");
         }
     }
 

--- a/src/test/java/hudson/remoting/TrafficAnalyzer.java
+++ b/src/test/java/hudson/remoting/TrafficAnalyzer.java
@@ -8,11 +8,11 @@ import java.io.DataInputStream;
 import java.io.ObjectInputStream;
 
 /**
- * A little forensic analysis tool to figure out what information master and slaves are exchanging.
+ * A little forensic analysis tool to figure out what information master and agent are exchanging.
  *
  * <p>
  * Use the tee command or network packet capturing tool to capture the traffic between the master and
- * the slave, then run it through this tool to get the dump of what commands are sent between them.
+ * the agent, then run it through this tool to get the dump of what commands are sent between them.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/src/test/java/org/jenkinsci/remoting/engine/HandshakeCiphersTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/HandshakeCiphersTest.java
@@ -37,7 +37,7 @@ public class HandshakeCiphersTest {
 
     @Test
     public void testEncryptDecrypt() throws Exception {
-        HandshakeCiphers ciphers = HandshakeCiphers.create("some slave", "some secret");
+        HandshakeCiphers ciphers = HandshakeCiphers.create("some agent", "some secret");
 
         assertNotEquals("string 1", ciphers.encrypt("string 1"));
         assertEquals("string 1", ciphers.decrypt(ciphers.encrypt("string 1")));
@@ -47,8 +47,8 @@ public class HandshakeCiphersTest {
 
     @Test
     public void testMatchingWithSameValues() throws Exception {
-        HandshakeCiphers ciphers1 = HandshakeCiphers.create("some slave", "some secret");
-        HandshakeCiphers ciphers2 = HandshakeCiphers.create("some slave", "some secret");
+        HandshakeCiphers ciphers1 = HandshakeCiphers.create("some agent", "some secret");
+        HandshakeCiphers ciphers2 = HandshakeCiphers.create("some agent", "some secret");
 
         assertEquals("string 1", ciphers2.decrypt(ciphers1.encrypt("string 1")));
         assertEquals("string 2", ciphers1.decrypt(ciphers2.encrypt("string 2")));
@@ -56,8 +56,8 @@ public class HandshakeCiphersTest {
 
     @Test
     public void testNotMatchingWithDifferentValues() throws Exception {
-        HandshakeCiphers ciphers1 = HandshakeCiphers.create("some slave", "some secret");
-        HandshakeCiphers ciphers2 = HandshakeCiphers.create("other slave", "other secret");
+        HandshakeCiphers ciphers1 = HandshakeCiphers.create("some agent", "some secret");
+        HandshakeCiphers ciphers2 = HandshakeCiphers.create("other agent", "other secret");
 
         assertNotEquals("string 1", ciphers2.decrypt(ciphers1.encrypt("string 1")));
         assertNotEquals("string 2", ciphers1.decrypt(ciphers2.encrypt("string 2")));


### PR DESCRIPTION
Where possible remove the term "slave" from documentation, replacing with "agent" as needed. In some instances, both were used but we're past the time where we need to continue using the old name.
Removes from AsciiDoc pages, JavaDoc, and code comments.
The remaining documentation references are for external or remaining API references.