### PR TITLE
Add missing override annotations

### DIFF
--- a/src/main/java/hudson/remoting/AbstractByteArrayCommandTransport.java
+++ b/src/main/java/hudson/remoting/AbstractByteArrayCommandTransport.java
@@ -59,6 +59,7 @@ public abstract class AbstractByteArrayCommandTransport extends CommandTransport
     public final void setup(final Channel channel, final CommandReceiver receiver) {
         this.channel = channel;
         setup(new ByteArrayReceiver() {
+            @Override
             public void handle(byte[] payload) {
                 try {
                     Command cmd = Command.readFrom(channel, payload);
@@ -68,6 +69,7 @@ public abstract class AbstractByteArrayCommandTransport extends CommandTransport
                 }
             }
 
+            @Override
             public void terminate(IOException e) {
                 receiver.terminate(e);
             }

--- a/src/main/java/hudson/remoting/AsyncFutureImpl.java
+++ b/src/main/java/hudson/remoting/AsyncFutureImpl.java
@@ -58,18 +58,22 @@ public class AsyncFutureImpl<V> implements Future<V> {
         set(value);
     }
 
+    @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         return false;
     }
 
+    @Override
     public synchronized boolean isCancelled() {
         return cancelled;
     }
 
+    @Override
     public synchronized boolean isDone() {
         return completed;
     }
 
+    @Override
     public synchronized V get() throws InterruptedException, ExecutionException {
         while(!completed)
             wait();
@@ -80,6 +84,7 @@ public class AsyncFutureImpl<V> implements Future<V> {
         return value;
     }
 
+    @Override
     @CheckForNull
     public synchronized V get(@Nonnegative long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         // The accuracy of wait(long) operation is milliseconds anyway, but ok.

--- a/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
+++ b/src/main/java/hudson/remoting/AtmostOneThreadExecutor.java
@@ -39,6 +39,7 @@ public class AtmostOneThreadExecutor extends AbstractExecutorService {
         this(new DaemonThreadFactory());
     }
 
+    @Override
     public void shutdown() {
         synchronized (q) {
             shutdown = true;
@@ -54,6 +55,7 @@ public class AtmostOneThreadExecutor extends AbstractExecutorService {
         return worker!=null && worker.isAlive();
     }
 
+    @Override
     public List<Runnable> shutdownNow() {
         synchronized (q) {
             shutdown = true;
@@ -63,14 +65,17 @@ public class AtmostOneThreadExecutor extends AbstractExecutorService {
         }
     }
 
+    @Override
     public boolean isShutdown() {
         return shutdown;
     }
 
+    @Override
     public boolean isTerminated() {
         return shutdown && !isAlive();
     }
 
+    @Override
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         synchronized (q) {
             long now = System.nanoTime();
@@ -83,6 +88,7 @@ public class AtmostOneThreadExecutor extends AbstractExecutorService {
         return isTerminated();
     }
 
+    @Override
     public void execute(Runnable command) {
         synchronized (q) {
             if (isShutdown()) {
@@ -98,6 +104,7 @@ public class AtmostOneThreadExecutor extends AbstractExecutorService {
     }
 
     private class Worker implements Runnable {
+        @Override
         public void run() {
             while (true) {
                 Runnable task;

--- a/src/main/java/hudson/remoting/BinarySafeStream.java
+++ b/src/main/java/hudson/remoting/BinarySafeStream.java
@@ -75,6 +75,7 @@ public final class BinarySafeStream {
             final byte[] qualtet = new byte[4];
             int input = 0;
 
+            @Override
             public int read() throws IOException {
                 if(remaining==0) {
                     remaining = _read(triplet,0,3);
@@ -87,6 +88,7 @@ public final class BinarySafeStream {
                 return ((int) triplet[3 - remaining--]) & 0xFF;
             }
 
+            @Override
             public int read(byte b[], int off, int len) throws IOException {
                 if(remaining==-1)   return -1; // EOF
 
@@ -209,6 +211,7 @@ public final class BinarySafeStream {
                 return totalRead;
             }
 
+            @Override
             public int available() throws IOException {
                 // roughly speaking we got 3/4 of the underlying available bytes
                 return super.available()*3/4;
@@ -228,6 +231,7 @@ public final class BinarySafeStream {
             private int remaining=0;
             private final byte[] out = new byte[4];
 
+            @Override
             public void write(int b) throws IOException {
                 if(remaining==2) {
                     _write(triplet[0],triplet[1],(byte)b);
@@ -237,6 +241,7 @@ public final class BinarySafeStream {
                 }
             }
 
+            @Override
             public void write(byte b[], int off, int len) throws IOException {
                 // if there's anything left in triplet from the last write, try to write them first
                 if(remaining>0) {
@@ -272,6 +277,7 @@ public final class BinarySafeStream {
                 super.out.write(out,0,4);
             }
 
+            @Override
             public void flush() throws IOException {
                 int a = triplet[0];
                 int b = triplet[1];

--- a/src/main/java/hudson/remoting/CallableDecoratorList.java
+++ b/src/main/java/hudson/remoting/CallableDecoratorList.java
@@ -17,6 +17,7 @@ class CallableDecoratorList extends CopyOnWriteArrayList<CallableDecorator> {
 
     private <V> java.util.concurrent.Callable<V> applyDecorator(final java.util.concurrent.Callable<V> inner, final CallableDecorator filter) {
         return new java.util.concurrent.Callable<V>() {
+            @Override
             public V call() throws Exception {
                 return filter.call(inner);
             }

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -593,6 +593,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         this.properties.putAll(settings.getProperties());
 
         transport.setup(this, new CommandReceiver() {
+            @Override
             public void handle(Command cmd) {
                 commandsReceived++;
                 long receivedAt = System.currentTimeMillis();
@@ -615,6 +616,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
                 }
             }
 
+            @Override
             public void terminate(IOException e) {
                 Channel.this.terminate(e);
             }
@@ -983,6 +985,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * {@inheritDoc}
      */
+    @Override
     public <V,T extends Throwable>
     V call(Callable<V,T> callable) throws IOException, T, InterruptedException {
         if (isClosingOrClosed()) {
@@ -1017,6 +1020,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * {@inheritDoc}
      */
+    @Override
     public <V,T extends Throwable>
     Future<V> callAsync(final Callable<V,T> callable) throws IOException {
         if (isClosingOrClosed()) {
@@ -1173,6 +1177,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      * @throws InterruptedException
      *      If the current thread is interrupted while waiting for the completion.
      */
+    @Override
     public synchronized void join() throws InterruptedException {
         while(inClosed==null || outClosed==null)
             // not that I really encountered any situation where this happens, but
@@ -1267,6 +1272,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         SetMaximumBytecodeLevel(short level) {
             this.level = level;
         }
+        @Override
         public Void call() throws RuntimeException {
             Channel.currentOrFail().maximumBytecodeLevel = level;
             return null;
@@ -1287,6 +1293,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *      If the current thread is interrupted while waiting for the completion.
      * @since 1.299
      */
+    @Override
     public synchronized void join(long timeout) throws InterruptedException {
         long now = System.nanoTime();
         long end = now + TimeUnit.MILLISECONDS.toNanos(timeout);
@@ -1308,6 +1315,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
             super(channel, cause);
         }
 
+        @Override
         protected void execute(Channel channel) {
             try {
                 channel.close();
@@ -1442,6 +1450,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void close() throws IOException {
         close(null);
     }
@@ -1535,6 +1544,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
      *      to wait for the set by the other side of the channel (via {@link #waitForRemoteProperty(Object)}.
      *      If we don't abort after the channel shutdown, this method will block forever.
      */
+    @Override
     @Nonnull
     public Object waitForProperty(@Nonnull Object key) throws InterruptedException {
 
@@ -1743,6 +1753,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
 //        callAsync(new IOSyncer());
 //    }
 
+    @Override
     public void syncLocalIO() throws InterruptedException {
         Thread t = Thread.currentThread();
         String old = t.getName();
@@ -1750,6 +1761,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         try {
             // no one waits for the completion of this Runnable, so not using I/O ID
             pipeWriter.submit(0,new Runnable() {
+                @Override
                 public void run() {
                     // noop
                 }

--- a/src/main/java/hudson/remoting/ClassicCommandTransport.java
+++ b/src/main/java/hudson/remoting/ClassicCommandTransport.java
@@ -47,6 +47,7 @@ import java.io.StreamCorruptedException;
         return remoteCapability;
     }
 
+    @Override
     public final void write(Command cmd, boolean last) throws IOException {
         cmd.writeTo(channel,oos);
         // TODO notifyWrite using CountingOutputStream
@@ -62,10 +63,12 @@ import java.io.StreamCorruptedException;
             oos.reset();
     }
 
+    @Override
     public void closeWrite() throws IOException {
         oos.close();
     }
 
+    @Override
     public final Command read() throws IOException, ClassNotFoundException {
         try {
             Command cmd = Command.readFromObjectStream(channel, ois);
@@ -95,6 +98,7 @@ import java.io.StreamCorruptedException;
         return rawIn.analyzeCrash(e,(channel!=null ? channel : this).toString());
     }
 
+    @Override
     public void closeRead() throws IOException {
         ois.close();
     }

--- a/src/main/java/hudson/remoting/Command.java
+++ b/src/main/java/hudson/remoting/Command.java
@@ -185,6 +185,7 @@ public abstract class Command implements Serializable {
             super(cause);
         }
 
+        @Override
         public String toString() {
             return "Command "+Command.this.toString()+" created at";
         }

--- a/src/main/java/hudson/remoting/DaemonThreadFactory.java
+++ b/src/main/java/hudson/remoting/DaemonThreadFactory.java
@@ -10,6 +10,7 @@ import java.util.logging.Logger;
 public class DaemonThreadFactory implements ThreadFactory {
     private static final Logger LOGGER = Logger.getLogger(DaemonThreadFactory.class.getName());
 
+    @Override
     public Thread newThread(Runnable r) {
         Thread thread = new Thread(r);
         thread.setDaemon(true);

--- a/src/main/java/hudson/remoting/DelegatingExecutorService.java
+++ b/src/main/java/hudson/remoting/DelegatingExecutorService.java
@@ -18,54 +18,67 @@ class DelegatingExecutorService implements ExecutorService {
         this.base = base;
     }
 
+    @Override
     public void shutdown() {
         base.shutdown();
     }
 
+    @Override
     public List<Runnable> shutdownNow() {
         return base.shutdownNow();
     }
 
+    @Override
     public boolean isShutdown() {
         return base.isShutdown();
     }
 
+    @Override
     public boolean isTerminated() {
         return base.isTerminated();
     }
 
+    @Override
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         return base.awaitTermination(timeout, unit);
     }
 
+    @Override
     public <T> Future<T> submit(Callable<T> task) {
         return base.submit(task);
     }
 
+    @Override
     public <T> Future<T> submit(Runnable task, T result) {
         return base.submit(task, result);
     }
 
+    @Override
     public Future<?> submit(Runnable task) {
         return base.submit(task);
     }
 
+    @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
         return base.invokeAll(tasks);
     }
 
+    @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
         return base.invokeAll(tasks, timeout, unit);
     }
 
+    @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
         return base.invokeAny(tasks);
     }
 
+    @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         return base.invokeAny(tasks, timeout, unit);
     }
 
+    @Override
     public void execute(Runnable command) {
         base.execute(command);
     }

--- a/src/main/java/hudson/remoting/DumbClassLoaderBridge.java
+++ b/src/main/java/hudson/remoting/DumbClassLoaderBridge.java
@@ -30,14 +30,17 @@ class DumbClassLoaderBridge implements IClassLoader {
         this.base = base;
     }
 
+    @Override
     public byte[] fetchJar(URL url) throws IOException {
         return base.fetchJar(url);
     }
 
+    @Override
     public byte[] fetch(String className) throws ClassNotFoundException {
         return base.fetch(className);
     }
 
+    @Override
     public ClassFile fetch2(String className) throws ClassNotFoundException {
         return base.fetch2(className);
     }
@@ -53,6 +56,7 @@ class DumbClassLoaderBridge implements IClassLoader {
         return base.getResources(name);
     }
 
+    @Override
     public Map<String,ClassFile2> fetch3(String className) throws ClassNotFoundException {
         ClassFile cf = fetch2(className);
         return Collections.singletonMap(className,

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -111,6 +111,7 @@ public class Engine extends Thread {
      */
     private final ExecutorService executor = Executors.newCachedThreadPool(new ThreadFactory() {
         private final ThreadFactory defaultFactory = Executors.defaultThreadFactory();
+        @Override
         public Thread newThread(final Runnable r) {
             Thread thread = defaultFactory.newThread(() -> {
                 CURRENT.set(Engine.this);
@@ -874,6 +875,7 @@ public class Engine extends Thread {
             NoSuchAlgorithmException, IOException {
         Map<String, String> properties = AccessController.doPrivileged(
                 new PrivilegedExceptionAction<Map<String, String>>() {
+                    @Override
                     public Map<String, String> run() throws Exception {
                         Map<String, String> result = new HashMap<String, String>();
                         result.put("trustStore", System.getProperty("javax.net.ssl.trustStore"));
@@ -955,6 +957,7 @@ public class Engine extends Thread {
     @CheckForNull
     private static FileInputStream getFileInputStream(final File file) throws PrivilegedActionException {
         return AccessController.doPrivileged(new PrivilegedExceptionAction<FileInputStream>() {
+            @Override
             public FileInputStream run() throws Exception {
                 try {
                     return file.exists() ? new FileInputStream(file) : null;

--- a/src/main/java/hudson/remoting/EngineListenerAdapter.java
+++ b/src/main/java/hudson/remoting/EngineListenerAdapter.java
@@ -7,18 +7,23 @@ package hudson.remoting;
  * @since 2.36
  */
 public abstract class EngineListenerAdapter implements EngineListener {
+    @Override
     public void status(String msg) {
     }
 
+    @Override
     public void status(String msg, Throwable t) {
     }
 
+    @Override
     public void error(Throwable t) {
     }
 
+    @Override
     public void onDisconnect() {
     }
 
+    @Override
     public void onReconnect() {
     }
 }

--- a/src/main/java/hudson/remoting/EngineListenerSplitter.java
+++ b/src/main/java/hudson/remoting/EngineListenerSplitter.java
@@ -20,30 +20,35 @@ public class EngineListenerSplitter implements EngineListener {
         listeners.remove(el);
     }
 
+    @Override
     public void status(String msg) {
         for (EngineListener l : listeners) {
             l.status(msg);
         }
     }
 
+    @Override
     public void status(String msg, Throwable t) {
         for (EngineListener l : listeners) {
             l.status(msg,t);
         }
     }
 
+    @Override
     public void error(Throwable t) {
         for (EngineListener l : listeners) {
             l.error(t);
         }
     }
 
+    @Override
     public void onDisconnect() {
         for (EngineListener l : listeners) {
             l.onDisconnect();
         }
     }
 
+    @Override
     public void onReconnect() {
         for (EngineListener l : listeners) {
             l.onReconnect();

--- a/src/main/java/hudson/remoting/FastPipedInputStream.java
+++ b/src/main/java/hudson/remoting/FastPipedInputStream.java
@@ -141,6 +141,7 @@ public class FastPipedInputStream extends InputStream {
         return false;
     }
 
+    @Override
     public int read() throws IOException {
         byte[] b = new byte[1];
         return read(b, 0, b.length) == -1 ? -1 : (255 & b[0]);

--- a/src/main/java/hudson/remoting/FastPipedOutputStream.java
+++ b/src/main/java/hudson/remoting/FastPipedOutputStream.java
@@ -90,6 +90,7 @@ public class FastPipedOutputStream extends OutputStream implements ErrorPropagat
         error(null);
     }
 
+    @Override
     public void error(Throwable e) throws IOException {
         if(sink == null) {
             throw new IOException("Unconnected pipe");
@@ -129,6 +130,7 @@ public class FastPipedOutputStream extends OutputStream implements ErrorPropagat
         }
     }
 
+    @Override
     public void write(int b) throws IOException {
         write(new byte[] { (byte) b });
     }

--- a/src/main/java/hudson/remoting/FlightRecorderInputStream.java
+++ b/src/main/java/hudson/remoting/FlightRecorderInputStream.java
@@ -53,6 +53,7 @@ class FlightRecorderInputStream extends InputStream {
         final IOException[] error = new IOException[1];
 
         Thread diagnosisThread = new Thread(diagnosisName+" stream corruption diagnosis thread") {
+            @Override
             public void run() {
                 int b;
                 try {

--- a/src/main/java/hudson/remoting/FutureAdapter.java
+++ b/src/main/java/hudson/remoting/FutureAdapter.java
@@ -39,22 +39,27 @@ abstract class FutureAdapter<X,Y> implements Future<X> {
         this.core = core;
     }
 
+    @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         return core.cancel(mayInterruptIfRunning);
     }
 
+    @Override
     public boolean isCancelled() {
         return core.isCancelled();
     }
 
+    @Override
     public boolean isDone() {
         return core.isDone();
     }
 
+    @Override
     public X get() throws InterruptedException, ExecutionException {
         return adapt(core.get());
     }
 
+    @Override
     public X get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         return adapt(core.get(timeout, unit));
     }

--- a/src/main/java/hudson/remoting/GCCommand.java
+++ b/src/main/java/hudson/remoting/GCCommand.java
@@ -29,6 +29,7 @@ package hudson.remoting;
  * @author Kohsuke Kawaguchi
  */
 class GCCommand extends Command {
+    @Override
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("DM_GC")
     protected void execute(Channel channel) {
         System.gc();

--- a/src/main/java/hudson/remoting/InterceptingExecutorService.java
+++ b/src/main/java/hudson/remoting/InterceptingExecutorService.java
@@ -68,6 +68,7 @@ class InterceptingExecutorService extends DelegatingExecutorService {
 
     private <V> Callable<V> wrap(final Runnable r, final V value) {
         return wrap(new Callable<V>() {
+            @Override
             public V call() throws Exception {
                 r.run();
                 return value;

--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -34,6 +34,7 @@ class JarLoaderImpl implements JarLoader, SerializableOnlyOverRemoting {
 
     private final Set<Checksum> presentOnRemote = Collections.synchronizedSet(new HashSet<Checksum>());
 
+    @Override
     @SuppressFBWarnings(value = {"URLCONNECTION_SSRF_FD", "PATH_TRAVERSAL_IN"}, justification = "This is only used for managing the jar cache as files, not URLs.")
     public void writeJarTo(long sum1, long sum2, OutputStream sink) throws IOException, InterruptedException {
         Checksum k = new Checksum(sum1, sum2);
@@ -63,14 +64,17 @@ class JarLoaderImpl implements JarLoader, SerializableOnlyOverRemoting {
         return calcChecksum(jar.toURI().toURL());
     }
 
+    @Override
     public boolean isPresentOnRemote(Checksum sum) {
         return presentOnRemote.contains(sum);
     }
 
+    @Override
     public void notifyJarPresence(long sum1, long sum2) {
         presentOnRemote.add(new Checksum(sum1,sum2));
     }
 
+    @Override
     public void notifyJarPresence(long[] sums) {
         synchronized (presentOnRemote) {
             for (int i=0; i<sums.length; i+=2)

--- a/src/main/java/hudson/remoting/LocalChannel.java
+++ b/src/main/java/hudson/remoting/LocalChannel.java
@@ -41,12 +41,15 @@ public class LocalChannel implements VirtualChannel {
         this.executor = executor;
     }
 
+    @Override
     public <V, T extends Throwable> V call(Callable<V,T> callable) throws T {
         return callable.call();
     }
 
+    @Override
     public <V, T extends Throwable> Future<V> callAsync(final Callable<V,T> callable) throws IOException {
         final java.util.concurrent.Future<V> f = executor.submit(new java.util.concurrent.Callable<V>() {
+            @Override
             public V call() throws Exception {
                 try {
                     return callable.call();
@@ -61,32 +64,39 @@ public class LocalChannel implements VirtualChannel {
         });
 
         return new Future<V>() {
+            @Override
             public boolean cancel(boolean mayInterruptIfRunning) {
                 return f.cancel(mayInterruptIfRunning);
             }
 
+            @Override
             public boolean isCancelled() {
                 return f.isCancelled();
             }
 
+            @Override
             public boolean isDone() {
                 return f.isDone();
             }
 
+            @Override
             public V get() throws InterruptedException, ExecutionException {
                 return f.get();
             }
 
+            @Override
             public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
                 return f.get(timeout,unit);
             }
         };
     }
 
+    @Override
     public void close() {
         // noop
     }
 
+    @Override
     public void join() throws InterruptedException {
         // noop
     }
@@ -96,10 +106,12 @@ public class LocalChannel implements VirtualChannel {
         // noop
     }
 
+    @Override
     public <T> T export(Class<T> intf, T instance) {
         return instance;
     }
 
+    @Override
     public void syncLocalIO() throws InterruptedException {
         // noop
     }

--- a/src/main/java/hudson/remoting/PingThread.java
+++ b/src/main/java/hudson/remoting/PingThread.java
@@ -81,6 +81,7 @@ public abstract class PingThread extends Thread {
         this(channel, TimeUnit.MINUTES.toMillis(10));
     }
 
+    @Override
     public void run() {
         try {
             while(true) {
@@ -155,6 +156,7 @@ public abstract class PingThread extends Thread {
     private static final class Ping implements Callable<Void, IOException> {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public Void call() throws IOException {
             return null;
         }

--- a/src/main/java/hudson/remoting/Pipe.java
+++ b/src/main/java/hudson/remoting/Pipe.java
@@ -126,6 +126,7 @@ public final class Pipe implements SerializableOnlyOverRemoting, ErrorPropagatin
      *
      * @see ErrorPropagatingOutputStream#error(Throwable)
      */
+    @Override
     public void error(Throwable t) throws IOException {
         if (out instanceof ErrorPropagatingOutputStream) {
             ErrorPropagatingOutputStream eo = (ErrorPropagatingOutputStream) out;
@@ -219,6 +220,7 @@ public final class Pipe implements SerializableOnlyOverRemoting, ErrorPropagatin
         protected void execute(final Channel channel) throws ExecutionException {
             // ordering barrier not needed for this I/O call, so not giving I/O ID.
             channel.pipeWriter.submit(0,new Runnable() {
+                @Override
                 public void run() {
                     try {
                         final ProxyOutputStream ros = (ProxyOutputStream) channel.getExportedObject(oidRos);

--- a/src/main/java/hudson/remoting/PipeWindow.java
+++ b/src/main/java/hudson/remoting/PipeWindow.java
@@ -132,18 +132,22 @@ abstract class PipeWindow {
             return Integer.MAX_VALUE;
         }
 
+        @Override
         void increase(int delta) {
         }
 
+        @Override
         int peek() {
             return Integer.MAX_VALUE;
         }
 
+        @Override
         int get(int min) throws InterruptedException, IOException {
             checkDeath();
             return Integer.MAX_VALUE;
         }
 
+        @Override
         void decrease(int delta) {
         }
     }
@@ -200,6 +204,7 @@ abstract class PipeWindow {
             return initial;
         }
 
+        @Override
         public synchronized void increase(int delta) {
             if (LOGGER.isLoggable(FINER))
                 LOGGER.finer(String.format("increase(%d,%d)->%d",oid,delta,delta+available));
@@ -208,6 +213,7 @@ abstract class PipeWindow {
             notifyAll();
         }
 
+        @Override
         public synchronized int peek() {
             return available;
         }
@@ -215,6 +221,7 @@ abstract class PipeWindow {
         /**
          * Blocks until some space becomes available.
          */
+        @Override
         public int get(int min) throws InterruptedException, IOException {
             checkDeath();
             synchronized (this) {
@@ -230,6 +237,7 @@ abstract class PipeWindow {
             }
         }
 
+        @Override
         public synchronized void decrease(int delta) {
             if (LOGGER.isLoggable(FINER))
                 LOGGER.finer(String.format("decrease(%d,%d)->%d",oid,delta,available-delta));

--- a/src/main/java/hudson/remoting/PipeWriter.java
+++ b/src/main/java/hudson/remoting/PipeWriter.java
@@ -150,6 +150,7 @@ class PipeWriter {
         assert old==null;
 
         return fh.set(base.submit(new Runnable() {
+            @Override
             public void run() {
                 final Thread t = Thread.currentThread();
                 final String oldName = t.getName();

--- a/src/main/java/hudson/remoting/PreloadJarTask.java
+++ b/src/main/java/hudson/remoting/PreloadJarTask.java
@@ -57,6 +57,7 @@ final class PreloadJarTask implements DelegatingCallable<Boolean,IOException> {
         return target;
     }
 
+    @Override
     public Boolean call() throws IOException {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         if (!(cl instanceof RemoteClassLoader))

--- a/src/main/java/hudson/remoting/ProxyInputStream.java
+++ b/src/main/java/hudson/remoting/ProxyInputStream.java
@@ -131,6 +131,7 @@ final class ProxyInputStream extends InputStream {
             this.len = len;
         }
 
+        @Override
         protected Buffer perform(Channel channel) throws IOException {
             InputStream in;
             try {
@@ -163,6 +164,7 @@ final class ProxyInputStream extends InputStream {
             this.oid = oid;
         }
 
+        @Override
         protected void execute(Channel channel) {
             final InputStream in = (InputStream) channel.getExportedObjectOrNull(oid);
             // EOF may be late to the party if we interrupt request, hence we do not fail for this command         
@@ -180,6 +182,7 @@ final class ProxyInputStream extends InputStream {
             }
         }
 
+        @Override
         public String toString() {
             return "ProxyInputStream.EOF("+oid+")";
         }

--- a/src/main/java/hudson/remoting/ProxyWriter.java
+++ b/src/main/java/hudson/remoting/ProxyWriter.java
@@ -108,10 +108,12 @@ final class ProxyWriter extends Writer {
         }
     }
 
+    @Override
     public void write(int c) throws IOException {
         write(new char[]{(char)c},0,1);
     }
 
+    @Override
     public void write(char[] cbuf, int off, int len) throws IOException {
         if (closeCause != null) {
             throw new IOException("stream is already closed");
@@ -178,11 +180,13 @@ final class ProxyWriter extends Writer {
         }
     }
 
+    @Override
     public synchronized void flush() throws IOException {
         if(channel!=null && channel.remoteCapability.supportsProxyWriter2_35())
             channel.send(new Flush(channel.newIoId(),oid));
     }
 
+    @Override
     public synchronized void close() throws IOException {
         error(null);
     }
@@ -285,6 +289,7 @@ final class ProxyWriter extends Writer {
         protected void execute(final Channel channel) throws ExecutionException {
             final Writer os = (Writer) channel.getExportedObject(oid);
             channel.pipeWriter.submit(ioId, new Runnable() {
+                @Override
                 public void run() {
                     try {
                         os.write(buf);
@@ -317,6 +322,7 @@ final class ProxyWriter extends Writer {
             });
         }
 
+        @Override
         public String toString() {
             return "ProxyWriter.Chunk("+oid+","+buf.length+")";
         }
@@ -338,9 +344,11 @@ final class ProxyWriter extends Writer {
             this.oid = oid;
         }
 
+        @Override
         protected void execute(Channel channel) throws ExecutionException {
             final Writer os = (Writer) channel.getExportedObject(oid);
             channel.pipeWriter.submit(ioId, new Runnable() {
+                @Override
                 public void run() {
                     try {
                         os.flush();
@@ -351,6 +359,7 @@ final class ProxyWriter extends Writer {
             });
         }
 
+        @Override
         public String toString() {
             return "ProxyWriter.Flush("+oid+")";
         }
@@ -374,14 +383,17 @@ final class ProxyWriter extends Writer {
             this.oid = oid;
         }
 
+        @Override
         protected void execute(final Channel channel) {
             channel.pipeWriter.submit(ioId,new Runnable() {
+                @Override
                 public void run() {
                     channel.unexport(oid,createdAt,false);
                 }
             });
         }
 
+        @Override
         public String toString() {
             return "ProxyWriter.Unexport("+oid+")";
         }
@@ -401,6 +413,7 @@ final class ProxyWriter extends Writer {
             this.oid = oid;
         }
 
+        @Override
         protected void execute(final Channel channel) {
             final Writer os = (Writer) channel.getExportedObjectOrNull(oid);
             // EOF may be late to the party if we interrupt request, hence we do not fail for this command
@@ -409,6 +422,7 @@ final class ProxyWriter extends Writer {
                 return;
             }
             channel.pipeWriter.submit(ioId, new Runnable() {
+                @Override
                 public void run() {
                     channel.unexport(oid,createdAt,false);
                     try {
@@ -420,6 +434,7 @@ final class ProxyWriter extends Writer {
             });
         }
 
+        @Override
         public String toString() {
             return "ProxyWriter.EOF("+oid+")";
         }
@@ -447,11 +462,13 @@ final class ProxyWriter extends Writer {
             this.size = size;
         }
 
+        @Override
         protected void execute(Channel channel) {
             PipeWindow w = channel.getPipeWindow(oid);
             w.increase(size);
         }
 
+        @Override
         public String toString() {
             return "ProxyWriter.Ack("+oid+','+size+")";
         }
@@ -477,6 +494,7 @@ final class ProxyWriter extends Writer {
             w.dead(createdAt != null ? createdAt.getCause() : null);
         }
 
+        @Override
         public String toString() {
             return "ProxyWriter.Dead("+oid+")";
         }

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -440,6 +440,7 @@ final class RemoteClassLoader extends URLClassLoader {
         definePackage(packageName, null, null, null, null, null, null, null);
     }
 
+    @Override
     @CheckForNull
     public URL findResource(String name) {
         // first attempt to load from locally fetched jars
@@ -501,6 +502,7 @@ final class RemoteClassLoader extends URLClassLoader {
         return r;
     }
 
+    @Override
     public Enumeration<URL> findResources(String name) throws IOException {
         final Channel channel = channel();
         if (channel == null || !channel.isRemoteClassLoadingAllowed()) {
@@ -834,11 +836,13 @@ final class RemoteClassLoader extends URLClassLoader {
             this.channel = channel;
         }
 
+        @Override
         @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "This is only used for managing the jar cache as files.")
         public byte[] fetchJar(URL url) throws IOException {
             return readFully(url.openStream());
         }
 
+        @Override
         public byte[] fetch(String className) throws ClassNotFoundException {
             if (!USE_BOOTSTRAP_CLASSLOADER && cl == PSEUDO_BOOTSTRAP) {
                 throw new ClassNotFoundException("Classloading from bootstrap classloader disabled");
@@ -856,6 +860,7 @@ final class RemoteClassLoader extends URLClassLoader {
             }
         }
 
+        @Override
         public ClassFile fetch2(String className) throws ClassNotFoundException {
             ClassLoader ecl = cl.loadClass(className).getClassLoader();
             if (ecl == null) {
@@ -928,6 +933,7 @@ final class RemoteClassLoader extends URLClassLoader {
             }
         }
 
+        @Override
         @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "This is only used for managing the jar cache as files.")
         public Map<String, ClassFile2> fetch3(String className) throws ClassNotFoundException {
             ClassFile2 cf = fetch4(className, null);
@@ -977,6 +983,7 @@ final class RemoteClassLoader extends URLClassLoader {
             return resource;
         }
 
+        @Override
         @CheckForNull
         public ResourceFile getResource2(String name) throws IOException {
             URL resource = getResourceURL(name);
@@ -1063,6 +1070,7 @@ final class RemoteClassLoader extends URLClassLoader {
             return r;
         }
 
+        @Override
         public boolean equals(Object that) {
             if (this == that) {
                 return true;
@@ -1074,6 +1082,7 @@ final class RemoteClassLoader extends URLClassLoader {
             return cl.equals(((ClassLoaderProxy) that).cl);
         }
 
+        @Override
         public int hashCode() {
             return cl.hashCode();
         }
@@ -1117,18 +1126,22 @@ final class RemoteClassLoader extends URLClassLoader {
             this.oid = oid;
         }
 
+        @Override
         public byte[] fetchJar(URL url) throws IOException {
             return proxy.fetchJar(url);
         }
 
+        @Override
         public byte[] fetch(String className) throws ClassNotFoundException {
             return proxy.fetch(className);
         }
 
+        @Override
         public ClassFile fetch2(String className) throws ClassNotFoundException {
             return proxy.fetch2(className);
         }
 
+        @Override
         public Map<String, ClassFile2> fetch3(String className) throws ClassNotFoundException {
             return proxy.fetch3(className);
         }

--- a/src/main/java/hudson/remoting/RemoteInputStream.java
+++ b/src/main/java/hudson/remoting/RemoteInputStream.java
@@ -125,6 +125,7 @@ public class RemoteInputStream extends InputStream implements SerializableOnlyOv
                         setDaemon(true);
                     }
 
+                    @Override
                     public void run() {
                         try {
                             byte[] buf = new byte[8192];
@@ -265,38 +266,47 @@ public class RemoteInputStream extends InputStream implements SerializableOnlyOv
 //
 //
 
+    @Override
     public int read() throws IOException {
         return core.read();
     }
 
+    @Override
     public int read(byte[] b) throws IOException {
         return core.read(b);
     }
 
+    @Override
     public int read(byte[] b, int off, int len) throws IOException {
         return core.read(b, off, len);
     }
 
+    @Override
     public long skip(long n) throws IOException {
         return core.skip(n);
     }
 
+    @Override
     public int available() throws IOException {
         return core.available();
     }
 
+    @Override
     public void close() throws IOException {
         core.close();
     }
 
+    @Override
     public void mark(int readlimit) {
         core.mark(readlimit);
     }
 
+    @Override
     public void reset() throws IOException {
         core.reset();
     }
 
+    @Override
     public boolean markSupported() {
         return core.markSupported();
     }

--- a/src/main/java/hudson/remoting/RemoteInvocationHandler.java
+++ b/src/main/java/hudson/remoting/RemoteInvocationHandler.java
@@ -249,6 +249,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         return null;
     }
 
+    @Override
     @Nullable
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         if(method.getDeclaringClass()==IReadResolve.class) {
@@ -328,6 +329,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
     /**
      * Two proxies are the same iff they represent the same remote object.
      */
+    @Override
     public boolean equals(Object o) {
         if(o!=null && Proxy.isProxyClass(o.getClass()))
             o = Proxy.getInvocationHandler(o);
@@ -341,6 +343,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
 
     }
 
+    @Override
     public int hashCode() {
         return oid;
     }
@@ -901,6 +904,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
             assert types.length == arguments.length;
         }
 
+        @Override
         public Serializable call() throws Throwable {
             return perform(getChannelOrFail());
         }
@@ -918,6 +922,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
                 return getClass().getClassLoader();
         }
 
+        @Override
         protected Serializable perform(@Nonnull Channel channel) throws Throwable {
             Object o = channel.getExportedObject(oid);
             Class<?>[] clazz = channel.getExportedTypes(oid);

--- a/src/main/java/hudson/remoting/RemoteOutputStream.java
+++ b/src/main/java/hudson/remoting/RemoteOutputStream.java
@@ -96,22 +96,27 @@ public final class RemoteOutputStream extends OutputStream implements Serializab
 // delegation to core
 //
 //
+    @Override
     public void write(int b) throws IOException {
         core.write(b);
     }
 
+    @Override
     public void write(byte[] b) throws IOException {
         core.write(b);
     }
 
+    @Override
     public void write(byte[] b, int off, int len) throws IOException {
         core.write(b, off, len);
     }
 
+    @Override
     public void flush() throws IOException {
         core.flush();
     }
 
+    @Override
     public void close() throws IOException {
         core.close();
     }

--- a/src/main/java/hudson/remoting/RemoteWriter.java
+++ b/src/main/java/hudson/remoting/RemoteWriter.java
@@ -81,42 +81,52 @@ public final class RemoteWriter extends Writer implements SerializableOnlyOverRe
 // delegation to core
 //
 //
+    @Override
     public void write(int c) throws IOException {
         core.write(c);
     }
 
+    @Override
     public void write(char[] cbuf) throws IOException {
         core.write(cbuf);
     }
 
+    @Override
     public void write(char[] cbuf, int off, int len) throws IOException {
         core.write(cbuf, off, len);
     }
 
+    @Override
     public void write(String str) throws IOException {
         core.write(str);
     }
 
+    @Override
     public void write(String str, int off, int len) throws IOException {
         core.write(str, off, len);
     }
 
+    @Override
     public Writer append(CharSequence csq) throws IOException {
         return core.append(csq);
     }
 
+    @Override
     public Writer append(CharSequence csq, int start, int end) throws IOException {
         return core.append(csq, start, end);
     }
 
+    @Override
     public Writer append(char c) throws IOException {
         return core.append(c);
     }
 
+    @Override
     public void flush() throws IOException {
         core.flush();
     }
 
+    @Override
     public void close() throws IOException {
         core.close();
     }

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -240,6 +240,7 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
 
             private volatile boolean cancelled;
 
+            @Override
             public boolean cancel(boolean mayInterruptIfRunning) {
                 if (cancelled || isDone()) {
                     return false;
@@ -255,14 +256,17 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
                 return true;
             }
 
+            @Override
             public boolean isCancelled() {
                 return cancelled;
             }
 
+            @Override
             public boolean isDone() {
                 return isCancelled() || response!=null;
             }
 
+            @Override
             public RSP get() throws InterruptedException, ExecutionException {
                 synchronized(Request.this) {
                     String oldThreadName = Thread.currentThread().getName();
@@ -295,6 +299,7 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
                 }
             }
 
+            @Override
             public RSP get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
                 synchronized (Request.this) {
                     // wait until the response arrives
@@ -342,6 +347,7 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
     /**
      * Schedules the execution of this request.
      */
+    @Override
     final void execute(final Channel channel) {
         channel.executingCalls.put(id,this);
         future = channel.executor.submit(new Runnable() {
@@ -354,6 +360,7 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
                 return endIoId;
             }
 
+            @Override
             public void run() {
                 String oldThreadName = Thread.currentThread().getName();
                 Thread.currentThread().setName(oldThreadName+" for "+channel.getName()+" id="+id);
@@ -435,6 +442,7 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
             this.id = id;
         }
 
+        @Override
         protected void execute(Channel channel) {
             Request<?,?> r = channel.executingCalls.get(id);
             if(r==null)     return; // already completed

--- a/src/main/java/hudson/remoting/SingleLaneExecutorService.java
+++ b/src/main/java/hudson/remoting/SingleLaneExecutorService.java
@@ -64,6 +64,7 @@ public class SingleLaneExecutorService extends AbstractExecutorService {
      * <p>
      * Note that this does not shutdown the wrapped {@link ExecutorService}.
      */
+    @Override
     public synchronized void shutdown() {
         shuttingDown = true;
         if (tasks.isEmpty())
@@ -76,6 +77,7 @@ public class SingleLaneExecutorService extends AbstractExecutorService {
      * <p>
      * Note that this does not shutdown the wrapped {@link ExecutorService}.
      */
+    @Override
     public synchronized List<Runnable> shutdownNow() {
         shuttingDown = shutDown = true;
         List<Runnable> all = new LinkedList<Runnable>(tasks);
@@ -83,14 +85,17 @@ public class SingleLaneExecutorService extends AbstractExecutorService {
         return all;
     }
 
+    @Override
     public synchronized boolean isShutdown() {
         return shuttingDown;
     }
 
+    @Override
     public synchronized boolean isTerminated() {
         return shutDown;
     }
 
+    @Override
     public synchronized boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         long now = System.nanoTime();
         long end = now + unit.toNanos(timeout);

--- a/src/main/java/hudson/remoting/SocketChannelStream.java
+++ b/src/main/java/hudson/remoting/SocketChannelStream.java
@@ -31,10 +31,12 @@ public class SocketChannelStream {
         final Socket s = ch.socket();
 
         return Channels.newInputStream(new ReadableByteChannel() {
+            @Override
             public int read(ByteBuffer dst) throws IOException {
                 return ch.read(dst);
             }
 
+            @Override
             public void close() throws IOException {
                 if (!s.isInputShutdown()) {
                     try {
@@ -49,6 +51,7 @@ public class SocketChannelStream {
                 }
             }
 
+            @Override
             public boolean isOpen() {
                 return !s.isInputShutdown();
             }
@@ -66,10 +69,12 @@ public class SocketChannelStream {
         final Socket s = ch.socket();
 
         return Channels.newOutputStream(new WritableByteChannel() {
+            @Override
             public int write(ByteBuffer src) throws IOException {
                 return ch.write(src);
             }
 
+            @Override
             public void close() throws IOException {
                 if (!s.isOutputShutdown()) {
                     try {
@@ -84,6 +89,7 @@ public class SocketChannelStream {
                 }
             }
 
+            @Override
             public boolean isOpen() {
                 return !s.isOutputShutdown();
             }

--- a/src/main/java/hudson/remoting/SocketOutputStream.java
+++ b/src/main/java/hudson/remoting/SocketOutputStream.java
@@ -51,14 +51,17 @@ public class SocketOutputStream extends FilterOutputStream {
         this.socket = socket;
     }
 
+    @Override
     public void write(int b) throws IOException {
         out.write(b);
     }
 
+    @Override
     public void write(byte[] b) throws IOException {
         out.write(b);
     }
 
+    @Override
     public void write(byte[] b, int off, int len) throws IOException {
         out.write(b, off, len);
     }

--- a/src/main/java/hudson/remoting/SynchronousExecutorService.java
+++ b/src/main/java/hudson/remoting/SynchronousExecutorService.java
@@ -15,23 +15,28 @@ class SynchronousExecutorService extends AbstractExecutorService {
     private volatile boolean shutdown = false;
     private int count = 0;
 
+    @Override
     public void shutdown() {
         shutdown = true;
     }
 
+    @Override
     public List<Runnable> shutdownNow() {
         shutdown = true;
         return Collections.emptyList();
     }
 
+    @Override
     public boolean isShutdown() {
         return shutdown;
     }
 
+    @Override
     public synchronized boolean isTerminated() {
         return shutdown && count==0;
     }
 
+    @Override
     public synchronized boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         long now = System.nanoTime();
         long end = now + unit.toNanos(timeout);
@@ -47,6 +52,7 @@ class SynchronousExecutorService extends AbstractExecutorService {
         return true;
     }
 
+    @Override
     public void execute(Runnable command) {
         if (shutdown)
             throw new IllegalStateException("Already shut down");

--- a/src/main/java/hudson/remoting/TeeOutputStream.java
+++ b/src/main/java/hudson/remoting/TeeOutputStream.java
@@ -51,6 +51,7 @@ public class TeeOutputStream extends FilterOutputStream {
      * @param b the bytes to write
      * @throws IOException if an I/O error occurs
      */
+    @Override
     public synchronized void write(byte[] b) throws IOException {
         super.write(b);
         this.branch.write(b);
@@ -63,6 +64,7 @@ public class TeeOutputStream extends FilterOutputStream {
      * @param len The number of bytes to write
      * @throws IOException if an I/O error occurs
      */
+    @Override
     public synchronized void write(byte[] b, int off, int len) throws IOException {
         super.write(b, off, len);
         this.branch.write(b, off, len);
@@ -73,6 +75,7 @@ public class TeeOutputStream extends FilterOutputStream {
      * @param b the byte to write
      * @throws IOException if an I/O error occurs
      */
+    @Override
     public synchronized void write(int b) throws IOException {
         super.write(b);
         this.branch.write(b);
@@ -82,6 +85,7 @@ public class TeeOutputStream extends FilterOutputStream {
      * Flushes both streams.
      * @throws IOException if an I/O error occurs
      */
+    @Override
     public void flush() throws IOException {
         super.flush();
         this.branch.flush();
@@ -91,6 +95,7 @@ public class TeeOutputStream extends FilterOutputStream {
      * Closes both streams.
      * @throws IOException if an I/O error occurs
      */
+    @Override
     public void close() throws IOException {
         super.close();
         this.branch.close();

--- a/src/main/java/hudson/remoting/UnexportCommand.java
+++ b/src/main/java/hudson/remoting/UnexportCommand.java
@@ -45,6 +45,7 @@ public class UnexportCommand extends Command {
         this(oid,null);
     }
 
+    @Override
     protected void execute(Channel channel) {
         channel.unexport(oid,createdAt);
     }

--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -298,6 +298,7 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserRequest.R
         exports.release(callSite);
     }
 
+    @Override
     public String toString() {
         return "UserRequest:"+toString;
     }
@@ -379,6 +380,7 @@ final class UserResponse<RSP,EXC extends Throwable> implements UserRequest.Respo
     /**
      * Deserializes the response byte stream into an object.
      */
+    @Override
     public RSP retrieve(Channel channel, ClassLoader cl) throws IOException, ClassNotFoundException, EXC {
         Channel old = Channel.setCurrent(channel);
         try {

--- a/src/main/java/hudson/remoting/forward/CopyThread.java
+++ b/src/main/java/hudson/remoting/forward/CopyThread.java
@@ -38,6 +38,7 @@ final class CopyThread extends Thread {
         });
     }
 
+    @Override
     public void run() {
         try {
             byte[] buf = new byte[8192];

--- a/src/main/java/hudson/remoting/forward/ForwarderFactory.java
+++ b/src/main/java/hudson/remoting/forward/ForwarderFactory.java
@@ -70,6 +70,7 @@ public class ForwarderFactory {
             this.remotePort = remotePort;
         }
 
+        @Override
         @SuppressFBWarnings(value = "UNENCRYPTED_SOCKET", justification = "Unused mechanism.")
         public OutputStream connect(OutputStream out) throws IOException {
             Socket s = new Socket(remoteHost, remotePort);
@@ -115,6 +116,7 @@ public class ForwarderFactory {
             this.remotePort = remotePort;
         }
 
+        @Override
         public Forwarder call() throws IOException {
             return new ForwarderImpl(remoteHost, remotePort);
         }

--- a/src/main/java/hudson/remoting/forward/ListeningPort.java
+++ b/src/main/java/hudson/remoting/forward/ListeningPort.java
@@ -20,5 +20,6 @@ public interface ListeningPort extends Closeable {
      * Connections that are already established will not be affected
      * by this operation.
      */
+    @Override
     void close() throws IOException;
 }

--- a/src/main/java/hudson/remoting/forward/PortForwarder.java
+++ b/src/main/java/hudson/remoting/forward/PortForwarder.java
@@ -72,6 +72,7 @@ public class PortForwarder extends Thread implements Closeable, ListeningPort {
         });
     }
 
+    @Override
     public int getPort() {
         return socket.getLocalPort();
     }
@@ -87,6 +88,7 @@ public class PortForwarder extends Thread implements Closeable, ListeningPort {
                             setUncaughtExceptionHandler(
                                     (t, e) -> LOGGER.log(Level.SEVERE, "Unhandled exception in port forwarding session " + t, e));
                         }
+                        @Override
                         public void run() {
                             try (InputStream in = SocketChannelStream.in(s);
                                     OutputStream out = forwarder.connect(new RemoteOutputStream(SocketChannelStream.out(s)))) {
@@ -119,6 +121,7 @@ public class PortForwarder extends Thread implements Closeable, ListeningPort {
     /**
      * Shuts down this port forwarder.
      */
+    @Override
     public void close() throws IOException {
         interrupt();
         socket.close();
@@ -155,6 +158,7 @@ public class PortForwarder extends Thread implements Closeable, ListeningPort {
             this.proxy = proxy;
         }
 
+        @Override
         public ListeningPort call() throws IOException {
             final Channel channel = getOpenChannelOrFail(); // We initialize it early, so the forwarder won's start its daemon if the channel is shutting down
             PortForwarder t = new PortForwarder(acceptingPort, proxy);

--- a/src/main/java/hudson/remoting/jnlp/GuiListener.java
+++ b/src/main/java/hudson/remoting/jnlp/GuiListener.java
@@ -46,12 +46,15 @@ public final class GuiListener implements EngineListener {
         frame.setVisible(true);
     }
 
+    @Override
     public void status(final String msg) {
         status(msg,null);
     }
 
+    @Override
     public void status(final String msg, final Throwable t) {
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 frame.status(msg);
                 if(t!=null)
@@ -77,8 +80,10 @@ public final class GuiListener implements EngineListener {
         });
     }
 
+    @Override
     public void onDisconnect() {
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 // discard all the menu items that might have been added by the master.
                 frame.resetMenuBar();
@@ -86,6 +91,7 @@ public final class GuiListener implements EngineListener {
         });
     }
 
+    @Override
     public void onReconnect() {
     }
 

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -419,14 +419,17 @@ public class Main {
             LOGGER.info("Jenkins agent is running in headless mode.");
         }
 
+        @Override
         public void status(String msg, Throwable t) {
             LOGGER.log(INFO,msg,t);
         }
 
+        @Override
         public void status(String msg) {
             status(msg,null);
         }
 
+        @Override
         @SuppressFBWarnings(value = "DM_EXIT",
                 justification = "Yes, we really want to exit in the case of severe error")
         public void error(Throwable t) {
@@ -434,9 +437,11 @@ public class Main {
             System.exit(-1);
         }
 
+        @Override
         public void onDisconnect() {
         }
 
+        @Override
         public void onReconnect() {
         }
     }

--- a/src/main/java/org/jenkinsci/remoting/nio/Closeables.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/Closeables.java
@@ -18,6 +18,7 @@ class Closeables {
         if (ch instanceof SocketChannel) {
             final SocketChannel s = (SocketChannel) ch;
             return new Closeable() {
+                @Override
                 public void close() throws IOException {
                     try {
                         s.socket().shutdownInput();
@@ -38,6 +39,7 @@ class Closeables {
         if (ch instanceof SocketChannel) {
             final SocketChannel s = (SocketChannel) ch;
             return new Closeable() {
+                @Override
                 public void close() throws IOException {
                     try {
                         s.socket().shutdownOutput();

--- a/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
@@ -417,6 +417,7 @@ public class FifoBuffer implements Closeable {
      * Once the remaining bytes are drained by the reader, the read method will start
      * returning EOF signals.
      */
+    @Override
     public void close() {
         // Async modification of the field in order to notify other threads that we are about closing this buffer
         closeRequested = true;

--- a/src/main/java/org/jenkinsci/remoting/nio/NioChannelBuilder.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/NioChannelBuilder.java
@@ -31,6 +31,7 @@ public abstract class NioChannelBuilder extends ChannelBuilder {
         super(name, executors);
     }
 
+    @Override
     public Channel build(SocketChannel socket) throws IOException {
         this.r = socket;
         this.w = socket;

--- a/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
@@ -549,6 +549,7 @@ public class NioChannelHub implements Runnable, Closeable {
     /**
      * Shuts down the selector thread and aborts all
      */
+    @Override
     public void close() throws IOException {
         selector.close();
     }
@@ -558,6 +559,7 @@ public class NioChannelHub implements Runnable, Closeable {
      *
      * This method returns when {@link #close()} is called and the selector is shut down.
      */
+    @Override
     public void run() {
         synchronized (startedLock) {
             started = true;

--- a/src/main/java/org/jenkinsci/remoting/protocol/FilterLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/FilterLayer.java
@@ -272,6 +272,7 @@ public abstract class FilterLayer implements ProtocolLayer, ProtocolLayer.Send, 
     /**
      * {@inheritDoc}
      */
+    @Override
     @OverridingMethodsMustInvokeSuper
     public void onRecvClosed(IOException cause) throws IOException {
         if (LOGGER.isLoggable(Level.FINEST)) {
@@ -313,6 +314,7 @@ public abstract class FilterLayer implements ProtocolLayer, ProtocolLayer.Send, 
     /**
      * {@inheritDoc}
      */
+    @Override
     @OverridingMethodsMustInvokeSuper
     public void doCloseSend() throws IOException {
         if (LOGGER.isLoggable(Level.FINEST)) {

--- a/src/main/java/org/jenkinsci/remoting/protocol/IOHub.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/IOHub.java
@@ -994,6 +994,7 @@ public class IOHub implements Executor, Closeable, Runnable, ByteBufferPool {
         /**
          * {@inheritDoc}
          */
+        @Override
         public synchronized boolean isCancelled() {
             return task == null;
         }

--- a/src/main/java/org/jenkinsci/remoting/util/DirectByteBufferPool.java
+++ b/src/main/java/org/jenkinsci/remoting/util/DirectByteBufferPool.java
@@ -66,6 +66,7 @@ public class DirectByteBufferPool implements ByteBufferPool {
     /**
      * {@inheritDoc}
      */
+    @Override
     public ByteBuffer acquire(int size) {
         synchronized (this) {
             if (poolCount > 0) {
@@ -97,6 +98,7 @@ public class DirectByteBufferPool implements ByteBufferPool {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void release(ByteBuffer buffer) {
         if (buffer.isDirect() && !buffer.isReadOnly() && buffer.capacity() >= bufferSize) {
             synchronized (this) {

--- a/src/main/java/org/jenkinsci/remoting/util/VersionNumber.java
+++ b/src/main/java/org/jenkinsci/remoting/util/VersionNumber.java
@@ -99,6 +99,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
      */
     private static class WildCardItem implements Item {
 
+        @Override
         public int compare(Item item) {
             if (item==null) // 1.* ( > 1.99) > 1
                 return 1;
@@ -114,10 +115,12 @@ public class VersionNumber implements Comparable<VersionNumber> {
             }
         }
 
+        @Override
         public int getType() {
             return WILDCARD_ITEM;
         }
 
+        @Override
         public boolean isNull() {
             return false;
         }
@@ -147,14 +150,17 @@ public class VersionNumber implements Comparable<VersionNumber> {
             this.value = new BigInteger(str);
         }
 
+        @Override
         public int getType() {
             return INTEGER_ITEM;
         }
 
+        @Override
         public boolean isNull() {
             return BigInteger_ZERO.equals(value);
         }
 
+        @Override
         public int compare(Item item) {
             if (item == null) {
                 return BigInteger_ZERO.equals(value) ? 0 : 1; // 1.0 == 1, 1.1 > 1
@@ -180,6 +186,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
             }
         }
 
+        @Override
         public String toString() {
             return value.toString();
         }
@@ -230,10 +237,12 @@ public class VersionNumber implements Comparable<VersionNumber> {
             this.value = ALIASES.getProperty(value, value);
         }
 
+        @Override
         public int getType() {
             return STRING_ITEM;
         }
 
+        @Override
         public boolean isNull() {
             return (comparableQualifier(value).compareTo(RELEASE_VERSION_INDEX) == 0);
         }
@@ -257,6 +266,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
             return i == -1 ? _QUALIFIERS.size() + "-" + qualifier : String.valueOf(i);
         }
 
+        @Override
         public int compare(Item item) {
             if (item == null) {
                 // 1-rc < 1, 1-ga > 1
@@ -282,6 +292,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
             }
         }
 
+        @Override
         public String toString() {
             return value;
         }
@@ -294,10 +305,12 @@ public class VersionNumber implements Comparable<VersionNumber> {
     private static class ListItem extends ArrayList<Item> implements Item {
         private static final long serialVersionUID = 1;
 
+        @Override
         public int getType() {
             return LIST_ITEM;
         }
 
+        @Override
         public boolean isNull() {
             return (size() == 0);
         }
@@ -313,6 +326,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
             }
         }
 
+        @Override
         public int compare(Item item) {
             if (item == null) {
                 if (size() == 0) {
@@ -366,6 +380,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
             }
         }
 
+        @Override
         public String toString() {
             StringBuilder buffer = new StringBuilder("(");
             for (Iterator<Item> iter = iterator(); iter.hasNext(); ) {
@@ -481,6 +496,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
         return isDigit ? new IntegerItem(buf) : new StringItem(buf, false);
     }
 
+    @Override
     public int compareTo(VersionNumber o) {
         int result = items.compare(o.items);
         if (result != 0) {
@@ -505,10 +521,12 @@ public class VersionNumber implements Comparable<VersionNumber> {
         return (i1 < i2) ? -1 : ((i1 == i2) ? 0 : 1);
     }
 
+    @Override
     public String toString() {
         return value;
     }
 
+    @Override
     public boolean equals(Object o) {
         if (!(o instanceof VersionNumber)) {
             return false;
@@ -527,6 +545,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
         return snapshot.equals(that.snapshot);
     }
 
+    @Override
     public int hashCode() {
         return canonical.hashCode();
     }
@@ -574,6 +593,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
     }
 
     public static final Comparator<VersionNumber> DESCENDING = new Comparator<VersionNumber>() {
+        @Override
         public int compare(VersionNumber o1, VersionNumber o2) {
             return o2.compareTo(o1);
         }

--- a/src/main/java/org/jenkinsci/remoting/util/https/NoCheckTrustManager.java
+++ b/src/main/java/org/jenkinsci/remoting/util/https/NoCheckTrustManager.java
@@ -40,12 +40,15 @@ import java.security.cert.X509Certificate;
 @Restricted(NoExternalUse.class)
 @SuppressFBWarnings(value = "WEAK_TRUST_MANAGER", justification = "User set parameter to skip verifier.")
 public class NoCheckTrustManager implements X509TrustManager {
+    @Override
     public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
     }
 
+    @Override
     public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
     }
 
+    @Override
     public X509Certificate[] getAcceptedIssuers() {
         return new X509Certificate[0];
     }

--- a/src/test/java/hudson/remoting/AbstractNioChannelRunner.java
+++ b/src/test/java/hudson/remoting/AbstractNioChannelRunner.java
@@ -19,6 +19,7 @@ public abstract class AbstractNioChannelRunner implements DualSideChannelRunner 
     protected Channel south;
 
 
+    @Override
     public void stop(Channel channel) throws Exception {
         channel.close();
         channel.join();

--- a/src/test/java/hudson/remoting/ChannelFilterTest.java
+++ b/src/test/java/hudson/remoting/ChannelFilterTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.Callable;
 public class ChannelFilterTest extends RmiTestBase {
     public void testFilter() throws Exception {
         channel.addLocalExecutionInterceptor(new CallableDecorator() {
+            @Override
             public <V> V call(Callable<V> callable) throws Exception {
                 Object old = STORE.get();
                 STORE.set("x");
@@ -36,6 +37,7 @@ public class ChannelFilterTest extends RmiTestBase {
             this.c = c;
         }
 
+        @Override
         public Object call() throws Exception {
            return c.call();
         }
@@ -85,6 +87,7 @@ public class ChannelFilterTest extends RmiTestBase {
     private interface ShadyBusiness {}
 
     static class GunImporter extends CallableBase<String,IOException> implements ShadyBusiness {
+        @Override
         public String call() {
             return "gun";
         }
@@ -92,6 +95,7 @@ public class ChannelFilterTest extends RmiTestBase {
     }
 
     static class ReverseGunImporter extends CallableBase<String, Exception> {
+        @Override
         public String call() throws Exception {
             return Channel.currentOrFail().call(new GunImporter());
         }

--- a/src/test/java/hudson/remoting/ChannelTest.java
+++ b/src/test/java/hudson/remoting/ChannelTest.java
@@ -44,6 +44,7 @@ public class ChannelTest extends RmiTestBase {
     }
 
     private static class CallableImpl extends CallableBase<Object,IOException> {
+        @Override
         public Object call() throws IOException {
             return null;
         }
@@ -121,6 +122,7 @@ public class ChannelTest extends RmiTestBase {
     }
 
     private static class WaitForRemotePropertyCallable extends CallableBase<Void, Exception> {
+        @Override
         public Void call() throws Exception {
             Thread.sleep(500);
             getChannelOrFail().setProperty("foo","bar");
@@ -135,6 +137,7 @@ public class ChannelTest extends RmiTestBase {
 
     private static class GreeterImpl implements Greeter, SerializableOnlyOverRemoting {
         String name;
+        @Override
         public void greet(String name) {
             this.name = name;
         }
@@ -151,6 +154,7 @@ public class ChannelTest extends RmiTestBase {
             this.g = g;
         }
 
+        @Override
         public Object call() throws IOException {
             g.greet("Kohsuke");
             return null;
@@ -172,6 +176,7 @@ public class ChannelTest extends RmiTestBase {
             this.t = t;
         }
 
+        @Override
         public T call() throws RuntimeException {
             return t;
         }

--- a/src/test/java/hudson/remoting/ChunkedInputStreamTest.java
+++ b/src/test/java/hudson/remoting/ChunkedInputStreamTest.java
@@ -48,6 +48,7 @@ public class ChunkedInputStreamTest extends Assert {
         test(new Workload() {
             int size = 1024;
 
+            @Override
             public void write(OutputStream o) throws IOException {
                 Random boundary = new Random(0);
                 Random data = new Random(1);
@@ -62,6 +63,7 @@ public class ChunkedInputStreamTest extends Assert {
                 o.close();
             }
 
+            @Override
             public void read(InputStream i) throws IOException {
                 Random boundary = new Random(0);
                 Random data = new Random(1);

--- a/src/test/java/hudson/remoting/ClassRemotingTest.java
+++ b/src/test/java/hudson/remoting/ClassRemotingTest.java
@@ -182,6 +182,7 @@ public class ClassRemotingTest extends RmiTestBase {
     }
 
     private static class RemotePropertyVerifier extends CallableBase<Object, IOException> {
+        @Override
         public Object call() throws IOException {
             Object o = getOpenChannelOrFail().getRemoteProperty("test");
             assertEquals(o.getClass().getName(), CLASSNAME);

--- a/src/test/java/hudson/remoting/Copier.java
+++ b/src/test/java/hudson/remoting/Copier.java
@@ -42,6 +42,7 @@ class Copier extends Thread {
         this.out = out;
     }
 
+    @Override
     public void run() {
         try {
             byte[] buf = new byte[8192];

--- a/src/test/java/hudson/remoting/DeadRemoteOutputStreamTest.java
+++ b/src/test/java/hudson/remoting/DeadRemoteOutputStreamTest.java
@@ -36,6 +36,7 @@ public class DeadRemoteOutputStreamTest extends RmiTestBase implements Serializa
             this.os = os;
         }
 
+        @Override
         public Void call() throws Exception {
             os.write(0); // this write will go through because we won't notice that it's dead
             System.gc();

--- a/src/test/java/hudson/remoting/DefaultClassFilterTest.java
+++ b/src/test/java/hudson/remoting/DefaultClassFilterTest.java
@@ -133,6 +133,7 @@ public class DefaultClassFilterTest {
     /** Simple hamcrest matcher that checks if the provided className is blacklisted. */
     static class BlackListMatcher extends org.hamcrest.BaseMatcher<String> {
 
+        @Override
         public void describeMismatch(Object item, Description description) {
             description.appendValue(item).appendText(" was not blacklisted");
         }
@@ -141,6 +142,7 @@ public class DefaultClassFilterTest {
             return new BlackListMatcher();
         }
 
+        @Override
         public boolean matches(Object item) {
             try {
                 ClassFilter.createDefaultInstance().check(item.toString());
@@ -152,6 +154,7 @@ public class DefaultClassFilterTest {
             }
         }
 
+        @Override
         public void describeTo(Description description) {
             description.appendText("blacklisted");
         }

--- a/src/test/java/hudson/remoting/DummyClassLoader.java
+++ b/src/test/java/hudson/remoting/DummyClassLoader.java
@@ -118,6 +118,7 @@ class DummyClassLoader extends ClassLoader {
     }
 
 
+    @Override
     protected Class<?> findClass(String name) throws ClassNotFoundException {
         for (Entry e : entries) {
             if(name.equals(e.logicalName)) {
@@ -135,6 +136,7 @@ class DummyClassLoader extends ClassLoader {
     }
 
 
+    @Override
     protected URL findResource(String name) {
         for (Entry e : entries) {
             if (name.equals(e.logicalPath)) {

--- a/src/test/java/hudson/remoting/ForkRunner.java
+++ b/src/test/java/hudson/remoting/ForkRunner.java
@@ -34,6 +34,7 @@ public class ForkRunner implements ChannelRunner {
         return r;
     }
 
+    @Override
     public Channel start() throws Exception {
         System.out.println("forking a new process");
         // proc = Runtime.getRuntime().exec("java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=8000 hudson.remoting.Launcher");
@@ -55,6 +56,7 @@ public class ForkRunner implements ChannelRunner {
         return new ChannelBuilder("north", executor).build(proc.getInputStream(), out);
     }
 
+    @Override
     public void stop(Channel channel) throws Exception {
         channel.close();
         channel.join(10*1000);
@@ -70,6 +72,7 @@ public class ForkRunner implements ChannelRunner {
         assertEquals("exit code should have been 0", 0, r);
     }
 
+    @Override
     public String getName() {
         return "fork";
     }

--- a/src/test/java/hudson/remoting/InProcessCompatibilityRunner.java
+++ b/src/test/java/hudson/remoting/InProcessCompatibilityRunner.java
@@ -4,6 +4,7 @@ package hudson.remoting;
 * @author Kohsuke Kawaguchi
 */
 public class InProcessCompatibilityRunner extends InProcessRunner {
+    @Override
     public String getName() {
         return "local-compatibility";
     }

--- a/src/test/java/hudson/remoting/InProcessRunner.java
+++ b/src/test/java/hudson/remoting/InProcessRunner.java
@@ -20,6 +20,7 @@ public class InProcessRunner implements DualSideChannelRunner {
     private Exception failure;
     private Channel south;
 
+    @Override
     public Channel start() throws Exception {
         final FastPipedInputStream in1 = new FastPipedInputStream();
         final FastPipedOutputStream out1 = new FastPipedOutputStream(in1);
@@ -32,6 +33,7 @@ public class InProcessRunner implements DualSideChannelRunner {
         executor = Executors.newCachedThreadPool();
 
         Thread t = new Thread("south bridge runner") {
+            @Override
             public void run() {
                 try {
                     Channel south = configureSouth().build(in2,out1);
@@ -63,6 +65,7 @@ public class InProcessRunner implements DualSideChannelRunner {
                 .withCapability(createCapability());
     }
 
+    @Override
     public void stop(Channel channel) throws Exception {
         channel.close();
         channel.join();
@@ -75,6 +78,7 @@ public class InProcessRunner implements DualSideChannelRunner {
             throw failure;  // report a failure in the south side
     }
 
+    @Override
     public String getName() {
         return "local";
     }

--- a/src/test/java/hudson/remoting/NioPipeRunner.java
+++ b/src/test/java/hudson/remoting/NioPipeRunner.java
@@ -19,6 +19,7 @@ import java.util.logging.Logger;
  * @author Kohsuke Kawaguchi
  */
 public class NioPipeRunner extends AbstractNioChannelRunner {
+    @Override
     public Channel start() throws Exception {
         final SynchronousQueue<Channel> southHandoff = new SynchronousQueue<>();
 
@@ -56,6 +57,7 @@ public class NioPipeRunner extends AbstractNioChannelRunner {
         return north;
     }
 
+    @Override
     public String getName() {
         return "NIO+pipe";
     }

--- a/src/test/java/hudson/remoting/NioSocketRunner.java
+++ b/src/test/java/hudson/remoting/NioSocketRunner.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.*;
  * Runs a channel over NIO+socket.
  */
 public class NioSocketRunner extends AbstractNioChannelRunner {
+    @Override
     public Channel start() throws Exception {
         final SynchronousQueue<Channel> southHandoff = new SynchronousQueue<>();
 
@@ -83,6 +84,7 @@ public class NioSocketRunner extends AbstractNioChannelRunner {
     }
 
 
+    @Override
     public String getName() {
         return "NIO+socket";
     }

--- a/src/test/java/hudson/remoting/NonSerializableExceptionTest.java
+++ b/src/test/java/hudson/remoting/NonSerializableExceptionTest.java
@@ -59,6 +59,7 @@ public class NonSerializableExceptionTest extends RmiTestBase {
     }
 
     private static final class Failure extends CallableBase<Object, Throwable> {
+        @Override
         public Object call() throws Throwable {
             throw new NoneSerializableException("message1",new SocketException("message2"));
         }

--- a/src/test/java/hudson/remoting/PipeTest.java
+++ b/src/test/java/hudson/remoting/PipeTest.java
@@ -93,6 +93,7 @@ public class PipeTest extends RmiTestBase implements Serializable {
             this.pipe = pipe;
         }
 
+        @Override
         public Void call() throws Exception {
             while (true) {
                 pipe.getOut().write(0);
@@ -109,6 +110,7 @@ public class PipeTest extends RmiTestBase implements Serializable {
             this.pipe = pipe;
         }
 
+        @Override
         public Integer call() throws IOException {
             write(pipe);
             return 5;
@@ -198,17 +200,21 @@ public class PipeTest extends RmiTestBase implements Serializable {
             this.pipe = pipe;
         }
 
+        @Override
         public ISaturationTest call() throws IOException {
             return Channel.currentOrFail().export(ISaturationTest.class, new ISaturationTest() {
                 private InputStream in;
+                @Override
                 public void ensureConnected() {
                     in = pipe.getIn();
                 }
 
+                @Override
                 public int readFirst() throws IOException {
                     return in.read();
                 }
 
+                @Override
                 public void readRest() throws IOException {
                     new DataInputStream(in).readFully(new byte[Channel.PIPE_WINDOW_SIZE*2]);
                 }
@@ -224,6 +230,7 @@ public class PipeTest extends RmiTestBase implements Serializable {
             this.pipe = pipe;
         }
 
+        @Override
         public Integer call() throws IOException {
             try {
                 read(pipe);
@@ -281,6 +288,7 @@ public class PipeTest extends RmiTestBase implements Serializable {
     }
 
     private static class DevNullSink extends CallableBase<OutputStream, IOException> {
+        @Override
         public OutputStream call() throws IOException {
             return new RemoteOutputStream(new NullOutputStream());
         }
@@ -302,6 +310,7 @@ public class PipeTest extends RmiTestBase implements Serializable {
             this.p = p;
         }
 
+        @Override
         public Integer call() throws IOException {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             IOUtils.copy(p.getIn(), baos);

--- a/src/test/java/hudson/remoting/PipeWriterTest.java
+++ b/src/test/java/hudson/remoting/PipeWriterTest.java
@@ -31,6 +31,7 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
      * Base test case for the response / IO coordination.
      */
     abstract class ResponseIoCoordCallable extends CallableBase<Object,Exception> {
+        @Override
         public Object call() throws Exception {
             long start = System.currentTimeMillis();
             System.out.println("touch");
@@ -102,6 +103,7 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
      * Base test case for the request / IO coordination.
      */
     abstract class RequestIoCoordCallable extends CallableBase<Object,Exception> {
+        @Override
         public Object call() throws IOException {
             long start = System.currentTimeMillis();
             System.out.println("touch");
@@ -135,12 +137,14 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
         assertSlowStreamTouched();
     }
 
+    @Override
     public void assertSlowStreamNotTouched() {
         assertFalse(slow.closed);
         assertFalse(slow.flushed);
         assertFalse(slow.written);
     }
 
+    @Override
     public void assertSlowStreamTouched() {
         assertTrue(slow.closed || slow.flushed || slow.written);
     }
@@ -179,6 +183,7 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
     }
 
     private class ResponseCallableWriter extends ResponseIoCoordCallable {
+        @Override
         void touch() throws IOException {
             ros.write(0);
         }
@@ -186,6 +191,7 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
     }
 
     private class ResponseCallableFlusher extends ResponseIoCoordCallable {
+        @Override
         void touch() throws IOException {
             ros.flush();
         }
@@ -193,6 +199,7 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
     }
 
     private class ResponseCallableCloser extends ResponseIoCoordCallable {
+        @Override
         void touch() throws IOException {
             ros.close();
         }
@@ -200,6 +207,7 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
     }
 
     private class RequestCallableWriter extends RequestIoCoordCallable {
+        @Override
         void touch() throws IOException {
             ros.write(0);
         }
@@ -207,6 +215,7 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
     }
 
     private class RequestCallableFlusher extends RequestIoCoordCallable {
+        @Override
         void touch() throws IOException {
             ros.flush();
         }
@@ -214,6 +223,7 @@ public class PipeWriterTest extends RmiTestBase implements Serializable, PipeWri
     }
 
     private class RequestCallableCloser extends RequestIoCoordCallable {
+        @Override
         void touch() throws IOException {
             ros.close();
         }

--- a/src/test/java/hudson/remoting/PrefetchTest.java
+++ b/src/test/java/hudson/remoting/PrefetchTest.java
@@ -43,6 +43,7 @@ public class PrefetchTest extends RmiTestBase {
     }
 
     private static class VerifyTask extends CallableBase<String,IOException> {
+        @Override
         public String call() throws IOException {
             StackMapAttribute sma = new StackMapAttribute();
             return Which.jarFile(sma.getClass()).getPath();

--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -96,6 +96,7 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
     }
 
     private static class Verifier implements Function<Object,Object>, Serializable {
+        @Override
         public Object apply(Object o) {
             try {
                 // verify that 'o' is loaded from a jar file
@@ -199,6 +200,7 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
     private static final class Echo<V> extends CallableBase<V,IOException> implements Serializable {
         V value;
 
+        @Override
         public V call() {
             return value;
         }
@@ -216,6 +218,7 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
             this.sum2 = sum.sum2;
         }
 
+        @Override
         public Void call() throws IOException {
             try {
                 final Channel ch = Channel.currentOrFail();
@@ -233,6 +236,7 @@ public class PrefetchingTest extends RmiTestBase implements Serializable {
     }
 
     private class JarCacherCallable extends CallableBase<Void, IOException> {
+        @Override
         public Void call() throws IOException {
             Channel.currentOrFail().setJarCache(new FileSystemJarCache(dir, true));
             return null;

--- a/src/test/java/hudson/remoting/ProxyWriterTest.java
+++ b/src/test/java/hudson/remoting/ProxyWriterTest.java
@@ -141,6 +141,7 @@ public class ProxyWriterTest extends RmiTestBase implements Serializable {
             this.w = w;
         }
 
+        @Override
         public Void call() throws IOException {
             writeBunchOfData(w);
             return null;
@@ -155,6 +156,7 @@ public class ProxyWriterTest extends RmiTestBase implements Serializable {
             this.w = w;
         }
 
+        @Override
         public Void call() throws IOException {
             w.write("hello");
             W = new WeakReference<>(w);
@@ -163,6 +165,7 @@ public class ProxyWriterTest extends RmiTestBase implements Serializable {
     }
 
     private static class GcCallable extends CallableBase<Boolean, IOException> {
+        @Override
         public Boolean call() throws IOException {
             System.gc();
             return W.get() == null;
@@ -177,6 +180,7 @@ public class ProxyWriterTest extends RmiTestBase implements Serializable {
             this.w = w;
         }
 
+        @Override
         public Void call() throws IOException {
             w.write("1--", 0, 1);
             return null;

--- a/src/test/java/hudson/remoting/RemoteInputStreamTest.java
+++ b/src/test/java/hudson/remoting/RemoteInputStreamTest.java
@@ -58,6 +58,7 @@ public class RemoteInputStreamTest extends RmiTestBase {
             this.expected = expected;
         }
 
+        @Override
         public Object call() throws IOException {
             assertArrayEquals(readFully(in, expected.length), expected);
             return null;
@@ -84,6 +85,7 @@ public class RemoteInputStreamTest extends RmiTestBase {
             this.i = i;
         }
 
+        @Override
         public Void call() throws IOException {
             assertEquals(readFully(i, 4), toBytes("1234"));
             assertEquals(readFully(i, 4), toBytes("5678"));
@@ -118,6 +120,7 @@ public class RemoteInputStreamTest extends RmiTestBase {
             this.i = i;
         }
 
+        @Override
         public Void call() throws IOException {
             assertEquals(readFully(i, 4), toBytes("1234"));
             try {

--- a/src/test/java/hudson/remoting/RemoteInvocationHandlerTest.java
+++ b/src/test/java/hudson/remoting/RemoteInvocationHandlerTest.java
@@ -42,9 +42,11 @@ public class RemoteInvocationHandlerTest extends RmiTestBase {
         public void meth(String arg1, String arg2) {
             assert false : "should be ignored";
         }
+        @Override
         public void meth(String arg1) {
             this.arg = arg1;
         }
+        @Override
         public void meth2(String arg) {
             this.arg = arg;
         }
@@ -59,6 +61,7 @@ public class RemoteInvocationHandlerTest extends RmiTestBase {
         Task(Contract c) {
             this.c = c;
         }
+        @Override
         public Void call() throws Error {
             c.meth("value");
             return null;
@@ -71,6 +74,7 @@ public class RemoteInvocationHandlerTest extends RmiTestBase {
         Task2(Contract2 c) {
             this.c = c;
         }
+        @Override
         public Void call() throws Error {
             c.meth2("value");
             return null;
@@ -100,6 +104,7 @@ public class RemoteInvocationHandlerTest extends RmiTestBase {
 
     private static class AsyncImpl implements AsyncContract, Serializable {
         String arg;
+        @Override
         public void meth(String arg1) {
             synchronized (this) {
                 this.arg = arg1;
@@ -114,6 +119,7 @@ public class RemoteInvocationHandlerTest extends RmiTestBase {
         AsyncTask(AsyncContract c) {
             this.c = c;
         }
+        @Override
         public Void call() throws Error {
             c.meth("value");
             return null;

--- a/src/test/java/hudson/remoting/RmiTestBase.java
+++ b/src/test/java/hudson/remoting/RmiTestBase.java
@@ -46,11 +46,13 @@ public abstract class RmiTestBase extends TestCase {
     protected transient ChannelRunner channelRunner = new NioPipeRunner();
     protected String testSuffix="";
 
+    @Override
     protected void setUp() throws Exception {
         System.out.println("Starting "+getName());
         channel = channelRunner.start();
     }
 
+    @Override
     protected void tearDown() throws Exception {
         channelRunner.stop(channel);
     }
@@ -64,6 +66,7 @@ public abstract class RmiTestBase extends TestCase {
         }
     }
 
+    @Override
     public String getName() {
         return super.getName()+testSuffix;
     }

--- a/src/test/java/hudson/remoting/SimpleTest.java
+++ b/src/test/java/hudson/remoting/SimpleTest.java
@@ -48,6 +48,7 @@ public class SimpleTest extends RmiTestBase {
     }
 
     private static class Callable1 extends CallableBase<Integer, RuntimeException> {
+        @Override
         public Integer call() throws RuntimeException {
             System.err.println("invoked");
             return 5;
@@ -76,6 +77,7 @@ public class SimpleTest extends RmiTestBase {
     }
 
     private static class Callable2 extends CallableBase<Integer, RuntimeException> {
+        @Override
         public Integer call() throws RuntimeException {
             throw new RuntimeException("foo");
         }
@@ -101,6 +103,7 @@ public class SimpleTest extends RmiTestBase {
             this.t = t;
         }
 
+        @Override
         public T call() throws RuntimeException {
             return t;
         }
@@ -129,6 +132,7 @@ public class SimpleTest extends RmiTestBase {
     }
     private static class Cancellable extends CallableBase<Integer, InterruptedException> {
         boolean ran;
+        @Override
         public Integer call() throws InterruptedException {
             Thread.sleep(9999);
             ran = true;

--- a/src/test/java/hudson/remoting/TestCallable.java
+++ b/src/test/java/hudson/remoting/TestCallable.java
@@ -38,6 +38,7 @@ import java.io.InputStream;
  * @see DummyClassLoader
  */
 public class TestCallable extends Exception implements Callable<Object, Throwable> {
+    @Override
     public Object call() throws Throwable {
         Object[] r = new Object[4];
 

--- a/src/test/java/hudson/remoting/TestLinkage.java
+++ b/src/test/java/hudson/remoting/TestLinkage.java
@@ -26,6 +26,7 @@ package hudson.remoting;
 
 public class TestLinkage extends CallableBase<Object, Throwable> {
 
+    @Override
     public Object call() throws Throwable {
         // force classloading of several classes
         // when we run this test, we insert an artificial delay to each  classloading

--- a/src/test/java/hudson/remoting/pipe/RandomWorkload.java
+++ b/src/test/java/hudson/remoting/pipe/RandomWorkload.java
@@ -24,6 +24,7 @@ public class RandomWorkload extends Assert implements Workload {
         this.size = size;
     }
 
+    @Override
     public void write(OutputStream o) throws IOException {
         Random data = new Random(0);
         Random boundary = new Random(1);
@@ -43,6 +44,7 @@ public class RandomWorkload extends Assert implements Workload {
         o.close();
     }
 
+    @Override
     public void read(InputStream i) throws IOException {
         Random data = new Random(0);
         Random boundary = new Random(2);

--- a/src/test/java/hudson/remoting/throughput/Sender.java
+++ b/src/test/java/hudson/remoting/throughput/Sender.java
@@ -77,6 +77,7 @@ public class Sender {
             this.p = p;
         }
 
+        @Override
         public byte[] call() throws Exception {
             return digest(p.getIn());
         }

--- a/src/test/java/hudson/remoting/util/GCTask.java
+++ b/src/test/java/hudson/remoting/util/GCTask.java
@@ -20,6 +20,7 @@ public class GCTask extends CallableBase<Object, IOException> {
         this.agressive = agressive;
     }
 
+    @Override
     public Object call() throws IOException {
         if (agressive) {
             Set<Object[]> objects = new HashSet<>();

--- a/src/test/java/org/jenkinsci/remoting/nio/SocketClientMain.java
+++ b/src/test/java/org/jenkinsci/remoting/nio/SocketClientMain.java
@@ -44,6 +44,7 @@ public class SocketClientMain {
             this.arg = arg;
         }
 
+        @Override
         public String call() throws Exception {
             LOGGER.info("Echoing back " + arg);
             return arg;

--- a/src/test/java/org/jenkinsci/remoting/protocol/IOBufferMatcherLayer.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/IOBufferMatcherLayer.java
@@ -42,6 +42,7 @@ public class IOBufferMatcherLayer extends ApplicationLayer<IOBufferMatcher> {
 
     public IOBufferMatcherLayer(String name) {
         app = new IOBufferMatcher(name) {
+            @Override
             public void send(ByteBuffer data) throws IOException {
                 write(data);
             }

--- a/src/test/java/org/jenkinsci/remoting/protocol/impl/BatchSendBufferingFilterLayer.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/impl/BatchSendBufferingFilterLayer.java
@@ -38,6 +38,7 @@ public class BatchSendBufferingFilterLayer extends FilterLayer implements Clonea
         this.batch = ByteBuffer.allocate(length);
     }
 
+    @Override
     public BatchSendBufferingFilterLayer clone() {
         return new BatchSendBufferingFilterLayer(batch.capacity());
     }


### PR DESCRIPTION
This PR applies the IntelliJ "Add missing `@Override` annotations" automated refactoring tool against the entire codebase. This convention is used by most modern Java style guides, including [Google Java Style Guide §6.1](https://google.github.io/styleguide/javaguide.html#s6.1-override-annotation).