### PR TITLE
[JENKINS-61103] Retry on class resource load failures and introduce timeouts

### DIFF
--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -306,6 +306,7 @@ final class RemoteClassLoader extends URLClassLoader {
                         } catch (InterruptedException e) {
                             // Not much to do if we can't sleep. Run through the tries more quickly.
                         }
+                        LOGGER.finer("Handling interrupt while loading remote class. Current retry count = " + tries + ", maximum = " + MAX_RETRIES);
                     }
                  }
                 throw new ClassNotFoundException("Could not load class " + name + " after " + MAX_RETRIES + " tries.");
@@ -405,6 +406,7 @@ final class RemoteClassLoader extends URLClassLoader {
                             } catch (InterruptedException e) {
                                 // Not much to do if we can't sleep. Run through the tries more quickly.
                             }
+                            LOGGER.finer("Handling interrupt while fetching class reference. Current retry count = " + tries + ", maximum = " + MAX_RETRIES);
                             continue;   // JENKINS-19453: retry
                         }
                         throw x;
@@ -551,6 +553,7 @@ final class RemoteClassLoader extends URLClassLoader {
                         } catch (InterruptedException e) {
                             // Not much to do if we can't sleep. Run through the tries more quickly.
                         }
+                        LOGGER.finer("Handling interrupt while finding resource. Current retry count = " + tries + ", maximum = " + MAX_RETRIES);
                         continue;
                     }
                     throw x;

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -271,9 +271,7 @@ final class RemoteClassLoader extends URLClassLoader {
                 // and just retry until it succeeds, but in the end we set the interrupt flag
                 // back on to let the interrupt in the next earliest occasion.
 
-                int tries = 0;
-                while (tries < MAX_RETRIES) {
-                    tries++;
+                for (int tries = 0; tries < MAX_RETRIES; tries++) {
                     try {
                         invokeClassLoadTestingHookIfNeeded();
 
@@ -342,9 +340,7 @@ final class RemoteClassLoader extends URLClassLoader {
                 // and just retry until it succeeds, but in the end we set the interrupt flag
                 // back on to let the interrupt in the next earliest occasion.
 
-                int tries = 0;
-                while (tries < MAX_RETRIES) {
-                    tries++;
+                 for (int tries = 0; tries < MAX_RETRIES; tries++) {
                     try {
                         invokeClassReferenceLoadTestingHookIfNeeded();
 
@@ -494,7 +490,6 @@ final class RemoteClassLoader extends URLClassLoader {
     }
 
     @CheckForNull
-    @SuppressFBWarnings(value = "DLS_DEAD_LOCAL_STORE", justification = "False positive -- spotbugs mistake.")
     public URL findResource(String name) {
         // first attempt to load from locally fetched jars
         URL url = super.findResource(name);
@@ -505,9 +500,7 @@ final class RemoteClassLoader extends URLClassLoader {
 
         boolean interrupted = false;
         try {
-            int tries = 0;
-            while (tries < MAX_RETRIES) {
-                tries++;
+            for (int tries = 0; tries < MAX_RETRIES; tries++) {
                 try {
                     if (resourceMap.containsKey(name)) {
                         URLish f = resourceMap.get(name);

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -542,9 +542,9 @@ final class RemoteClassLoader extends URLClassLoader {
                     URLish res = image.resolveURL(channel, name).get();
                     resourceMap.put(name, res);
                     return res.toURL();
-                } catch (IOException | InterruptedException | ExecutionException e) {
+                } catch (IOException | ExecutionException e) {
                     throw new Error("Unable to load resource " + name, e);
-                } catch (RemotingSystemException x) {
+                } catch (InterruptedException | RemotingSystemException x) {
                     if (shouldRetry(x)) {
                         // pretend as if this operation is not interruptible.
                         // but we need to remember to set the interrupt flag back on
@@ -558,7 +558,7 @@ final class RemoteClassLoader extends URLClassLoader {
                         LOGGER.finer("Handling interrupt while finding resource. Current retry count = " + tries + ", maximum = " + MAX_RETRIES);
                         continue;
                     }
-                    throw x;
+                    throw x instanceof RemotingSystemException ? (RemotingSystemException)x : new RemotingSystemException(x);
                 }
 
                 // no code is allowed to reach here

--- a/src/test/java/hudson/remoting/ClassRemoting2Test.java
+++ b/src/test/java/hudson/remoting/ClassRemoting2Test.java
@@ -51,7 +51,8 @@ import java.util.concurrent.Future;
 public class ClassRemoting2Test extends RmiTestBase {
 
     @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
+        super.tearDown();
         RemoteClassLoader.TESTING_CLASS_REFERENCE_LOAD = null;
         RemoteClassLoader.TESTING_CLASS_LOAD = null;
         RemoteClassLoader.TESTING_RESOURCE_LOAD = null;
@@ -63,7 +64,7 @@ public class ClassRemoting2Test extends RmiTestBase {
         DummyClassLoader parent = new DummyClassLoader(TestLinkage.B.class);
         final DummyClassLoader child1 = new DummyClassLoader(parent, TestLinkage.A.class);
         final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
-        final Callable<Object, Exception> callable = (Callable) child2.load(TestLinkage.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) child2.load(TestLinkage.class);
         assertEquals(child2, callable.getClass().getClassLoader());
         RemoteClassLoader.RETRY_SLEEP_DURATION_MILLISECONDS = 1;
         RemoteClassLoader.MAX_RETRIES = 10;
@@ -81,7 +82,7 @@ public class ClassRemoting2Test extends RmiTestBase {
         DummyClassLoader parent = new DummyClassLoader(TestLinkage.B.class);
         final DummyClassLoader child1 = new DummyClassLoader(parent, TestLinkage.A.class);
         final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
-        final Callable<Object, Exception> callable = (Callable) child2.load(TestLinkage.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) child2.load(TestLinkage.class);
         assertEquals(child2, callable.getClass().getClassLoader());
         RemoteClassLoader.RETRY_SLEEP_DURATION_MILLISECONDS = 1;
         RemoteClassLoader.MAX_RETRIES = 10;
@@ -98,7 +99,7 @@ public class ClassRemoting2Test extends RmiTestBase {
         DummyClassLoader parent = new DummyClassLoader(TestLinkage.B.class);
         final DummyClassLoader child1 = new DummyClassLoader(parent, TestLinkage.A.class);
         final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
-        final Callable<Object, Exception> callable = (Callable) child2.load(TestLinkage.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) child2.load(TestLinkage.class);
         assertEquals(child2, callable.getClass().getClassLoader());
         RemoteClassLoader.RETRY_SLEEP_DURATION_MILLISECONDS = 1;
         RemoteClassLoader.MAX_RETRIES = 3;
@@ -118,7 +119,7 @@ public class ClassRemoting2Test extends RmiTestBase {
         DummyClassLoader parent = new DummyClassLoader(TestLinkage.B.class);
         final DummyClassLoader child1 = new DummyClassLoader(parent, TestLinkage.A.class);
         final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
-        final Callable<Object, Exception> callable = (Callable) child2.load(TestLinkage.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) child2.load(TestLinkage.class);
         assertEquals(child2, callable.getClass().getClassLoader());
         RemoteClassLoader.RETRY_SLEEP_DURATION_MILLISECONDS = 1;
         RemoteClassLoader.MAX_RETRIES = 10;
@@ -137,7 +138,7 @@ public class ClassRemoting2Test extends RmiTestBase {
         DummyClassLoader parent = new DummyClassLoader(TestLinkage.B.class);
         final DummyClassLoader child1 = new DummyClassLoader(parent, TestLinkage.A.class);
         final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
-        final Callable<Object, Exception> callable = (Callable) child2.load(TestLinkage.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) child2.load(TestLinkage.class);
         assertEquals(child2, callable.getClass().getClassLoader());
         RemoteClassLoader.RETRY_SLEEP_DURATION_MILLISECONDS = 1;
         RemoteClassLoader.MAX_RETRIES = 10;
@@ -155,7 +156,7 @@ public class ClassRemoting2Test extends RmiTestBase {
         DummyClassLoader parent = new DummyClassLoader(TestLinkage.B.class);
         final DummyClassLoader child1 = new DummyClassLoader(parent, TestLinkage.A.class);
         final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
-        final Callable<Object, Exception> callable = (Callable) child2.load(TestLinkage.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) child2.load(TestLinkage.class);
         assertEquals(child2, callable.getClass().getClassLoader());
         RemoteClassLoader.RETRY_SLEEP_DURATION_MILLISECONDS = 1;
         RemoteClassLoader.MAX_RETRIES = 3;
@@ -174,7 +175,7 @@ public class ClassRemoting2Test extends RmiTestBase {
     @Issue("JENKINS-61103")
     public void testSingleInterruptionOfClassInitializationWithStaticResourceReference() throws Exception {
         final DummyClassLoader dcl = new DummyClassLoader(TestStaticResourceReference.class);
-        final Callable<Object, Exception> callable = (Callable) dcl.load(TestStaticResourceReference.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) dcl.load(TestStaticResourceReference.class);
         // make sure we get a remote interruption exception on "getResource" call
         RemoteClassLoader.TESTING_RESOURCE_LOAD = new InterruptInvocation(1, 1);
         Future<Object> f1 = ClassRemotingTest.scheduleCallableLoad(channel, callable);
@@ -187,7 +188,7 @@ public class ClassRemoting2Test extends RmiTestBase {
     @Issue("JENKINS-61103")
     public void testMultipleInterruptionOfClassInitializationWithStaticResourceReference() throws Exception {
         final DummyClassLoader dcl = new DummyClassLoader(TestStaticResourceReference.class);
-        final Callable<Object, Exception> callable = (Callable) dcl.load(TestStaticResourceReference.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) dcl.load(TestStaticResourceReference.class);
         // make sure we get a remote interruption exception on "getResource" call
         RemoteClassLoader.RETRY_SLEEP_DURATION_MILLISECONDS = 1;
         RemoteClassLoader.MAX_RETRIES = 10;
@@ -202,7 +203,7 @@ public class ClassRemoting2Test extends RmiTestBase {
     @Issue("JENKINS-61103")
     public void testContinuedInterruptionOfClassInitializationWithStaticResourceReference() throws Exception {
         final DummyClassLoader dcl = new DummyClassLoader(TestStaticResourceReference.class);
-        final Callable<Object, Exception> callable = (Callable) dcl.load(TestStaticResourceReference.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) dcl.load(TestStaticResourceReference.class);
         // make sure we get a remote interruption exception on "getResource" call
         RemoteClassLoader.RETRY_SLEEP_DURATION_MILLISECONDS = 1;
         RemoteClassLoader.MAX_RETRIES = 3;

--- a/src/test/java/hudson/remoting/ClassRemoting2Test.java
+++ b/src/test/java/hudson/remoting/ClassRemoting2Test.java
@@ -264,7 +264,7 @@ public class ClassRemoting2Test extends RmiTestBase {
         }
     }
 
-    private static class InterruptInvocation implements Runnable {
+    private static class InterruptInvocation implements RemoteClassLoader.Interruptible {
         private int invocationCount = 0;
         private int beginInterrupt;
         private int endInterrupt;

--- a/src/test/java/hudson/remoting/ClassRemoting2Test.java
+++ b/src/test/java/hudson/remoting/ClassRemoting2Test.java
@@ -275,10 +275,10 @@ public class ClassRemoting2Test extends RmiTestBase {
         }
 
         @Override
-        public void run() {
+        public void run() throws InterruptedException {
             invocationCount++;
             if (invocationCount >= beginInterrupt && invocationCount <= endInterrupt) {
-                Thread.currentThread().interrupt();
+                throw new InterruptedException("Artificial testing interrupt.");
             }
         }
     }

--- a/src/test/java/hudson/remoting/ClassRemoting2Test.java
+++ b/src/test/java/hudson/remoting/ClassRemoting2Test.java
@@ -1,0 +1,196 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.remoting;
+
+import junit.framework.Test;
+import org.junit.After;
+import org.jvnet.hudson.test.Issue;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+/**
+ * Remote class loading tests that don't work with the full set of test runners
+ * specified in RmiTestBase for various reasons. These tests may not be valid in
+ * all runner configurations.
+ *
+ * For example, tests that depend on the MULTI_CLASSLOADER capability don't work
+ * with Capability.NONE. Tests that are forked in a different JVM cannot use
+ * test resources.
+ *
+ * The full suite of runners may test configurations that are no longer interesting
+ * or applicable. It doesn't make sense to expect class loading to work with
+ * Capability.NONE.
+ */
+@WithRunner({
+        InProcessRunner.class,
+        NioSocketRunner.class,
+        NioPipeRunner.class,
+})
+public class ClassRemoting2Test extends RmiTestBase {
+
+    @After
+    public void tearDown() {
+        RemoteClassLoader.TESTING_CLASS_REFERENCE_LOAD = null;
+        RemoteClassLoader.TESTING_CLASS_LOAD = null;
+        RemoteClassLoader.SLEEP_DURATION_MS = 100;
+    }
+
+    @Issue("JENKINS-19453")
+    public void testSingleInterruptionOfClassCreation() throws Exception {
+        DummyClassLoader parent = new DummyClassLoader(TestLinkage.B.class);
+        final DummyClassLoader child1 = new DummyClassLoader(parent, TestLinkage.A.class);
+        final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
+        final Callable<Object, Exception> callable = (Callable) child2.load(TestLinkage.class);
+        assertEquals(child2, callable.getClass().getClassLoader());
+        RemoteClassLoader.SLEEP_DURATION_MS = 1;
+        RemoteClassLoader.MAX_RETRIES = 10;
+        RemoteClassLoader.TESTING_CLASS_LOAD = new InterruptInvocation(3, 3);
+        Future<Object> f1 = ClassRemotingTest.scheduleCallableLoad(channel, callable);
+
+        Object result = f1.get();
+
+        // verify that classes that we tried to load aren't irrevocably damaged and it's still available
+        ClassRemotingTest.assertTestLinkageResults(channel, parent, child1, child2, callable, result);
+    }
+
+    @Issue("JENKINS-19453")
+    public void testMultipleInterruptionOfClassCreation() throws Exception {
+        DummyClassLoader parent = new DummyClassLoader(TestLinkage.B.class);
+        final DummyClassLoader child1 = new DummyClassLoader(parent, TestLinkage.A.class);
+        final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
+        final Callable<Object, Exception> callable = (Callable) child2.load(TestLinkage.class);
+        assertEquals(child2, callable.getClass().getClassLoader());
+        RemoteClassLoader.SLEEP_DURATION_MS = 1;
+        RemoteClassLoader.MAX_RETRIES = 10;
+        RemoteClassLoader.TESTING_CLASS_LOAD = new InterruptInvocation(3, 6);
+        Future<Object> f1 = ClassRemotingTest.scheduleCallableLoad(channel, callable);
+
+        Object result = f1.get();
+
+        // verify that classes that we tried to load aren't irrevocably damaged and it's still available
+        ClassRemotingTest.assertTestLinkageResults(channel, parent, child1, child2, callable, result);
+    }
+
+    public void testContinuedInterruptionOfClassCreation() throws Exception {
+        DummyClassLoader parent = new DummyClassLoader(TestLinkage.B.class);
+        final DummyClassLoader child1 = new DummyClassLoader(parent, TestLinkage.A.class);
+        final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
+        final Callable<Object, Exception> callable = (Callable) child2.load(TestLinkage.class);
+        assertEquals(child2, callable.getClass().getClassLoader());
+        RemoteClassLoader.SLEEP_DURATION_MS = 1;
+        RemoteClassLoader.MAX_RETRIES = 3;
+        RemoteClassLoader.TESTING_CLASS_LOAD = new InterruptInvocation(3, 10);
+        Future<Object> f1 = ClassRemotingTest.scheduleCallableLoad(channel, callable);
+
+        try {
+            f1.get();
+            fail("Should have timed out, exceeding the max retries.");
+        } catch (ExecutionException ex) {
+            // Expected when we exceed the retries.
+        }
+    }
+
+    @Issue("JENKINS-36991")
+    public void testSingleInterruptionOfClassReferenceCreation() throws Exception {
+        DummyClassLoader parent = new DummyClassLoader(TestLinkage.B.class);
+        final DummyClassLoader child1 = new DummyClassLoader(parent, TestLinkage.A.class);
+        final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
+        final Callable<Object, Exception> callable = (Callable) child2.load(TestLinkage.class);
+        assertEquals(child2, callable.getClass().getClassLoader());
+        RemoteClassLoader.SLEEP_DURATION_MS = 1;
+        RemoteClassLoader.MAX_RETRIES = 10;
+        RemoteClassLoader.TESTING_CLASS_REFERENCE_LOAD = new InterruptInvocation(3, 3);
+
+        Future<Object> f1 = ClassRemotingTest.scheduleCallableLoad(channel, callable);
+
+        Object result = f1.get();
+
+        // verify that classes that we tried to load aren't irrevocably damaged and it's still available
+        ClassRemotingTest.assertTestLinkageResults(channel, parent, child1, child2, callable, result);
+    }
+
+    @Issue("JENKINS-36991")
+    public void testMultipleInterruptionOfClassReferenceCreation() throws Exception {
+        DummyClassLoader parent = new DummyClassLoader(TestLinkage.B.class);
+        final DummyClassLoader child1 = new DummyClassLoader(parent, TestLinkage.A.class);
+        final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
+        final Callable<Object, Exception> callable = (Callable) child2.load(TestLinkage.class);
+        assertEquals(child2, callable.getClass().getClassLoader());
+        RemoteClassLoader.SLEEP_DURATION_MS = 1;
+        RemoteClassLoader.MAX_RETRIES = 10;
+        RemoteClassLoader.TESTING_CLASS_REFERENCE_LOAD = new InterruptInvocation(3, 6);
+
+        Future<Object> f1 = ClassRemotingTest.scheduleCallableLoad(channel, callable);
+
+        Object result = f1.get();
+
+        // verify that classes that we tried to load aren't irrevocably damaged and it's still available
+        ClassRemotingTest.assertTestLinkageResults(channel, parent, child1, child2, callable, result);
+    }
+
+    public void testContinuedInterruptionOfClassReferenceCreation() throws Exception {
+        DummyClassLoader parent = new DummyClassLoader(TestLinkage.B.class);
+        final DummyClassLoader child1 = new DummyClassLoader(parent, TestLinkage.A.class);
+        final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
+        final Callable<Object, Exception> callable = (Callable) child2.load(TestLinkage.class);
+        assertEquals(child2, callable.getClass().getClassLoader());
+        RemoteClassLoader.SLEEP_DURATION_MS = 1;
+        RemoteClassLoader.MAX_RETRIES = 3;
+        RemoteClassLoader.TESTING_CLASS_REFERENCE_LOAD = new InterruptInvocation(3, 10);
+
+        Future<Object> f1 = ClassRemotingTest.scheduleCallableLoad(channel, callable);
+
+        try {
+            f1.get();
+            fail("Should have timed out, exceeding the max retries.");
+        } catch (ExecutionException ex) {
+            // Expected when we exceed the retries.
+        }
+    }
+
+    private static class InterruptInvocation implements Runnable {
+        private int invocationCount = 0;
+        private int beginInterrupt;
+        private int endInterrupt;
+
+        private InterruptInvocation(int beginInterrupt, int endInterrupt) {
+            this.beginInterrupt = beginInterrupt;
+            this.endInterrupt = endInterrupt;
+        }
+
+        @Override
+        public void run() {
+            invocationCount++;
+            if (invocationCount >= beginInterrupt && invocationCount <= endInterrupt) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    public static Test suite() {
+        return buildSuite(ClassRemoting2Test.class);
+    }
+
+}

--- a/src/test/java/hudson/remoting/ClassRemotingTest.java
+++ b/src/test/java/hudson/remoting/ClassRemotingTest.java
@@ -46,7 +46,7 @@ public class ClassRemotingTest extends RmiTestBase {
     public void test1() throws Throwable {
         // call a class that's only available on DummyClassLoader, so that on the remote channel
         // it will be fetched from this class loader and not from the system classloader.
-        Callable callable = (Callable) DummyClassLoader.apply(TestCallable.class);
+        Callable<Object, Exception> callable = (Callable<Object, Exception>) DummyClassLoader.apply(TestCallable.class);
 
         Object[] result = (Object[]) channel.call(callable);
 
@@ -65,7 +65,7 @@ public class ClassRemotingTest extends RmiTestBase {
         }
 
         DummyClassLoader cl = new DummyClassLoader(TestCallable.class);
-        Callable c = (Callable) cl.load(TestCallable.class);
+        Callable<Object, Exception> c = (Callable<Object, Exception>) cl.load(TestCallable.class);
         assertSame(c.getClass().getClassLoader(), cl);
 
         channel.setProperty("test",c);
@@ -77,11 +77,11 @@ public class ClassRemotingTest extends RmiTestBase {
     public void testRaceCondition() throws Throwable {
         DummyClassLoader parent = new DummyClassLoader(TestCallable.class);
         DummyClassLoader child1 = new DummyClassLoader(parent, TestCallable.Sub.class);
-        final Callable<Object,Exception> c1 = (Callable) child1.load(TestCallable.Sub.class);
+        final Callable<Object,Exception> c1 = (Callable<Object, Exception>) child1.load(TestCallable.Sub.class);
         assertEquals(child1, c1.getClass().getClassLoader());
         assertEquals(parent, c1.getClass().getSuperclass().getClassLoader());
         DummyClassLoader child2 = new DummyClassLoader(parent, TestCallable.Sub.class);
-        final Callable<Object,Exception> c2 = (Callable) child2.load(TestCallable.Sub.class);
+        final Callable<Object,Exception> c2 = (Callable<Object, Exception>) child2.load(TestCallable.Sub.class);
         assertEquals(child2, c2.getClass().getClassLoader());
         assertEquals(parent, c2.getClass().getSuperclass().getClassLoader());
         ExecutorService svc = Executors.newFixedThreadPool(2);
@@ -96,7 +96,7 @@ public class ClassRemotingTest extends RmiTestBase {
 
     public void testClassCreation_TestCallable() throws Exception {
         DummyClassLoader dummyClassLoader = new DummyClassLoader(TestCallable.class);
-        final Callable<Object, Exception> callable = (Callable) dummyClassLoader.load(TestCallable.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) dummyClassLoader.load(TestCallable.class);
         java.util.concurrent.Future<Object> f1 = scheduleCallableLoad(channel, callable);
 
         Object result = f1.get();
@@ -110,7 +110,7 @@ public class ClassRemotingTest extends RmiTestBase {
         DummyClassLoader parent = new DummyClassLoader(TestLinkage.B.class);
         final DummyClassLoader child1 = new DummyClassLoader(parent, TestLinkage.A.class);
         final DummyClassLoader child2 = new DummyClassLoader(child1, TestLinkage.class);
-        final Callable<Object, Exception> callable = (Callable) child2.load(TestLinkage.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) child2.load(TestLinkage.class);
         assertEquals(child2, callable.getClass().getClassLoader());
         java.util.concurrent.Future<Object> f1 = scheduleCallableLoad(channel, callable);
 
@@ -122,7 +122,7 @@ public class ClassRemotingTest extends RmiTestBase {
     @Issue("JENKINS-61103")
     public void testClassCreation_TestStaticResourceReference() throws Exception {
         final DummyClassLoader dcl = new DummyClassLoader(TestStaticResourceReference.class);
-        final Callable<Object, Exception> callable = (Callable) dcl.load(TestStaticResourceReference.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) dcl.load(TestStaticResourceReference.class);
         Future<Object> f1 = ClassRemotingTest.scheduleCallableLoad(channel, callable);
 
         Object result = f1.get();

--- a/src/test/java/hudson/remoting/ClassRemotingTest.java
+++ b/src/test/java/hudson/remoting/ClassRemotingTest.java
@@ -85,7 +85,7 @@ public class ClassRemotingTest extends RmiTestBase {
         assertEquals(child2, c2.getClass().getClassLoader());
         assertEquals(parent, c2.getClass().getSuperclass().getClassLoader());
         ExecutorService svc = Executors.newFixedThreadPool(2);
-        RemoteClassLoader.TESTING_CLASS_LOAD = new SleepForASec();
+        RemoteClassLoader.TESTING_CLASS_LOAD = () -> Thread.sleep(1000);
         java.util.concurrent.Future<Object> f1 = svc.submit(() -> channel.call(c1));
         java.util.concurrent.Future<Object> f2 = svc.submit(() -> channel.call(c2));
         Object result1 = f1.get();
@@ -170,17 +170,6 @@ public class ClassRemotingTest extends RmiTestBase {
         // make sure cache is taking effect
         assertEquals(result[2],result[3]);
         assertTrue(result[2].toString().contains(TESTCALLABLE_TRANSFORMED_CLASSNAME.replace(".", "/") + ".class"));
-    }
-
-    private static final class SleepForASec implements Runnable {
-        @Override
-        public void run() {
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                // Nothing
-            }
-        }
     }
 
     public static Test suite() {

--- a/src/test/java/hudson/remoting/ClassRemotingTest.java
+++ b/src/test/java/hudson/remoting/ClassRemotingTest.java
@@ -122,7 +122,17 @@ public class ClassRemotingTest extends RmiTestBase {
     @Issue("JENKINS-61103")
     public void testClassCreation_TestStaticResourceReference() throws Exception {
         final DummyClassLoader dcl = new DummyClassLoader(TestStaticResourceReference.class);
-        final Callable<Object, Exception> callable = (Callable<Object, Exception>) dcl.load(TestStaticResourceReference.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) dcl.load(TestStaticGetResources.class);
+        Future<Object> f1 = ClassRemotingTest.scheduleCallableLoad(channel, callable);
+
+        Object result = f1.get();
+        assertTestStaticResourceReferenceResults(channel, callable, result);
+    }
+
+    @Issue("JENKINS-61103")
+    public void testClassCreation_TestFindResources() throws Exception {
+        final DummyClassLoader dcl = new DummyClassLoader(TestStaticGetResources.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) dcl.load(TestStaticGetResources.class);
         Future<Object> f1 = ClassRemotingTest.scheduleCallableLoad(channel, callable);
 
         Object result = f1.get();

--- a/src/test/java/hudson/remoting/ClassRemotingTest.java
+++ b/src/test/java/hudson/remoting/ClassRemotingTest.java
@@ -122,7 +122,7 @@ public class ClassRemotingTest extends RmiTestBase {
     @Issue("JENKINS-61103")
     public void testClassCreation_TestStaticResourceReference() throws Exception {
         final DummyClassLoader dcl = new DummyClassLoader(TestStaticResourceReference.class);
-        final Callable<Object, Exception> callable = (Callable<Object, Exception>) dcl.load(TestStaticGetResources.class);
+        final Callable<Object, Exception> callable = (Callable<Object, Exception>) dcl.load(TestStaticResourceReference.class);
         Future<Object> f1 = ClassRemotingTest.scheduleCallableLoad(channel, callable);
 
         Object result = f1.get();

--- a/src/test/java/hudson/remoting/ClassRemotingTest.java
+++ b/src/test/java/hudson/remoting/ClassRemotingTest.java
@@ -119,6 +119,20 @@ public class ClassRemotingTest extends RmiTestBase {
         assertTestLinkageResults(channel, parent, child1, child2, callable, result);
     }
 
+    @Issue("JENKINS-61103")
+    public void testClassCreation_TestStaticResourceReference() throws Exception {
+        final DummyClassLoader dcl = new DummyClassLoader(TestStaticResourceReference.class);
+        final Callable<Object, Exception> callable = (Callable) dcl.load(TestStaticResourceReference.class);
+        Future<Object> f1 = ClassRemotingTest.scheduleCallableLoad(channel, callable);
+
+        Object result = f1.get();
+        assertTestStaticResourceReferenceResults(channel, callable, result);
+    }
+
+    static void assertTestStaticResourceReferenceResults(Channel channel, Callable<Object, Exception> callable, Object result) throws Exception {
+        assertEquals(String.class, channel.call(callable).getClass());
+        assertTrue(result.toString().contains("impossible"));
+    }
 
     static Future<Object> scheduleCallableLoad(Channel channel, final Callable<Object, Exception> c) {
         ExecutorService svc = Executors.newSingleThreadExecutor();

--- a/src/test/java/hudson/remoting/ForkRunner.java
+++ b/src/test/java/hudson/remoting/ForkRunner.java
@@ -26,7 +26,6 @@ public class ForkRunner implements ChannelRunner {
     protected List<String> buildCommandLine() {
         String cp = getClasspath();
 
-        System.out.println(cp);
         List<String> r = new ArrayList<String>();
         r.add("-cp");
         r.add(cp);
@@ -35,9 +34,6 @@ public class ForkRunner implements ChannelRunner {
     }
 
     public Channel start() throws Exception {
-        System.out.println("forking a new process");
-        // proc = Runtime.getRuntime().exec("java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=8000 hudson.remoting.Launcher");
-
         List<String> cmds = buildCommandLine();
         cmds.add(0,"java");
         proc = Runtime.getRuntime().exec(cmds.toArray(new String[0]));
@@ -59,13 +55,10 @@ public class ForkRunner implements ChannelRunner {
         channel.close();
         channel.join(10*1000);
 
-//            System.out.println("north completed");
-
         executor.shutdown();
 
         copier.join();
         int r = proc.waitFor();
-//            System.out.println("south completed");
 
         assertEquals("exit code should have been 0", 0, r);
     }

--- a/src/test/java/hudson/remoting/ForkRunner.java
+++ b/src/test/java/hudson/remoting/ForkRunner.java
@@ -26,7 +26,7 @@ public class ForkRunner implements ChannelRunner {
     protected List<String> buildCommandLine() {
         String cp = getClasspath();
 
-        List<String> r = new ArrayList<String>();
+        List<String> r = new ArrayList<>();
         r.add("-cp");
         r.add(cp);
         r.add(Launcher.class.getName());
@@ -43,11 +43,6 @@ public class ForkRunner implements ChannelRunner {
 
         executor = Executors.newCachedThreadPool();
         OutputStream out = proc.getOutputStream();
-        if (RECORD_OUTPUT) {
-            File f = File.createTempFile("remoting",".log");
-            System.out.println("Recording to "+f);
-            out = new TeeOutputStream(out,new FileOutputStream(f));
-        }
         return new ChannelBuilder("north", executor).build(proc.getInputStream(), out);
     }
 
@@ -78,8 +73,4 @@ public class ForkRunner implements ChannelRunner {
         return buf.toString();
     }
 
-    /**
-     * Record the communication to the remote node. Used during debugging.
-     */
-    private static boolean RECORD_OUTPUT = false;
 }

--- a/src/test/java/hudson/remoting/TestStaticGetResources.java
+++ b/src/test/java/hudson/remoting/TestStaticGetResources.java
@@ -1,0 +1,23 @@
+package hudson.remoting;
+
+import java.io.IOException;
+
+public class TestStaticGetResources extends CallableBase {
+
+    private static final long serialVersionUID = 1L;
+
+    private static boolean FIRST_RESOURCE;
+
+    static {
+        try {
+            FIRST_RESOURCE = TestStaticGetResources.class.getClassLoader().getResources("BLAH").hasMoreElements();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public Object call() {
+        return "found the impossible: " + FIRST_RESOURCE;
+    }
+
+}

--- a/src/test/java/hudson/remoting/TestStaticResourceReference.java
+++ b/src/test/java/hudson/remoting/TestStaticResourceReference.java
@@ -1,0 +1,14 @@
+package hudson.remoting;
+
+public class TestStaticResourceReference extends CallableBase {
+
+    private static final long serialVersionUID = 1L;
+
+    // this is really just to check that we can initialize a static property from searching a classpath resource
+    private static boolean FALSE = TestStaticResourceReference.class.getClassLoader().getResource("BLAH") != null;
+
+    public Object call() {
+        return "found the impossible: " + FALSE;
+    }
+
+}


### PR DESCRIPTION
See [JENKINS-61103](https://github.com/jenkinsci/remoting/pull/372). This is an alternative approach to #372.

There have been a couple of previous efforts to introduce retries into the RemoteClassLoader. These have reportedly resolved some situations, however we have continued to receive reports of class loading failures. As noted in JENKINS-61103 and the earlier PR, one area that isn't covered by a retry is resource loading as part of a class.

This PR does three things:
1. Fixes some of the tests so that they work correctly. Some of them weren't really testing what they claimed to. Some could be simplified a little.
2. Introduces timeouts and sleep to the retries. This should slow down further attempts that may quickly fail and provide a way to eventually terminate if the problem doesn't resolve. I add this to the two existing retry areas and to the new one. I arbitrarily chose 10 minutes as the total timeout time. It's much smaller than the previous value (infinite), but still a significant amount of time.
3. Adds retries to `findResource()` using the same pattern.

These changes only get involved in truly exceptional conditions. I've never been able to reproduce them directly. Other reports of class loading failures have similarly lacked for reproducibility. This has two major impacts:
1. It's very difficult to test how much this fix will impact the situation, how well it improve things, or whether it will correct any of the reported situations.
2. Any problems introduced will not have widespread effect. If the retry period is not ideal, it won't affect the great majority of situations. This makes me feel like it is worthwhile to try out this change to see how well it helps.

This change might help for [JENKINS-51854](https://issues.jenkins-ci.org/browse/JENKINS-51854) and [JENKINS-514910](https://issues.jenkins-ci.org/browse/JENKINS-514910).