### PR TITLE
[JENKINS-60926] Fix "Install as a service" on Windows.

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -153,6 +153,9 @@ public class Engine extends Thread {
     @CheckForNull
     private URL hudsonUrl;
     private final String secretKey;
+    /* This needs to stay public and named "slaveName" until slave-installer-module is updated
+      to not refer to it directly by this name. See [JENKINS-60926].
+     */
     public final String slaveName;
     private boolean webSocket;
     private String credentials;

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -153,7 +153,7 @@ public class Engine extends Thread {
     @CheckForNull
     private URL hudsonUrl;
     private final String secretKey;
-    private final String agentName;
+    public final String slaveName;
     private boolean webSocket;
     private String credentials;
     private String proxyCredentials = System.getProperty("proxyCredentials");
@@ -242,7 +242,7 @@ public class Engine extends Thread {
         this.events.add(listener);
         this.candidateUrls = hudsonUrls;
         this.secretKey = secretKey;
-        this.agentName = agentName;
+        this.slaveName = agentName;
         this.instanceIdentity = instanceIdentity;
         this.protocols = protocols;
         if(candidateUrls.isEmpty() && instanceIdentity == null) {
@@ -534,7 +534,7 @@ public class Engine extends Thread {
                     Capability remoteCapability = new Capability();
                     @Override
                     public void beforeRequest(Map<String, List<String>> headers) {
-                        headers.put(JnlpConnectionState.CLIENT_NAME_KEY, Collections.singletonList(agentName));
+                        headers.put(JnlpConnectionState.CLIENT_NAME_KEY, Collections.singletonList(slaveName));
                         headers.put(JnlpConnectionState.SECRET_KEY, Collections.singletonList(secretKey));
                         headers.put(Capability.KEY, Collections.singletonList(localCap));
                         // TODO use JnlpConnectionState.COOKIE_KEY somehow (see EngineJnlpConnectionStateListener.afterChannel)
@@ -568,7 +568,7 @@ public class Engine extends Thread {
                         events.status("WebSocket connection open");
                         session.addMessageHandler(byte[].class, this::onMessage);
                         try {
-                            ch.set(new ChannelBuilder(agentName, executor).
+                            ch.set(new ChannelBuilder(slaveName, executor).
                                 withJarCacheOrDefault(jarCache). // unless EngineJnlpConnectionStateListener can be used for this purpose
                                 build(new Transport(session)));
                         } catch (IOException x) {
@@ -666,7 +666,7 @@ public class Engine extends Thread {
                 .withPreferNonBlockingIO(false) // we only have one connection, prefer blocking I/O
                 .handlers();
         final Map<String,String> headers = new HashMap<>();
-        headers.put(JnlpConnectionState.CLIENT_NAME_KEY, agentName);
+        headers.put(JnlpConnectionState.CLIENT_NAME_KEY, slaveName);
         headers.put(JnlpConnectionState.SECRET_KEY, secretKey);
         List<String> jenkinsUrls = new ArrayList<>();
         for (URL url: candidateUrls) {


### PR DESCRIPTION
See [JENKINS-60926](https://issues.jenkins-ci.org/browse/JENKINS-60926).

A renaming of Engine.slaveName to Engine.agentName and making it
private broke a complicated interaction with the server and the slave-installer-module.
Rename just this one part back to get it working again.

The previously unknown usage is in [slave-installer-module](https://github.com/jenkinsci/slave-installer-module/blob/3f1fce8ddb1de41b280546755700c727311448b9/src/main/java/org/jenkinsci/modules/slave_installer/impl/InstallerGui.java#L142).