### PR TITLE
Remove some usages of slave from public fields.

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -133,7 +133,7 @@ public class Engine extends Thread {
     @CheckForNull
     private URL hudsonUrl;
     private final String secretKey;
-    public final String slaveName;
+    public final String agentName;
     private String credentials;
     private String proxyCredentials = System.getProperty("proxyCredentials");
 
@@ -210,18 +210,18 @@ public class Engine extends Thread {
     private String instanceIdentity;
     private final Set<String> protocols;
 
-    public Engine(EngineListener listener, List<URL> hudsonUrls, String secretKey, String slaveName) {
-        this(listener, hudsonUrls, secretKey, slaveName, null, null, null);
+    public Engine(EngineListener listener, List<URL> hudsonUrls, String secretKey, String agentName) {
+        this(listener, hudsonUrls, secretKey, agentName, null, null, null);
     }
 
-    public Engine(EngineListener listener, List<URL> hudsonUrls, String secretKey, String slaveName, String directConnection, String instanceIdentity,
+    public Engine(EngineListener listener, List<URL> hudsonUrls, String secretKey, String agentName, String directConnection, String instanceIdentity,
                   Set<String> protocols) {
         this.listener = listener;
         this.directConnection = directConnection;
         this.events.add(listener);
         this.candidateUrls = hudsonUrls;
         this.secretKey = secretKey;
-        this.slaveName = slaveName;
+        this.agentName = agentName;
         this.instanceIdentity = instanceIdentity;
         this.protocols = protocols;
         if(candidateUrls.isEmpty() && instanceIdentity == null) {
@@ -503,7 +503,7 @@ public class Engine extends Thread {
                 .withPreferNonBlockingIO(false) // we only have one connection, prefer blocking I/O
                 .handlers();
         final Map<String,String> headers = new HashMap<>();
-        headers.put(JnlpConnectionState.CLIENT_NAME_KEY, slaveName);
+        headers.put(JnlpConnectionState.CLIENT_NAME_KEY, agentName);
         headers.put(JnlpConnectionState.SECRET_KEY, secretKey);
         List<String> jenkinsUrls = new ArrayList<>();
         for (URL url: candidateUrls) {

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -133,7 +133,7 @@ public class Engine extends Thread {
     @CheckForNull
     private URL hudsonUrl;
     private final String secretKey;
-    public final String agentName;
+    private final String agentName;
     private String credentials;
     private String proxyCredentials = System.getProperty("proxyCredentials");
 

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -121,7 +121,7 @@ public class Launcher {
      */
     @Option(name="-agentLog", aliases = {"-slaveLog"}, usage="Local agent error log destination (overrides workDir)")
     @CheckForNull
-    public File slaveLog = null;
+    public File agentLog = null;
 
     @Option(name="-text",usage="encode communication with the master with base64. " +
             "Useful for running agent over 8-bit unsafe protocol like telnet")
@@ -133,10 +133,10 @@ public class Launcher {
     @Option(name="-jnlpUrl",usage="instead of talking to the master via stdin/stdout, " +
             "emulate a JNLP client by making a TCP connection to the master. " +
             "Connection parameters are obtained by parsing the JNLP file.")
-    public URL slaveJnlpURL = null;
+    public URL agentJnlpURL = null;
 
     @Option(name="-jnlpCredentials",metaVar="USER:PASSWORD",usage="HTTP BASIC AUTH header to pass in for making HTTP requests.")
-    public String slaveJnlpCredentials = null;
+    public String agentJnlpCredentials = null;
 
     @Option(name="-secret", metaVar="HEX_SECRET", usage="Agent connection secret to use instead of -jnlpCredentials.")
     public String secret;
@@ -294,13 +294,13 @@ public class Launcher {
         // On the other hand, in such case there is no need to invoke WorkDirManager and handle the double initialization logic
         final WorkDirManager workDirManager = WorkDirManager.getInstance();
         final Path internalDirPath = workDirManager.initializeWorkDir(workDir, internalDir, failIfWorkDirIsMissing);
-        if (slaveLog != null) {
+        if (agentLog != null) {
             workDirManager.disable(WorkDirManager.DirType.LOGS_DIR);
         }
         if (loggingConfigFilePath != null) {
             workDirManager.setLoggingConfig(loggingConfigFilePath);
         }
-        workDirManager.setupLogging(internalDirPath, slaveLog != null ? PathUtils.fileToPath(slaveLog) : null);
+        workDirManager.setupLogging(internalDirPath, agentLog != null ? PathUtils.fileToPath(agentLog) : null);
 
         if(auth!=null) {
             final int idx = auth.indexOf(':');
@@ -317,7 +317,7 @@ public class Launcher {
         if(connectionTarget!=null) {
             runAsTcpClient();
         } else
-        if(slaveJnlpURL!=null) {
+        if(agentJnlpURL !=null) {
             List<String> jnlpArgs = parseJnlpArguments();
             if (jarCache != null) {
               jnlpArgs.add("-jar-cache");
@@ -329,9 +329,9 @@ public class Launcher {
             if (this.noKeepAlive) {
                 jnlpArgs.add("-noKeepAlive");
             }
-            if (slaveLog != null) {
+            if (agentLog != null) {
                 jnlpArgs.add("-agentLog");
-                jnlpArgs.add(slaveLog.getPath());
+                jnlpArgs.add(agentLog.getPath());
             }
             if (loggingConfigFilePath != null) {
                 jnlpArgs.add("-loggingConfig");
@@ -360,7 +360,7 @@ public class Launcher {
             try {
                 hudson.remoting.jnlp.Main._main(jnlpArgs.toArray(new String[jnlpArgs.size()]));
             } catch (CmdLineException e) {
-                System.err.println("JNLP file "+slaveJnlpURL+" has invalid arguments: "+jnlpArgs);
+                System.err.println("JNLP file "+ agentJnlpURL +" has invalid arguments: "+jnlpArgs);
                 System.err.println("Most likely a configuration error in the master");
                 System.err.println(e.getMessage());
                 System.exit(1);
@@ -465,19 +465,19 @@ public class Launcher {
      */
     public List<String> parseJnlpArguments() throws ParserConfigurationException, SAXException, IOException, InterruptedException {
         if (secret != null) {
-            slaveJnlpURL = new URL(slaveJnlpURL + "?encrypt=true");
-            if (slaveJnlpCredentials != null) {
+            agentJnlpURL = new URL(agentJnlpURL + "?encrypt=true");
+            if (agentJnlpCredentials != null) {
                 throw new IOException("-jnlpCredentials and -secret are mutually exclusive");
             }
         }
         while (true) {
             URLConnection con = null;
             try {
-                con = Util.openURLConnection(slaveJnlpURL);
+                con = Util.openURLConnection(agentJnlpURL);
                 if (con instanceof HttpURLConnection) {
                     HttpURLConnection http = (HttpURLConnection) con;
-                    if  (slaveJnlpCredentials != null) {
-                        String userPassword = slaveJnlpCredentials;
+                    if  (agentJnlpCredentials != null) {
+                        String userPassword = agentJnlpCredentials;
                         String encoding = Base64.getEncoder().encodeToString(userPassword.getBytes("UTF-8"));
                         http.setRequestProperty("Authorization", "Basic " + encoding);
                     }
@@ -492,7 +492,7 @@ public class Launcher {
                     HttpURLConnection http = (HttpURLConnection) con;
                     if(http.getResponseCode()>=400)
                         // got the error code. report that (such as 401)
-                        throw new IOException("Failed to load "+slaveJnlpURL+": "+http.getResponseCode()+" "+http.getResponseMessage());
+                        throw new IOException("Failed to load "+ agentJnlpURL +": "+http.getResponseCode()+" "+http.getResponseMessage());
                 }
 
                 Document dom;
@@ -519,14 +519,14 @@ public class Launcher {
                 if(contentType==null || !contentType.startsWith(expectedContentType)) {
                     // load DOM anyway, but if it fails to parse, that's probably because this is not an XML file to begin with.
                     try {
-                        dom = loadDom(slaveJnlpURL, input);
+                        dom = loadDom(agentJnlpURL, input);
                     } catch (SAXException e) {
-                        throw new IOException(slaveJnlpURL+" doesn't look like a JNLP file; content type was "+contentType);
+                        throw new IOException(agentJnlpURL +" doesn't look like a JNLP file; content type was "+contentType);
                     } catch (IOException e) {
-                        throw new IOException(slaveJnlpURL+" doesn't look like a JNLP file; content type was "+contentType);
+                        throw new IOException(agentJnlpURL +" doesn't look like a JNLP file; content type was "+contentType);
                     }
                 } else {
-                    dom = loadDom(slaveJnlpURL, input);
+                    dom = loadDom(agentJnlpURL, input);
                 }
 
                 // exec into the JNLP launcher, to fetch the connection parameter through JNLP.
@@ -534,9 +534,9 @@ public class Launcher {
                 List<String> jnlpArgs = new ArrayList<String>();
                 for( int i=0; i<argElements.getLength(); i++ )
                         jnlpArgs.add(argElements.item(i).getTextContent());
-                if (slaveJnlpCredentials != null) {
+                if (agentJnlpCredentials != null) {
                     jnlpArgs.add("-credentials");
-                    jnlpArgs.add(slaveJnlpCredentials);
+                    jnlpArgs.add(agentJnlpCredentials);
                 }
                 // force a headless mode
                 jnlpArgs.add("-headless");
@@ -551,9 +551,9 @@ public class Launcher {
                     throw e;
             } catch (IOException e) {
                 if (this.noReconnect)
-                    throw (IOException)new IOException("Failing to obtain "+slaveJnlpURL).initCause(e);
+                    throw (IOException)new IOException("Failing to obtain "+ agentJnlpURL).initCause(e);
 
-                System.err.println("Failing to obtain "+slaveJnlpURL);
+                System.err.println("Failing to obtain "+ agentJnlpURL);
                 e.printStackTrace(System.err);
                 System.err.println("Waiting 10 seconds before retry");
                 Thread.sleep(10*1000);


### PR DESCRIPTION
I'm not sure if we want to remove the term in these instances. It depends on what we consider the API and how much we prioritize removing the term "slave" vs. maintaining any possible library use.

Essentially the API at this point are the command-line parameters (the `@Option` tags) and the object fields are internal (though they have the access modifier `public`). Any integration that steps beyond the CLI parameters into the fields is deep and rare.

I'm inclined to think it's better to make this change and continue the removal of the disfavored term. How concerned are others about maintaining the existing API at this level?