### PR TITLE
Minor JNLP parsing improving, mostly in testing

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -543,14 +543,14 @@ public class Launcher {
                 if(contentType==null || !contentType.startsWith(expectedContentType)) {
                     // load DOM anyway, but if it fails to parse, that's probably because this is not an XML file to begin with.
                     try {
-                        dom = loadDom(agentJnlpURL, input);
+                        dom = loadDom(input);
                     } catch (SAXException e) {
                         throw new IOException(agentJnlpURL +" doesn't look like a JNLP file; content type was "+contentType);
                     } catch (IOException e) {
                         throw new IOException(agentJnlpURL +" doesn't look like a JNLP file; content type was "+contentType);
                     }
                 } else {
-                    dom = loadDom(agentJnlpURL, input);
+                    dom = loadDom(input);
                 }
 
                 // exec into the JNLP launcher, to fetch the connection parameter through JNLP.
@@ -607,11 +607,11 @@ public class Launcher {
         return r;
     }
 
-    private static Document loadDom(URL agentJnlpURL, InputStream is) throws ParserConfigurationException, SAXException, IOException {
+    static Document loadDom(InputStream is) throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         DocumentBuilder db = dbf.newDocumentBuilder();
-        return db.parse(is, agentJnlpURL.toExternalForm());
+        return db.parse(is);
     }
 
     /**

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -609,7 +609,7 @@ public class Launcher {
 
     static Document loadDom(InputStream is) throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder db = dbf.newDocumentBuilder();
         return db.parse(is);
     }

--- a/src/test/java/hudson/remoting/LauncherTest.java
+++ b/src/test/java/hudson/remoting/LauncherTest.java
@@ -1,0 +1,48 @@
+package hudson.remoting;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+
+public class LauncherTest {
+
+    @Test
+    public void loadDom_Standard() throws IOException, SAXException, ParserConfigurationException {
+        FileInputStream jnlpFile = new FileInputStream("src/test/resources/hudson/remoting/test.jnlp");
+        Document document = Launcher.loadDom(jnlpFile);
+        Element documentElement = document.getDocumentElement();
+        assertThat(documentElement.getNodeName(), is("jnlp"));
+        assertThat(documentElement.getChildNodes().getLength(), is(9));
+    }
+
+    @Test(expected = SAXParseException.class)
+    public void loadDom_Lol() throws IOException, SAXException, ParserConfigurationException {
+        FileInputStream jnlpFile = new FileInputStream("src/test/resources/hudson/remoting/lol.jnlp");
+        Document document = Launcher.loadDom(jnlpFile);
+        document.getDocumentElement();
+    }
+
+    @Test(expected = SAXParseException.class)
+    public void loadDom_XxeFile() throws IOException, SAXException, ParserConfigurationException {
+        FileInputStream jnlpFile = new FileInputStream("src/test/resources/hudson/remoting/xxe_file.jnlp");
+        Document document = Launcher.loadDom(jnlpFile);
+        document.getDocumentElement();
+    }
+
+    @Test(expected = SAXParseException.class)
+    public void loadDom_XxeHttp() throws IOException, SAXException, ParserConfigurationException {
+        FileInputStream jnlpFile = new FileInputStream("src/test/resources/hudson/remoting/xxe_http.jnlp");
+        Document document = Launcher.loadDom(jnlpFile);
+        document.getDocumentElement();
+    }
+
+}

--- a/src/test/resources/hudson/remoting/embedded_doctype.jnlp
+++ b/src/test/resources/hudson/remoting/embedded_doctype.jnlp
@@ -1,5 +1,8 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE note SYSTEM "file:src/test/resources/hudson/remoting/note.dtd">
+<!DOCTYPE note [
+        <!ENTITY nbsp "&#xA0;">
+        <!ENTITY writer "Writer: Donald Duck.">
+        <!ENTITY copyright "Copyright: W3Schools.">
+        ]>
 <jnlp codebase="http://jenkins:8080/computer/local/" spec="1.0+">
     <information>
         <title>Agent for local</title>

--- a/src/test/resources/hudson/remoting/lol.jnlp
+++ b/src/test/resources/hudson/remoting/lol.jnlp
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE lolz [
+ <!ENTITY lol "lol">
+ <!ELEMENT lolz (#PCDATA)>
+ <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+ <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+ <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+ <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+ <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+ <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+ <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+ <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+ <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+]>
+<lolz>&lol9;</lolz>

--- a/src/test/resources/hudson/remoting/lol.jnlp
+++ b/src/test/resources/hudson/remoting/lol.jnlp
@@ -13,3 +13,27 @@
  <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
 ]>
 <lolz>&lol9;</lolz>
+<jnlp codebase="http://jenkins:8080/computer/local/" spec="1.0+">
+<information>
+    <title>Agent for local</title>
+    <vendor>Jenkins project</vendor>
+    <homepage href="https://jenkins-ci.org/"></homepage>
+</information>
+<security>
+    <all-permissions></all-permissions>
+</security>
+<resources>
+    <j2se version="1.8+"></j2se>
+    <jar href="http://jenkins:8080/jnlpJars/remoting.jar"></jar>
+</resources>
+<application-desc main-class="hudson.remoting.jnlp.Main">
+    <argument>secret_key</argument>
+    <argument>local</argument>
+    <argument>-workDir</argument>
+    <argument>/jenkins/nodes/local</argument>
+    <argument>-internalDir</argument>
+    <argument>remoting</argument>
+    <argument>-url</argument>
+    <argument>http://jenkins:8080/</argument>
+</application-desc>
+</jnlp>

--- a/src/test/resources/hudson/remoting/note.dtd
+++ b/src/test/resources/hudson/remoting/note.dtd
@@ -1,0 +1,3 @@
+<!ELEMENT syllabus (#PCDATA)>
+<!ELEMENT author (#PCDATA)>
+<!ELEMENT booktitle (#PCDATA)>

--- a/src/test/resources/hudson/remoting/test.jnlp
+++ b/src/test/resources/hudson/remoting/test.jnlp
@@ -1,0 +1,24 @@
+<jnlp codebase="http://jenkins:8080/computer/local/" spec="1.0+">
+    <information>
+        <title>Agent for local</title>
+        <vendor>Jenkins project</vendor>
+        <homepage href="https://jenkins-ci.org/"></homepage>
+    </information>
+    <security>
+        <all-permissions></all-permissions>
+    </security>
+    <resources>
+        <j2se version="1.8+"></j2se>
+        <jar href="http://jenkins:8080/jnlpJars/remoting.jar"></jar>
+    </resources>
+    <application-desc main-class="hudson.remoting.jnlp.Main">
+        <argument>secret_key</argument>
+        <argument>local</argument>
+        <argument>-workDir</argument>
+        <argument>/jenkins/nodes/local</argument>
+        <argument>-internalDir</argument>
+        <argument>remoting</argument>
+        <argument>-url</argument>
+        <argument>http://jenkins:8080/</argument>
+    </application-desc>
+</jnlp>

--- a/src/test/resources/hudson/remoting/xxe_file.jnlp
+++ b/src/test/resources/hudson/remoting/xxe_file.jnlp
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE foo [
+   <!ENTITY xxe SYSTEM "file:CONTRIBUTING.md" > ]>
+<foo>&xxe;</foo>

--- a/src/test/resources/hudson/remoting/xxe_http.jnlp
+++ b/src/test/resources/hudson/remoting/xxe_http.jnlp
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="ISO-8859-1"?> 
+<!DOCTYPE foo [
+  <!ELEMENT foo ANY>
+  <!ENTITY xxe SYSTEM
+  "http://localhost">
+]>
+<foo>
+  &xxe;
+</foo>

--- a/src/test/resources/hudson/remoting/xxe_http.jnlp
+++ b/src/test/resources/hudson/remoting/xxe_http.jnlp
@@ -4,6 +4,27 @@
   <!ENTITY xxe SYSTEM
   "http://localhost">
 ]>
-<foo>
-  &xxe;
-</foo>
+<jnlp codebase="http://jenkins:8080/computer/local/" spec="1.0+">
+  <information>
+    <title>Agent for local</title>
+    <vendor>Jenkins project</vendor>
+    <homepage href="https://jenkins-ci.org/"></homepage>
+  </information>
+  <security>
+    <all-permissions></all-permissions>
+  </security>
+  <resources>
+    <j2se version="1.8+"></j2se>
+    <jar href="http://jenkins:8080/jnlpJars/remoting.jar"></jar>
+  </resources>
+  <application-desc main-class="hudson.remoting.jnlp.Main">
+    <argument>secret_key</argument>
+    <argument>local</argument>
+    <argument>-workDir</argument>
+    <argument>/jenkins/nodes/local</argument>
+    <argument>-internalDir</argument>
+    <argument>remoting</argument>
+    <argument>-url</argument>
+    <argument>http://jenkins:8080/</argument>
+  </application-desc>
+</jnlp>


### PR DESCRIPTION
This was improved during findsecbugs processing. Now that I've dug into it a little bit I'm adding some minor improvements. The findsecbugs documentation suggests two feature settings to resolve the issue. They both yield essentially the same result. This one is a little cleaner and more thorough.

Mostly, this change involves adding several tests to demonstrate the processing behavior. These aren't essential but they are good documentation.