### PR TITLE
[INFRA-2619] Add maven release plugin default setting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,6 +370,13 @@ THE SOFTWARE.
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <configuration>
+          <pushChanges>false</pushChanges>
+          <localCheckout>true</localCheckout>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>


### PR DESCRIPTION
This pull request is needed for https://github.com/jenkins-infra/release/pull/60/files, in order to use the same release workflow than jenkins core release.

Basically it configures the maven release plugin to not push commits (let that operation) done outside, and release based on local git repository
