### PR TITLE
Cleanup

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -549,7 +549,8 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         this(new ChannelBuilder(name,exec)
             .withBaseLoader(base)
             .withRestricted(restricted)
-            .withJarCache(jarCache), transport);
+            .withJarCache(jarCache)
+            , transport);
     }
 
     /**

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1865,7 +1865,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * Notification that {@link Command#readFrom} has succeeded.
      * @param cmd the resulting command
      * @param blockSize the serialized size of the command
-     * @see CommandListener
+     * @see Listener
      */
     void notifyRead(Command cmd, long blockSize) {
         for (Listener listener : listeners) {
@@ -1881,7 +1881,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * Notification that {@link Command#writeTo} has succeeded.
      * @param cmd the command passed in
      * @param blockSize the serialized size of the command
-     * @see CommandListener
+     * @see Listener
      */
     void notifyWrite(Command cmd, long blockSize) {
         for (Listener listener : listeners) {
@@ -1898,7 +1898,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * @param req the original request
      * @param rsp the resulting response
      * @param totalTime the total time in nanoseconds taken to service the request
-     * @see CommandListener
+     * @see Listener
      */
     void notifyResponse(Request<?, ?> req, Response<?, ?> rsp, long totalTime) {
         for (Listener listener : listeners) {
@@ -1913,7 +1913,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * Notification that a JAR file will be delivered to the remote side.
      * @param jar the JAR file from which code is being loaded remotely
-     * @see CommandListener
+     * @see Listener
      */
     void notifyJar(File jar) {
         for (Listener listener : listeners) {

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1618,7 +1618,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *      The remote port that the connection will be forwarded to.
      * @return
      *      Created {@link PortForwarder}
+     * @deprecated as of 3.39
      */
+    @Deprecated
     public ListeningPort createLocalToRemotePortForwarding(int recvPort, String forwardHost, int forwardPort) throws IOException, InterruptedException {
         PortForwarder portForwarder = new PortForwarder(recvPort,
                 ForwarderFactory.create(this, forwardHost, forwardPort));
@@ -1641,7 +1643,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *      The remote port that the connection will be forwarded to.
      * @return
      *      Created {@link PortForwarder}.
+     * @deprecated as of 3.39
      */
+    @Deprecated
     public ListeningPort createRemoteToLocalPortForwarding(int recvPort, String forwardHost, int forwardPort) throws IOException, InterruptedException {
         return PortForwarder.create(this,recvPort,
                 ForwarderFactory.create(forwardHost, forwardPort));

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -494,7 +494,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
                 .withBaseLoader(base)
                 .withCapability(capability)
                 .withHeaderStream(header)
-                .withRestricted(restricted), is, os);
+                .withArbitraryCallableAllowed(!restricted)
+                .withRemoteClassLoadingAllowed(!restricted)
+                , is, os);
     }
 
     /**
@@ -511,7 +513,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     public Channel(String name, ExecutorService exec, CommandTransport transport, boolean restricted, ClassLoader base) throws IOException {
         this(new ChannelBuilder(name,exec)
                 .withBaseLoader(base)
-                .withRestricted(restricted), transport);
+                .withArbitraryCallableAllowed(!restricted)
+                .withRemoteClassLoadingAllowed(!restricted)
+                , transport);
 
     }
 

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -403,6 +403,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * @deprecated as of 2.24
      *      Use {@link ChannelBuilder}
+     *      ChannelBuilder(name, exec)
+     *                  .withMode(Channel.Mode.BINARY)
+     *                  .build(is, os)
      */
     @Deprecated
     public Channel(String name, ExecutorService exec, InputStream is, OutputStream os) throws IOException {
@@ -412,6 +415,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * @deprecated as of 2.24
      *      Use {@link ChannelBuilder}
+     *      ChannelBuilder(name, exec)
+     *                  .withMode(mode)
+     *                  .build(is, os)
      */
     @Deprecated
     public Channel(String name, ExecutorService exec, Mode mode, InputStream is, OutputStream os) throws IOException {
@@ -421,6 +427,10 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * @deprecated as of 2.24
      *      Use {@link ChannelBuilder}
+     *      ChannelBuilder(name, exec)
+     *                  .withMode(Channel.Mode.BINARY)
+     *                  .withHeaderStream(header)
+     *                  .build(is, os)
      */
     @Deprecated
     public Channel(String name, ExecutorService exec, InputStream is, OutputStream os, OutputStream header) throws IOException {
@@ -430,6 +440,12 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * @deprecated as of 2.24
      *      Use {@link ChannelBuilder}
+     *      ChannelBuilder(name, exec)
+     *                  .withMode(mode)
+     *                  .withHeaderStream(header)
+     *                  .withArbitraryCallableAllowed(true)
+     *                  .withRemoteClassLoadingAllowed(true)
+     *                  .build(is, os)
      */
     @Deprecated
     public Channel(String name, ExecutorService exec, Mode mode, InputStream is, OutputStream os, OutputStream header) throws IOException {
@@ -439,6 +455,13 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * @deprecated as of 2.24
      *      Use {@link ChannelBuilder}
+     *      ChannelBuilder(name, exec)
+     *                  .withMode(mode)
+     *                  .withHeaderStream(header)
+     *                  .withArbitraryCallableAllowed(!restricted)
+     *                  .withRemoteClassLoadingAllowed(!restricted)
+     *                  .withBaseLoader(base)
+     *                  .build(is, os)
      */
     @Deprecated
     public Channel(String name, ExecutorService exec, Mode mode, InputStream is, OutputStream os, OutputStream header, boolean restricted) throws IOException {
@@ -452,6 +475,13 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *      See {@link #Channel(String, ExecutorService, Mode, InputStream, OutputStream, OutputStream, boolean, ClassLoader)}
      * @deprecated as of 2.24
      *      Use {@link ChannelBuilder}
+     *      ChannelBuilder(name, exec)
+     *                  .withMode(mode)
+     *                  .withHeaderStream(header)
+     *                  .withArbitraryCallableAllowed(!restricted)
+     *                  .withRemoteClassLoadingAllowed(!restricted)
+     *                  .withBaseLoader(base)
+     *                  .build(is, os)
      */
     @Deprecated
     public Channel(String name, ExecutorService exec, Mode mode, InputStream is, OutputStream os, OutputStream header, boolean restricted, ClassLoader base) throws IOException {
@@ -470,6 +500,11 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * @deprecated as of 2.24
      *      Use {@link ChannelBuilder}
+     *      ChannelBuilder(name, exec)
+     *                  .withArbitraryCallableAllowed(!restricted)
+     *                  .withRemoteClassLoadingAllowed(!restricted)
+     *                  .withBaseLoader(base)
+     *                  .build(transport)
      * @since 2.13
      */
     @Deprecated
@@ -501,6 +536,13 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *
      * @since 2.24
      * @deprecated as of 2.38
+     *      Use {@link ChannelBuilder}
+     *      ChannelBuilder(name, exec)
+     *                  .withArbitraryCallableAllowed(!restricted)
+     *                  .withRemoteClassLoadingAllowed(!restricted)
+     *                  .withBaseLoader(base)
+     *                  .withJarCache(jarCache)
+     *                  .build(transport)
      */
     @Deprecated
     public Channel(String name, ExecutorService exec, CommandTransport transport, boolean restricted, ClassLoader base, JarCache jarCache) throws IOException {

--- a/src/main/java/hudson/remoting/SynchronousCommandTransport.java
+++ b/src/main/java/hudson/remoting/SynchronousCommandTransport.java
@@ -57,14 +57,14 @@ public abstract class SynchronousCommandTransport extends CommandTransport {
         public void run() {
             final String name =channel.getName();
             try {
-                while(!channel.isInClosed()) {
+                while (!channel.isInClosed()) {
                     Command cmd = null;
                     try {
                         cmd = read();
                     } catch (SocketTimeoutException ex) {
                         if (RDR_FAIL_ON_SOCKET_TIMEOUT) {
                             LOGGER.log(Level.SEVERE, "Socket timeout in the Synchronous channel reader."
-                                    + " The channel will be interrupted, because " + RDR_SOCKET_TIMEOUT_PROPERTY_NAME 
+                                    + " The channel will be interrupted, because " + RDR_SOCKET_TIMEOUT_PROPERTY_NAME
                                     + " is set", ex);
                             throw ex;
                         }
@@ -76,7 +76,7 @@ public abstract class SynchronousCommandTransport extends CommandTransport {
                     } catch (EOFException e) {
                         throw new IOException("Unexpected termination of the channel", e);
                     } catch (ClassNotFoundException e) {
-                        LOGGER.log(Level.SEVERE, "Unable to read a command (channel " + name + ")",e);
+                        LOGGER.log(Level.SEVERE, "Unable to read a command (channel " + name + ")", e);
                         continue;
                     } finally {
                         commandsReceived++;


### PR DESCRIPTION
While working on https://github.com/jenkinsci/jenkins/pull/4407#discussion_r369667658, I made a mistake in not recognizing that the default `withMode` is [different](https://github.com/jenkinsci/remoting/compare/master...jsoref:cleanup?expand=1#diff-8a0e2be489e004b87cc21e1fc8d17d3dR407) between `Channel(...)` and `ChannelBuilder(...)`.

I'm not absolutely certain about my comments, but if they're correct, it would help the next person like me perform a similar migration.