### PR TITLE
Add findsecbugs plugin to spotbugs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,6 +414,19 @@ THE SOFTWARE.
           <rerunFailingTestsCount>4</rerunFailingTestsCount>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <plugins>
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>1.10.1</version>
+            </plugin>
+          </plugins>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/hudson/remoting/Capability.java
+++ b/src/main/java/hudson/remoting/Capability.java
@@ -1,5 +1,6 @@
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.remoting.Channel.Mode;
 import java.io.IOException;
 import java.io.InputStream;
@@ -145,6 +146,7 @@ public final class Capability implements Serializable {
     /**
      * The opposite operation of {@link #writePreamble(OutputStream)}.
      */
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Capability is used for negotiating channel between authorized agent and server.")
     public static Capability read(InputStream is) throws IOException {
         try (ObjectInputStream ois = new ObjectInputStream(Mode.TEXT.wrap(is)) {
                 // during deserialization, only accept Capability to protect ourselves

--- a/src/main/java/hudson/remoting/Capability.java
+++ b/src/main/java/hudson/remoting/Capability.java
@@ -146,7 +146,7 @@ public final class Capability implements Serializable {
     /**
      * The opposite operation of {@link #writePreamble(OutputStream)}.
      */
-    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Capability is used for negotiating channel between authorized agent and server.")
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Capability is used for negotiating channel between authorized agent and server. Whitelisting and proper deserialization hygiene are used.")
     public static Capability read(InputStream is) throws IOException {
         try (ObjectInputStream ois = new ObjectInputStream(Mode.TEXT.wrap(is)) {
                 // during deserialization, only accept Capability to protect ourselves

--- a/src/main/java/hudson/remoting/Checksum.java
+++ b/src/main/java/hudson/remoting/Checksum.java
@@ -1,5 +1,7 @@
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.File;
@@ -72,6 +74,7 @@ final class Checksum {
     /**
      * Returns the checksum for the given URL.
      */
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "This is only used for managing the jar cache as files, not URLs.")
     static Checksum forURL(URL url) throws IOException {
         try {
             MessageDigest md = MessageDigest.getInstance(JarLoaderImpl.DIGEST_ALGORITHM);

--- a/src/main/java/hudson/remoting/ClassFilter.java
+++ b/src/main/java/hudson/remoting/ClassFilter.java
@@ -16,6 +16,8 @@ import java.util.regex.PatternSyntaxException;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkinsci.remoting.util.AnonymousClassWarnings;
 
 /**
@@ -240,6 +242,7 @@ public abstract class ClassFilter {
     /**
      * A class that uses a given set of regular expression patterns to determine if the class is blacklisted.
      */
+    @SuppressFBWarnings(value = "REDOS", justification = "In an odd usage, this pattern is used to determine if another pattern matches it and not to match a string to it. REDOS doesn't apply.")
     private static final class RegExpClassFilter extends ClassFilter {
 
         /**

--- a/src/main/java/hudson/remoting/Command.java
+++ b/src/main/java/hudson/remoting/Command.java
@@ -23,6 +23,8 @@
  */
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -146,6 +148,7 @@ public abstract class Command implements Serializable {
 
 
     /** Consider calling {@link Channel#notifyRead} afterwards. */
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Used for sending commands between authorized agent and server.)")
     static Command readFromObjectStream(Channel channel, ObjectInputStream ois) throws IOException, ClassNotFoundException {
         Channel old = Channel.setCurrent(channel);
         try {

--- a/src/main/java/hudson/remoting/Command.java
+++ b/src/main/java/hudson/remoting/Command.java
@@ -148,7 +148,7 @@ public abstract class Command implements Serializable {
 
 
     /** Consider calling {@link Channel#notifyRead} afterwards. */
-    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Used for sending commands between authorized agent and server.)")
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Used for sending commands between authorized agent and server. Class filtering is done through JEP-200.")
     static Command readFromObjectStream(Channel channel, ObjectInputStream ois) throws IOException, ClassNotFoundException {
         Channel old = Channel.setCurrent(channel);
         try {

--- a/src/main/java/hudson/remoting/DiagnosedStreamCorruptionException.java
+++ b/src/main/java/hudson/remoting/DiagnosedStreamCorruptionException.java
@@ -1,5 +1,7 @@
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.PrintWriter;
 import java.io.StreamCorruptedException;
 import java.io.StringWriter;
@@ -42,6 +44,7 @@ public class DiagnosedStreamCorruptionException extends StreamCorruptedException
     }
 
     @Override
+    @SuppressFBWarnings(value = "INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE", justification = "Used for diagnosing stream corruption between agent and server.")
     public String toString() {
         StringBuilder buf = new StringBuilder();
         buf.append(super.toString()).append("\n");

--- a/src/main/java/hudson/remoting/DumbClassLoaderBridge.java
+++ b/src/main/java/hudson/remoting/DumbClassLoaderBridge.java
@@ -1,6 +1,5 @@
 package hudson.remoting;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.remoting.RemoteClassLoader.ClassFile;
 import hudson.remoting.RemoteClassLoader.ClassFile2;
 import hudson.remoting.RemoteClassLoader.IClassLoader;

--- a/src/main/java/hudson/remoting/DumbClassLoaderBridge.java
+++ b/src/main/java/hudson/remoting/DumbClassLoaderBridge.java
@@ -1,5 +1,6 @@
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.remoting.RemoteClassLoader.ClassFile;
 import hudson.remoting.RemoteClassLoader.ClassFile2;
 import hudson.remoting.RemoteClassLoader.IClassLoader;

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -23,6 +23,7 @@
  */
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.remoting.Channel.Mode;
 import java.io.File;
 import java.io.FileInputStream;
@@ -438,6 +439,7 @@ public class Engine extends Thread {
     }
 
     @Override
+    @SuppressFBWarnings(value = "HARD_CODE_PASSWORD", justification = "Password doesn't need to be protected.")
     public void run() {
         // Create the engine
         try {
@@ -702,6 +704,7 @@ public class Engine extends Thread {
 
     private static final Logger LOGGER = Logger.getLogger(Engine.class.getName());
 
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "File path is loaded from system properties.")
     static KeyStore getCacertsKeyStore()
             throws PrivilegedActionException, KeyStoreException, NoSuchProviderException, CertificateException,
             NoSuchAlgorithmException, IOException {

--- a/src/main/java/hudson/remoting/FileSystemJarCache.java
+++ b/src/main/java/hudson/remoting/FileSystemJarCache.java
@@ -1,5 +1,6 @@
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkinsci.remoting.util.PathUtils;
 
 import javax.annotation.Nonnull;
@@ -85,6 +86,7 @@ public class FileSystemJarCache extends JarCacheSupport {
     }
 
     @Override
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "The file path is a generated value based on server supplied data.")
     protected URL retrieve(Channel channel, long sum1, long sum2) throws IOException, InterruptedException {
         Checksum expected = new Checksum(sum1, sum2);
         File target = map(sum1, sum2);
@@ -170,6 +172,7 @@ public class FileSystemJarCache extends JarCacheSupport {
         }
     }
 
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "This path exists within a temp directory so the potential traversal is limited.")
     /*package for testing*/ File createTempJar(@Nonnull File target) throws IOException {
         File parent = target.getParentFile();
         Util.mkdirs(parent);

--- a/src/main/java/hudson/remoting/InitializeJarCacheMain.java
+++ b/src/main/java/hudson/remoting/InitializeJarCacheMain.java
@@ -1,5 +1,7 @@
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -31,6 +33,7 @@ public class InitializeJarCacheMain {
      * <li>The jar cache directory.
      * </ol>
      */
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "These file values are provided by users with sufficient adminstrative permissions to run this utility program.")
     public static void main(String[] argv) throws Exception {
         if (argv.length != 2) {
             throw new IllegalArgumentException(

--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -1,5 +1,6 @@
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 
 import java.io.File;
@@ -33,6 +34,7 @@ class JarLoaderImpl implements JarLoader, SerializableOnlyOverRemoting {
 
     private final Set<Checksum> presentOnRemote = Collections.synchronizedSet(new HashSet<Checksum>());
 
+    @SuppressFBWarnings(value = {"URLCONNECTION_SSRF_FD", "PATH_TRAVERSAL_IN"}, justification = "This is only used for managing the jar cache as files, not URLs.")
     public void writeJarTo(long sum1, long sum2, OutputStream sink) throws IOException, InterruptedException {
         Checksum k = new Checksum(sum1, sum2);
         URL url = knownJars.get(k);

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -623,6 +623,7 @@ public class Launcher {
      * Listens on an ephemeral port, record that port number in a port file,
      * then accepts one TCP connection.
      */
+    @Deprecated
     @SuppressFBWarnings(value = {"UNENCRYPTED_SERVER_SOCKET", "DM_DEFAULT_ENCODING"}, justification = "This is an old, insecure mechanism that should be removed. port number file should be in platform default encoding.")
     private void runAsTcpServer() throws IOException, InterruptedException {
         // if no one connects for too long, assume something went wrong

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -146,6 +146,7 @@ public class Launcher {
 
     @Option(name="-cp",aliases="-classpath",metaVar="PATH",
             usage="add the given classpath elements to the system classloader.")
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Parameter supplied by user / administrator.")
     public void addClasspath(String pathList) throws Exception {
         Method $addURL = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
         $addURL.setAccessible(true);
@@ -401,6 +402,7 @@ public class Launcher {
     }
 
     @CheckForNull
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Parameter supplied by user / administrator.")
     private SSLSocketFactory getSSLSocketFactory()
             throws PrivilegedActionException, KeyStoreException, NoSuchProviderException, CertificateException,
             NoSuchAlgorithmException, IOException, KeyManagementException {
@@ -489,6 +491,7 @@ public class Launcher {
     /**
      * Parses the connection arguments from JNLP file given in the URL.
      */
+    @SuppressFBWarnings(value = {"CIPHER_INTEGRITY", "STATIC_IV"}, justification = "Integrity not needed here. IV used for decryption only, loaded from encryptor.")
     public List<String> parseJnlpArguments() throws ParserConfigurationException, SAXException, IOException, InterruptedException {
         if (secret != null) {
             slaveJnlpURL = new URL(slaveJnlpURL + "?encrypt=true");
@@ -610,6 +613,7 @@ public class Launcher {
         return r;
     }
 
+    @SuppressFBWarnings(value = "XXE_DOCUMENT", justification = "This is the (so-called) JNLP file from the server, which has to be trusted from the perspective of this agent.")
     private static Document loadDom(URL agentJnlpURL, InputStream is) throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
         return db.parse(is, agentJnlpURL.toExternalForm());
@@ -619,7 +623,7 @@ public class Launcher {
      * Listens on an ephemeral port, record that port number in a port file,
      * then accepts one TCP connection.
      */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("DM_DEFAULT_ENCODING")    // port number file should be in platform default encoding
+    @SuppressFBWarnings(value = {"UNENCRYPTED_SERVER_SOCKET", "DM_DEFAULT_ENCODING"}, justification = "This is an old, insecure mechanism that should be removed. port number file should be in platform default encoding.")
     private void runAsTcpServer() throws IOException, InterruptedException {
         // if no one connects for too long, assume something went wrong
         // and avoid hanging forever
@@ -665,6 +669,7 @@ public class Launcher {
     /**
      * Connects to the given TCP port and then start running
      */
+    @SuppressFBWarnings(value = "UNENCRYPTED_SOCKET", justification = "This implements an old, insecure connection mechanism.")
     private void runAsTcpClient() throws IOException, InterruptedException {
         // if no one connects for too long, assume something went wrong
         // and avoid hanging forever
@@ -783,6 +788,7 @@ public class Launcher {
                     System.exit(-1);
                 }
                 @Override
+                @SuppressFBWarnings(value = "INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE", justification = "Prints the agent-side message to the agent log before exiting.")
                 protected void onDead(Throwable cause) {
                     System.err.println("Ping failed. Terminating");
                     cause.printStackTrace();

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -53,6 +53,7 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.CmdLineException;
 
 import javax.crypto.spec.IvParameterSpec;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -613,9 +614,10 @@ public class Launcher {
         return r;
     }
 
-    @SuppressFBWarnings(value = "XXE_DOCUMENT", justification = "This is the (so-called) JNLP file from the server, which has to be trusted from the perspective of this agent.")
     private static Document loadDom(URL agentJnlpURL, InputStream is) throws ParserConfigurationException, SAXException, IOException {
-        DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        DocumentBuilder db = dbf.newDocumentBuilder();
         return db.parse(is, agentJnlpURL.toExternalForm());
     }
 
@@ -671,6 +673,7 @@ public class Launcher {
      * Connects to the given TCP port and then start running
      */
     @SuppressFBWarnings(value = "UNENCRYPTED_SOCKET", justification = "This implements an old, insecure connection mechanism.")
+    @Deprecated
     private void runAsTcpClient() throws IOException, InterruptedException {
         // if no one connects for too long, assume something went wrong
         // and avoid hanging forever

--- a/src/main/java/hudson/remoting/Pipe.java
+++ b/src/main/java/hudson/remoting/Pipe.java
@@ -23,6 +23,7 @@
  */
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 
 import java.io.IOException;
@@ -97,6 +98,7 @@ import java.util.logging.Logger;
  *
  * @author Kohsuke Kawaguchi
  */
+@SuppressFBWarnings(value = "DESERIALIZATION_GADGET", justification = "Serializable only over remoting.")
 public final class Pipe implements SerializableOnlyOverRemoting, ErrorPropagatingOutputStream {
     private InputStream in;
     private OutputStream out;

--- a/src/main/java/hudson/remoting/Pipe.java
+++ b/src/main/java/hudson/remoting/Pipe.java
@@ -98,7 +98,6 @@ import java.util.logging.Logger;
  *
  * @author Kohsuke Kawaguchi
  */
-@SuppressFBWarnings(value = "DESERIALIZATION_GADGET", justification = "Serializable only over remoting.")
 public final class Pipe implements SerializableOnlyOverRemoting, ErrorPropagatingOutputStream {
     private InputStream in;
     private OutputStream out;
@@ -175,6 +174,7 @@ public final class Pipe implements SerializableOnlyOverRemoting, ErrorPropagatin
         }
     }
 
+    @SuppressFBWarnings(value = "DESERIALIZATION_GADGET", justification = "Serializable only over remoting. Class filtering is done through JEP-200.")
     private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
         final Channel channel = getChannelForSerialization();
 

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -794,6 +794,7 @@ final class RemoteClassLoader extends URLClassLoader {
             this.channel = channel;
         }
 
+        @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "This is only used for managing the jar cache as files.")
         public byte[] fetchJar(URL url) throws IOException {
             return readFully(url.openStream());
         }
@@ -885,6 +886,7 @@ final class RemoteClassLoader extends URLClassLoader {
             }
         }
 
+        @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "This is only used for managing the jar cache as files.")
         public Map<String,ClassFile2> fetch3(String className) throws ClassNotFoundException {
             ClassFile2 cf = fetch4(className,null);
             Map<String,ClassFile2> all = new HashMap<String,ClassFile2>();

--- a/src/main/java/hudson/remoting/RemoteInputStream.java
+++ b/src/main/java/hudson/remoting/RemoteInputStream.java
@@ -23,6 +23,7 @@
  */
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 
 import java.io.BufferedInputStream;
@@ -48,6 +49,7 @@ import static hudson.remoting.RemoteInputStream.Flag.*;
  *
  * @author Kohsuke Kawaguchi
  */
+@SuppressFBWarnings(value = "DESERIALIZATION_GADGET", justification = "Serializable only over remoting.")
 public class RemoteInputStream extends InputStream implements SerializableOnlyOverRemoting {
     private static final Logger LOGGER = Logger.getLogger(RemoteInputStream.class.getName());
     private transient InputStream core;

--- a/src/main/java/hudson/remoting/RemoteInputStream.java
+++ b/src/main/java/hudson/remoting/RemoteInputStream.java
@@ -49,7 +49,6 @@ import static hudson.remoting.RemoteInputStream.Flag.*;
  *
  * @author Kohsuke Kawaguchi
  */
-@SuppressFBWarnings(value = "DESERIALIZATION_GADGET", justification = "Serializable only over remoting.")
 public class RemoteInputStream extends InputStream implements SerializableOnlyOverRemoting {
     private static final Logger LOGGER = Logger.getLogger(RemoteInputStream.class.getName());
     private transient InputStream core;
@@ -177,6 +176,7 @@ public class RemoteInputStream extends InputStream implements SerializableOnlyOv
         oos.writeInt(id);
     }
 
+    @SuppressFBWarnings(value = "DESERIALIZATION_GADGET", justification = "Serializable only over remoting. Class filtering is done through JEP-200.")
     private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
         final Channel channel = getChannelForSerialization();
         if (channel.remoteCapability.supportsGreedyRemoteInputStream()) {

--- a/src/main/java/hudson/remoting/RemoteInvocationHandler.java
+++ b/src/main/java/hudson/remoting/RemoteInvocationHandler.java
@@ -62,6 +62,7 @@ import org.jenkinsci.remoting.RoleChecker;
  */
 //TODO: Likely should be serializable over Remoting logic, but this class has protection logic
 // Use-cases need to be investigated
+@SuppressFBWarnings(value = "DESERIALIZATION_GADGET", justification = "This class has protection logic.")
 final class RemoteInvocationHandler implements InvocationHandler, Serializable {
     /**
      * Our logger.

--- a/src/main/java/hudson/remoting/ResourceImageDirect.java
+++ b/src/main/java/hudson/remoting/ResourceImageDirect.java
@@ -1,5 +1,7 @@
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.logging.Level;
@@ -15,6 +17,7 @@ import static hudson.remoting.Util.*;
  *
  * @author Kohsuke Kawaguchi
  */
+@SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Used by the agent as part of jar cache management.")
 class ResourceImageDirect extends ResourceImageRef {
     /**
      * The actual resource.

--- a/src/main/java/hudson/remoting/ResourceImageInJar.java
+++ b/src/main/java/hudson/remoting/ResourceImageInJar.java
@@ -1,5 +1,7 @@
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -42,6 +44,7 @@ class ResourceImageInJar extends ResourceImageRef {
     Future<byte[]> resolve(Channel channel, final String resourcePath) throws IOException, InterruptedException {
         return new FutureAdapter<byte[],URL>(_resolveJarURL(channel)) {
             @Override
+            @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "This is only used for managing the jar cache as files.")
             protected byte[] adapt(URL jar) throws ExecutionException {
                 try {
                     return Util.readFully(toResourceURL(jar,resourcePath).openStream());

--- a/src/main/java/hudson/remoting/URLDeserializationHelper.java
+++ b/src/main/java/hudson/remoting/URLDeserializationHelper.java
@@ -69,12 +69,14 @@ public class URLDeserializationHelper {
     
     private static class SafeURLStreamHandler extends URLStreamHandler {
         @Override
+        @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Used for safely handling URLs, not for opening a connection.")
         protected URLConnection openConnection(URL u, Proxy p) throws IOException
         {
             return new URL(u.toString()).openConnection(p);
         }
 
         @Override
+        @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Used for safely handling URLs, not for opening a connection.")
         protected URLConnection openConnection(URL u) throws IOException {
             return new URL(u.toString()).openConnection();
         }

--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -277,6 +277,7 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserRequest.R
         }
     }
 
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Used for sending user requests between authorized agent and server.")
     /*package*/ static Object deserialize(final Channel channel, byte[] data, ClassLoader defaultClassLoader) throws IOException, ClassNotFoundException {
         ByteArrayInputStream in = new ByteArrayInputStream(data);
 

--- a/src/main/java/hudson/remoting/Util.java
+++ b/src/main/java/hudson/remoting/Util.java
@@ -1,5 +1,6 @@
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkinsci.remoting.util.PathUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -60,6 +61,7 @@ public class Util {
     }
 
     @Nonnull
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "This path exists within a temp directory so the potential traversal is limited.")
     static File makeResource(String name, byte[] image) throws IOException {
         Path tmpDir = Files.createTempDirectory("resource-");
         File resource = new File(tmpDir.toFile(), name);
@@ -103,6 +105,7 @@ public class Util {
      * If http_proxy environment variable exists,  the connection uses the proxy.
      * Credentials can be passed e.g. to support running Jenkins behind a (reverse) proxy requiring authorization
      */
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Used for retrieving the connection info from the server. We should cleanup the other, unused references.")
     static URLConnection openURLConnection(URL url, String credentials, String proxyCredentials, SSLSocketFactory sslSocketFactory) throws IOException {
         String httpProxy = null;
         // If http.proxyHost property exists, openConnection() uses it.

--- a/src/main/java/hudson/remoting/Which.java
+++ b/src/main/java/hudson/remoting/Which.java
@@ -23,6 +23,8 @@
  */
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -45,6 +47,7 @@ import java.util.logging.Level;
  *
  * @author Kohsuke Kawaguchi
  */
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Managed by the jar cache mechanism, using server data.")
 public class Which {
     /**
      * Returns the URL of the class file where the given class has been loaded from.
@@ -109,6 +112,7 @@ public class Which {
      *      JAR File, which contains the URL
      */
     @Nonnull
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Used by the agent as part of jar cache management.")
     /*package*/ static File jarFile(URL res, String qualifiedName) throws IOException {
         String resURL = res.toExternalForm();
         String originalURL = resURL;

--- a/src/main/java/hudson/remoting/forward/ForwarderFactory.java
+++ b/src/main/java/hudson/remoting/forward/ForwarderFactory.java
@@ -23,6 +23,7 @@
  */
 package hudson.remoting.forward;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.remoting.Callable;
 import hudson.remoting.RemoteOutputStream;
 import hudson.remoting.SocketChannelStream;
@@ -68,6 +69,7 @@ public class ForwarderFactory {
             this.remotePort = remotePort;
         }
 
+        @SuppressFBWarnings(value = "UNENCRYPTED_SOCKET", justification = "Unused mechanism.")
         public OutputStream connect(OutputStream out) throws IOException {
             Socket s = new Socket(remoteHost, remotePort);
             try (InputStream in = SocketChannelStream.in(s)) {

--- a/src/main/java/hudson/remoting/forward/ForwarderFactory.java
+++ b/src/main/java/hudson/remoting/forward/ForwarderFactory.java
@@ -45,6 +45,7 @@ import java.util.logging.Logger;
  *
  * @author Kohsuke Kawaguchi
  */
+@Deprecated
 public class ForwarderFactory {
 
     private static final Logger LOGGER = Logger.getLogger(ForwarderFactory.class.getName());

--- a/src/main/java/hudson/remoting/forward/PortForwarder.java
+++ b/src/main/java/hudson/remoting/forward/PortForwarder.java
@@ -23,6 +23,7 @@
  */
 package hudson.remoting.forward;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.remoting.Callable;
 import hudson.remoting.Channel;
 import hudson.remoting.RemoteOutputStream;
@@ -52,6 +53,7 @@ public class PortForwarder extends Thread implements Closeable, ListeningPort {
     private final Forwarder forwarder;
     private final ServerSocket socket;
 
+    @SuppressFBWarnings(value = "UNENCRYPTED_SERVER_SOCKET", justification = "Unused")
     public PortForwarder(int localPort, Forwarder forwarder) throws IOException {
         super(String.format("Port forwarder %d",localPort));
         this.forwarder = forwarder;

--- a/src/main/java/hudson/remoting/forward/PortForwarder.java
+++ b/src/main/java/hudson/remoting/forward/PortForwarder.java
@@ -49,6 +49,7 @@ import static java.util.logging.Level.*;
  * @author Kohsuke Kawaguchi
  * @since 1.315
  */
+@Deprecated
 public class PortForwarder extends Thread implements Closeable, ListeningPort {
     private final Forwarder forwarder;
     private final ServerSocket socket;

--- a/src/main/java/hudson/remoting/jnlp/GuiListener.java
+++ b/src/main/java/hudson/remoting/jnlp/GuiListener.java
@@ -64,7 +64,7 @@ public final class GuiListener implements EngineListener {
     public void error(final Throwable t) {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
-            @SuppressFBWarnings(value = "DM_EXIT", justification = "This is an error handler for GUI, exit is valid")
+            @SuppressFBWarnings(value = {"DM_EXIT", "INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE"}, justification = "This is an error handler for GUI, exit is valid. Used to show errors to administrator when run with GUI.")
             public void run() {
                 LOGGER.log(SEVERE, t.getMessage(), t);
                 StringWriter sw = new StringWriter();

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -284,6 +284,7 @@ public class Main {
         }
     }
 
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Parameter supplied by user / administrator.")
     public Engine createEngine() {
         String agentName = args.get(1);
         LOGGER.log(INFO, "Setting up agent: {0}", agentName);

--- a/src/main/java/org/jenkinsci/remoting/engine/ChannelCiphers.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/ChannelCiphers.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.remoting.engine;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -91,6 +92,7 @@ class ChannelCiphers {
      *
      * @throws IOException If there is a problem constructing the ciphers.
      */
+    @SuppressFBWarnings(value = {"CIPHER_INTEGRITY", "STATIC_IV"}, justification = "Deprecated protocol. We should just remove it at this point.")
     public static ChannelCiphers create(byte[] aesKey, byte[] specKey) throws IOException {
         try {
             SecretKey secretKey = new SecretKeySpec(aesKey, "AES");

--- a/src/main/java/org/jenkinsci/remoting/engine/HandshakeCiphers.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/HandshakeCiphers.java
@@ -33,6 +33,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.spec.KeySpec;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -105,6 +107,7 @@ class HandshakeCiphers {
      * @param salt The agent for which the handshake is taking place.
      * @param secret The agent secret.
      */
+    @SuppressFBWarnings(value = {"CIPHER_INTEGRITY", "STATIC_IV"}, justification = "Deprecated protocol. We should just remove it at this point.")
     public static HandshakeCiphers create(String salt, String secret) {
         try {
             byte[] specKey = Jnlp3Util.generate128BitKey(salt + secret);

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.remoting.engine;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.remoting.Launcher;
 import hudson.remoting.NoProxyEvaluator;
 
@@ -342,6 +343,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
         return null;
     }
 
+    @SuppressFBWarnings(value = "UNENCRYPTED_SOCKET", justification = "This just verifies connection to the port. No data is transmitted.")
     private boolean isPortVisible(String hostname, int port, int timeout) {
         boolean exitStatus = false;
         Socket s = null;
@@ -500,6 +502,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
      * Credentials can be passed e.g. to support running Jenkins behind a (reverse) proxy requiring authorization
      * FIXME: similar to hudson.remoting.Util.openURLConnection which is still used in hudson.remoting.Launcher
      */
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Used by the agent for retrieving connection info from the server.")
     static URLConnection openURLConnection(URL url, String credentials, String proxyCredentials,
                                            SSLSocketFactory sslSocketFactory, boolean disableHttpsCertValidation) throws IOException {
         String httpProxy = null;

--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -184,6 +184,7 @@ public class WorkDirManager {
      *                     In such case Remoting should not start up at all.
      */
     @CheckForNull
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Parameter supplied by user / administrator.")
     public Path initializeWorkDir(final @CheckForNull File workDir, final @Nonnull String internalDir, final boolean failIfMissing) throws IOException {
 
         if (!internalDir.matches(SUPPORTED_INTERNAL_DIR_NAME_MASK)) {
@@ -218,6 +219,7 @@ public class WorkDirManager {
         }
     }
 
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Value supplied by user / administrator.")
     private void createInternalDirIfRequired(File internalDir, DirType type)
             throws IOException {
         if (!disabledDirectories.contains(type)) {

--- a/src/main/java/org/jenkinsci/remoting/protocol/cert/BlindTrustX509ExtendedTrustManager.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/cert/BlindTrustX509ExtendedTrustManager.java
@@ -28,6 +28,8 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.X509ExtendedTrustManager;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
@@ -36,6 +38,7 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
  * @since 3.0
  */
 @IgnoreJRERequirement // TODO We override some methods in Java 7, so remove this ignore when baseline is Java 7
+@SuppressFBWarnings(value = "WEAK_TRUST_MANAGER", justification = "User set parameter to skip verifier.")
 public class BlindTrustX509ExtendedTrustManager extends X509ExtendedTrustManager {
     /**
      * The Javadoc for {@link X509ExtendedTrustManager} mandates that an {@link IllegalArgumentException} be thrown

--- a/src/main/java/org/jenkinsci/remoting/protocol/cert/PublicKeyMatchingX509ExtendedTrustManager.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/cert/PublicKeyMatchingX509ExtendedTrustManager.java
@@ -37,6 +37,8 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedTrustManager;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.jenkinsci.remoting.util.KeyUtils;
 
@@ -287,6 +289,7 @@ public class PublicKeyMatchingX509ExtendedTrustManager extends X509ExtendedTrust
      * {@inheritDoc}
      */
     @Override
+    @SuppressFBWarnings(value = "WEAK_TRUST_MANAGER", justification = "An intentionally overtrusting manager.")
     public X509Certificate[] getAcceptedIssuers() {
         return new X509Certificate[0];
     }

--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/AckFilterLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/AckFilterLayer.java
@@ -30,6 +30,8 @@ import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.GuardedBy;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkinsci.remoting.protocol.FilterLayer;
 import org.jenkinsci.remoting.util.ByteBufferQueue;
 import org.jenkinsci.remoting.util.ByteBufferUtils;
@@ -117,6 +119,7 @@ public class AckFilterLayer extends FilterLayer {
         return expectHex.toString();
     }
 
+    @SuppressFBWarnings(value = "FORMAT_STRING_MANIPULATION", justification = "As this converts a String to a Hex string there is little that can be manipulated.")
     private void abort(String type) throws ConnectionRefusalException {
         aborted = true;
         if (LOGGER.isLoggable(Level.WARNING)) {

--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/ConnectionRefusalException.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/ConnectionRefusalException.java
@@ -23,6 +23,8 @@
  */
 package org.jenkinsci.remoting.protocol.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.IOException;
 
 /**
@@ -78,6 +80,7 @@ public class ConnectionRefusalException extends IOException {
      *                                          insufficient arguments given the format string, or other
      *                                          illegal conditions.
      */
+    @SuppressFBWarnings(value = "FORMAT_STRING_MANIPULATION", justification = "This is only used with String conversion to hex string.")
     public ConnectionRefusalException(Throwable cause, String message, Object... args) {
         super(String.format(message, args), cause);
     }

--- a/src/main/java/org/jenkinsci/remoting/util/KeyUtils.java
+++ b/src/main/java/org/jenkinsci/remoting/util/KeyUtils.java
@@ -99,6 +99,7 @@ public final class KeyUtils {
      */
     @Nonnull
     @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Used for fingerprinting, not security.")
+    @Deprecated
     public static String fingerprint(@CheckForNull Key key) {
         if (key == null) {
             return "null";

--- a/src/main/java/org/jenkinsci/remoting/util/KeyUtils.java
+++ b/src/main/java/org/jenkinsci/remoting/util/KeyUtils.java
@@ -23,6 +23,8 @@
  */
 package org.jenkinsci.remoting.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.security.Key;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -96,6 +98,7 @@ public final class KeyUtils {
      * @return the MD5 fingerprint of the key.
      */
     @Nonnull
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Used for fingerprinting, not security.")
     public static String fingerprint(@CheckForNull Key key) {
         if (key == null) {
             return "null";

--- a/src/main/java/org/jenkinsci/remoting/util/https/NoCheckHostnameVerifier.java
+++ b/src/main/java/org/jenkinsci/remoting/util/https/NoCheckHostnameVerifier.java
@@ -26,6 +26,7 @@
 
 package org.jenkinsci.remoting.util.https;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -36,6 +37,7 @@ import javax.net.ssl.SSLSession;
  * Hostname verifier, which accepts any hostname.
  */
 @Restricted(NoExternalUse.class)
+@SuppressFBWarnings(value = "WEAK_HOSTNAME_VERIFIER", justification = "User set parameter to skip verifier.")
 public class NoCheckHostnameVerifier implements HostnameVerifier {
 
     @Override

--- a/src/main/java/org/jenkinsci/remoting/util/https/NoCheckTrustManager.java
+++ b/src/main/java/org/jenkinsci/remoting/util/https/NoCheckTrustManager.java
@@ -26,6 +26,7 @@
 
 package org.jenkinsci.remoting.util.https;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -37,6 +38,7 @@ import java.security.cert.X509Certificate;
  * {@link X509TrustManager} that performs no check at all.
  */
 @Restricted(NoExternalUse.class)
+@SuppressFBWarnings(value = "WEAK_TRUST_MANAGER", justification = "User set parameter to skip verifier.")
 public class NoCheckTrustManager implements X509TrustManager {
     public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
     }

--- a/src/spotbugs/excludeFilter.xml
+++ b/src/spotbugs/excludeFilter.xml
@@ -11,7 +11,12 @@
     <!--We do not want do break API by converting potentially usefull classes-->
     <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
   </Match>
-  
+
+  <Match>
+    <!--We don't care about this behavior.-->
+    <Bug pattern="CRLF_INJECTION_LOGS"/>
+  </Match>
+
   <Match>
     <!-- TODO: On hold due to the discussion in PR #118 -->
     <Bug pattern="DP_DO_INSIDE_DO_PRIVILEGED"/>


### PR DESCRIPTION
Add findsecbugs plugin to spotbugs. And suppress existing warnings. We should clean some of them up, but that's for different PRs at a later time.

Some of the issues findsecbugs just misidentifies. With some it doesn't understand enough context.

As always with these sort of of analysis tools, adding them to existing code correctly can be a bit of a challenge. It's easier to suppress things that aren't really problems than to clean all of them up. Most of the benefit from applying these tools comes from checking newly added code and preventing new issues from creeping in.