### PR TITLE
[JENKINS-61409] Websockets: Use AbstractByteBufferCommandTransport to transport messages

### DIFF
--- a/src/main/java/hudson/remoting/AbstractByteBufferCommandTransport.java
+++ b/src/main/java/hudson/remoting/AbstractByteBufferCommandTransport.java
@@ -306,4 +306,13 @@ public abstract class AbstractByteBufferCommandTransport extends CommandTranspor
         }
     }
 
+    /**
+     * Indicates that the endpoint has encountered a problem.
+     * This tells the transport that it shouldn't expect future invocation of {@link #receive(ByteBuffer)},
+     * and it'll abort the communication.
+     */
+    public void terminate(IOException e) {
+        receiver.terminate(e);
+    }
+
 }

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -603,6 +603,7 @@ public class Engine extends Thread {
                         }
                         @Override
                         protected void write(ByteBuffer header, ByteBuffer data) throws IOException {
+                            LOGGER.finest(() -> "sending message of length + " + ChunkHeader.length(ChunkHeader.peek(header)));
                             session.getBasicRemote().sendBinary(header, false);
                             session.getBasicRemote().sendBinary(data, true);
                         }

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -592,7 +592,7 @@ public class Engine extends Thread {
                     }
                     class Transport extends AbstractByteArrayCommandTransport {
                         // Default maximum size accepted by jetty for websocket messages
-                        public static final int BLOCK_SIZE = 65_536;
+                        private static final int BLOCK_SIZE = 65_536;
 
                         final Session session;
                         Transport(Session session) {


### PR DESCRIPTION
See [JENKINS-61409](https://issues.jenkins-ci.org/browse/JENKINS-61409).

Fixes support of websocket messages more than 64kb long.

See downstream https://github.com/jenkinsci/jenkins/pull/4596