### PR TITLE
[JENKINS-63118] delete /tmp/resource-xxx on exit

### DIFF
--- a/src/main/java/hudson/remoting/Util.java
+++ b/src/main/java/hudson/remoting/Util.java
@@ -73,7 +73,7 @@ public class Util {
             fos.write(image);
         }
 
-        deleteDirectoryOnExit(resource);
+        deleteDirectoryOnExit(tmpDir.toFile());
         return resource;
     }
 


### PR DESCRIPTION
See [JENKINS-63118](https://issues.jenkins-ci.org/browse/JENKINS-63118)

In Util.makeResource(), call deleteDirectoryOnExit() on the temporary
directory, and not just on the resource file it contains.