### PR TITLE
Update to use the latest parent pom.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.53</version>
+    <version>1.56</version>
     <relativePath />
   </parent>
 
@@ -423,15 +423,6 @@ THE SOFTWARE.
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <plugins>
-            <plugin>
-              <groupId>com.h3xstream.findsecbugs</groupId>
-              <artifactId>findsecbugs-plugin</artifactId>
-              <version>1.10.1</version>
-            </plugin>
-          </plugins>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This eliminates the need for a local configuration for findsecbugs.