### PR TITLE
Remove an override attribute exists in pom.xml file since the related issue had been already fixed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,6 @@ THE SOFTWARE.
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.excludeFilterFile>${basedir}/src/spotbugs/excludeFilter.xml</spotbugs.excludeFilterFile>
     <spotbugs.threshold>Low</spotbugs.threshold>
-    <!-- TODO: Required to override by a version with certchain support (MJARSIGNER-53) on @oleg-nenashev's machine. Remove once it's in upstream -->
-    <maven-jarsigner-plugin.version>1.4</maven-jarsigner-plugin.version>
   </properties>
 
   <repositories>
@@ -288,7 +286,6 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-jarsigner-plugin</artifactId>
-        <version>${maven-jarsigner-plugin.version}</version>
         <configuration>
           <!--
             during the development, debug profile will cause


### PR DESCRIPTION
According to the link https://issues.apache.org/jira/browse/MJARSIGNER-53, I observed that such issue had already been fixed. And based on the comment "Remove once it's in upstream". This override attribute is not needed.

The override attribute and comment:
https://github.com/jenkinsci/remoting/blob/0860f222f45802f0dab0e9e7a06e93be89baf687/pom.xml#L74-L75