### PR TITLE
Add javax.websocket to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,11 @@ THE SOFTWARE.
       <version>1.12</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.websocket</groupId>
+      <artifactId>javax.websocket-api</artifactId>
+      <version>1.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,7 @@ THE SOFTWARE.
       <groupId>javax.websocket</groupId>
       <artifactId>javax.websocket-api</artifactId>
       <version>1.1</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
IntelliJ configured to use adoptopenjdk openj9 1.8 complains about:
https://github.com/jenkinsci/remoting/blob/ca2fbc659c5b2a899bbce6c22d3a0ff87c21de58/src/main/java/hudson/remoting/Engine.java#L70-L76

This appears to make it happy.