### PR TITLE
[JENKINS-60926] Expose the agent name via a getter

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -153,10 +153,7 @@ public class Engine extends Thread {
     @CheckForNull
     private URL hudsonUrl;
     private final String secretKey;
-    /* This needs to stay public and named "slaveName" until slave-installer-module is updated
-      to not refer to it directly by this name. See [JENKINS-60926].
-     */
-    public final String slaveName;
+    private final String agentName;
     private boolean webSocket;
     private String credentials;
     private String proxyCredentials = System.getProperty("proxyCredentials");
@@ -245,7 +242,7 @@ public class Engine extends Thread {
         this.events.add(listener);
         this.candidateUrls = hudsonUrls;
         this.secretKey = secretKey;
-        this.slaveName = agentName;
+        this.agentName = agentName;
         this.instanceIdentity = instanceIdentity;
         this.protocols = protocols;
         if(candidateUrls.isEmpty() && instanceIdentity == null) {
@@ -537,7 +534,7 @@ public class Engine extends Thread {
                     Capability remoteCapability = new Capability();
                     @Override
                     public void beforeRequest(Map<String, List<String>> headers) {
-                        headers.put(JnlpConnectionState.CLIENT_NAME_KEY, Collections.singletonList(slaveName));
+                        headers.put(JnlpConnectionState.CLIENT_NAME_KEY, Collections.singletonList(agentName));
                         headers.put(JnlpConnectionState.SECRET_KEY, Collections.singletonList(secretKey));
                         headers.put(Capability.KEY, Collections.singletonList(localCap));
                         // TODO use JnlpConnectionState.COOKIE_KEY somehow (see EngineJnlpConnectionStateListener.afterChannel)
@@ -571,7 +568,7 @@ public class Engine extends Thread {
                         events.status("WebSocket connection open");
                         session.addMessageHandler(byte[].class, this::onMessage);
                         try {
-                            ch.set(new ChannelBuilder(slaveName, executor).
+                            ch.set(new ChannelBuilder(agentName, executor).
                                 withJarCacheOrDefault(jarCache). // unless EngineJnlpConnectionStateListener can be used for this purpose
                                 build(new Transport(session)));
                         } catch (IOException x) {
@@ -669,7 +666,7 @@ public class Engine extends Thread {
                 .withPreferNonBlockingIO(false) // we only have one connection, prefer blocking I/O
                 .handlers();
         final Map<String,String> headers = new HashMap<>();
-        headers.put(JnlpConnectionState.CLIENT_NAME_KEY, slaveName);
+        headers.put(JnlpConnectionState.CLIENT_NAME_KEY, agentName);
         headers.put(JnlpConnectionState.SECRET_KEY, secretKey);
         List<String> jenkinsUrls = new ArrayList<>();
         for (URL url: candidateUrls) {

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -998,6 +998,7 @@ public class Engine extends Thread {
      * Get the agent name associated with this Engine instance.
      *
      * @return the agent name.
+     * @since TODO
      */
     public String getAgentName() {
         // This is used by various external components that need to get the name from the engine.

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -994,6 +994,16 @@ public class Engine extends Thread {
      */
     static final int SOCKET_TIMEOUT = Integer.getInteger(Engine.class.getName()+".socketTimeout",30*60*1000);
 
+    /**
+     * Get the agent name associated with this Engine instance.
+     *
+     * @return the agent name.
+     */
+    public String getAgentName() {
+        // This is used by various external components that need to get the name from the engine.
+        return agentName;
+    }
+
     private class EngineJnlpConnectionStateListener extends JnlpConnectionStateListener {
 
         private final RSAPublicKey publicKey;

--- a/src/test/java/hudson/remoting/EngineTest.java
+++ b/src/test/java/hudson/remoting/EngineTest.java
@@ -27,6 +27,8 @@ import java.io.File;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import org.jenkinsci.remoting.engine.WorkDirManager;
 import org.jenkinsci.remoting.engine.WorkDirManagerRule;
@@ -113,7 +115,15 @@ public class EngineTest {
         File location = mgr.getLocation(WorkDirManager.DirType.JAR_CACHE_DIR);
         Assert.assertThat("WorkDir manager should not be aware about external JAR cache location", location, nullValue());
     }
-    
+
+    @Test
+    @Issue("JENKINS-60926")
+    public void getAgentName() {
+        EngineListener l = new TestEngineListener();
+        Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
+        assertThat(engine.getAgentName(), is(AGENT_NAME));
+    }
+
     private static class TestEngineListener implements EngineListener {
 
         @Override


### PR DESCRIPTION
Different approach to earlier change. Keep the renaming and add a getter for other modules to use.