### PR TITLE
[WIP][JENKINS-61103] - improve handling of RemotingSystemException(InterruptedException) in RemoteClassLoader

### DIFF
--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -356,6 +356,11 @@ final class RemoteClassLoader extends URLClassLoader {
     static Runnable TESTING_CLASS_REFERENCE_LOAD;
 
     /**
+     * Intercept {@link RemoteClassLoader#findResource(String)} to allow unittests to be written.
+     */
+    static Runnable TESTING_RESOURCE_LOAD;
+
+    /**
      * Loads class from the byte array.
      * @param name Name of the class
      * @param bytes Bytes
@@ -422,6 +427,8 @@ final class RemoteClassLoader extends URLClassLoader {
                 URL u = f.toURL();
                 if (u!=null)    return u;
             }
+
+            if (TESTING_RESOURCE_LOAD != null) TESTING_RESOURCE_LOAD.run();
 
             long startTime = System.nanoTime();
 

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -441,7 +441,9 @@ final class RemoteClassLoader extends URLClassLoader {
                 if (u!=null)    return u;
             }
 
-            if (TESTING_RESOURCE_LOAD != null) TESTING_RESOURCE_LOAD.run();
+            if (TESTING_RESOURCE_LOAD != null) {
+                TESTING_RESOURCE_LOAD.run();
+            }
 
             long startTime = System.nanoTime();
 

--- a/src/test/java/hudson/remoting/ClassRemotingTest.java
+++ b/src/test/java/hudson/remoting/ClassRemotingTest.java
@@ -132,7 +132,7 @@ public class ClassRemotingTest extends RmiTestBase {
         final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
         final Callable<Object, Exception> c = (Callable) child2.load(TestLinkage.class);
         assertEquals(child2, c.getClass().getClassLoader());
-        RemoteClassLoader.TESTING_CLASS_LOAD = new InterruptThirdInvocation();
+        RemoteClassLoader.TESTING_CLASS_LOAD = new InterruptNthInvocation(2);
         try {
             java.util.concurrent.Future<Object> f1 = scheduleCallableLoad(c);
 
@@ -156,7 +156,7 @@ public class ClassRemotingTest extends RmiTestBase {
         final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
         final Callable<Object, Exception> c = (Callable) child2.load(TestLinkage.class);
         assertEquals(child2, c.getClass().getClassLoader());
-        RemoteClassLoader.TESTING_CLASS_REFERENCE_LOAD = new InterruptThirdInvocation();
+        RemoteClassLoader.TESTING_CLASS_REFERENCE_LOAD = new InterruptNthInvocation(3);
 
         try {
             Future<Object> f1 = scheduleCallableLoad(c);
@@ -187,12 +187,15 @@ public class ClassRemotingTest extends RmiTestBase {
         });
     }
 
-    private static class InterruptThirdInvocation implements Runnable {
-        private int invocationCount = 0;
+    private static class InterruptNthInvocation implements Runnable {
+        private int countDown;
+        private InterruptNthInvocation(int n) {
+            countDown = n;
+        }
         @Override
         public void run() {
-            invocationCount++;
-            if (invocationCount == 3) {
+            countDown--;
+            if (countDown == 0) {
                 Thread.currentThread().interrupt();
             }
         }

--- a/src/test/java/hudson/remoting/TestCallable.java
+++ b/src/test/java/hudson/remoting/TestCallable.java
@@ -26,6 +26,7 @@ package hudson.remoting;
 import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -37,8 +38,8 @@ import java.io.InputStream;
  * @author Kohsuke Kawaguchi
  * @see DummyClassLoader
  */
-public class TestCallable extends Exception implements Callable {
-    public Object call() throws Throwable {
+public class TestCallable extends Exception implements Callable<Object, IOException> {
+    public Object call() throws IOException {
         Object[] r = new Object[4];
 
         // to verify that this class is indeed loaded by the remote classloader

--- a/src/test/java/hudson/remoting/TestStaticResourceReference.java
+++ b/src/test/java/hudson/remoting/TestStaticResourceReference.java
@@ -1,0 +1,14 @@
+package hudson.remoting;
+
+public class TestStaticResourceReference extends CallableBase {
+
+    private static final long serialVersionUID = 1L;
+
+    // this is really just to check that we can initialize a static property from searching a classpath resource
+    private static boolean FALSE = TestStaticResourceReference.class.getClassLoader().getResource("BLAH") != null;
+
+    public Object call() {
+        return "found the impossible: " + FALSE;
+    }
+
+}


### PR DESCRIPTION
See [JENKINS-61103](https://issues.jenkins-ci.org/browse/JENKINS-61103)

Adds a dynamic proxy over the `IClassLoader` proxy in `RemoteClassLoader`, which will handle `RemotingSystemException`s caused by an `InterruptedException`.  The overall goal is to avoid letting a remote interruption irremediably damage loading/initialization of some classes.

- first commit workarounds a compilation "error" in a test, wrongly reported by my IDE (totally unrelated to the rest of the PR).
- second commit "fixes" a `RemoteClassLoading` test case which was not actually failing when I was removing what it was (I think) supposed to test (the retry logic in `RemoteClassLoader#findClass`).
- third commit is the actual proposed change.
- fourth commit adds a `RemoteClassLoading` test case showing that class initialization can also be damaged by a failure to load a resource.

I went for a dynamic proxy to keep code short enough, but of course this could have been a full concrete implementation of `IClassLoader` as well. I honestly don't know if it matters (from a performance point of view maybe?), please let me know if it is not appropriate.

Regarding the specific logic in this proxy, to decide whether a `RemotingSystemException` deserves special handling, there is room for discussion. I've tried to keep it simple, but for instance it could be argued that `getResource*` methods don't deserve a retry unless called during some class initialization (can be implemented, we have the calling stack available in the caught exception, we can look for `<clinit>`).

Regarding the two example error stack traces reported in [JENKINS-61103](https://issues.jenkins-ci.org/browse/JENKINS-61103), note that I don't have a unit test to prove that this change would actually fix the one with the exception raised from the `proxy.fetch(name)` call at [RemoteClassLoader.java#L315](https://github.com/jenkinsci/remoting/blob/remoting-3.36.1/src/main/java/hudson/remoting/RemoteClassLoader.java#L315).  FYI, the only unit test I've found which covers this line is [PrefetchingTest#testInnerClass](https://github.com/jenkinsci/remoting/blob/remoting-3.36.1/src/test/java/hudson/remoting/PrefetchingTest.java#L190), and so far I've not been able to work out something similar with a forced interruption via `RemoteClassLoader.TESTING_CLASS_LOAD`.

Final note, I've not really tested the proposed changes on top of `master`, but rather on top of 3.36.1. And my tests have been pretty basic so far, it is not something I have yet deployed on any "real" Jenkins servers, so there might be side effects I've not yet discovered.