### PR TITLE
Add protection against missing trailing slashes when using websocket.

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -625,8 +625,10 @@ public class Engine extends Thread {
                         }
                     }
                 }
+                String wsUrl = candidateUrls.get(0).toString().replaceFirst("^http", "ws");
+                if(!wsUrl.endsWith("/")) wsUrl += "/";
                 ContainerProvider.getWebSocketContainer().connectToServer(new AgentEndpoint(),
-                    ClientEndpointConfig.Builder.create().configurator(headerHandler).build(), URI.create(candidateUrls.get(0).toString().replaceFirst("^http", "ws") + "wsagents/"));
+                    ClientEndpointConfig.Builder.create().configurator(headerHandler).build(), URI.create(wsUrl + "wsagents/"));
                 while (ch.get() == null) {
                     Thread.sleep(100);
                 }


### PR DESCRIPTION
Currently, if -webSocket is set and -url does not have a trailing slash, connection will fail with an UnresolvedAddressException. This can prove confusing to diagnose and resolve.

This PR adds a check for a trailing slash and adds it if missing.