### PR TITLE
Update to the latest parent pom.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.56</version>
+    <version>1.59</version>
     <relativePath />
   </parent>
 
@@ -71,6 +71,7 @@ THE SOFTWARE.
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.excludeFilterFile>${basedir}/src/spotbugs/excludeFilter.xml</spotbugs.excludeFilterFile>
     <spotbugs.threshold>Low</spotbugs.threshold>
+    <argLine></argLine>
   </properties>
 
   <repositories>
@@ -101,7 +102,6 @@ THE SOFTWARE.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@ THE SOFTWARE.
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.excludeFilterFile>${basedir}/src/spotbugs/excludeFilter.xml</spotbugs.excludeFilterFile>
     <spotbugs.threshold>Low</spotbugs.threshold>
-    <argLine></argLine>
+    <argLine/> <!-- TODO pending upstream fix -->
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@ THE SOFTWARE.
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.excludeFilterFile>${basedir}/src/spotbugs/excludeFilter.xml</spotbugs.excludeFilterFile>
     <spotbugs.threshold>Low</spotbugs.threshold>
-    <argLine/> <!-- TODO pending upstream fix -->
+    <argLine/> <!-- TODO pending https://github.com/jenkinsci/pom/pull/142 -->
   </properties>
 
   <repositories>


### PR DESCRIPTION
Also obtain the junit version from the parent.
jenkinsci/pom#138 in the parent pom means that argLine needs to be defined.
Define it as empty unless overridden.

This change supersedes #405 and #395.