### PR TITLE
Upgrade bouncy castle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,13 +165,13 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.54</version>
+      <version>1.66</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.54</version>
+      <version>1.66</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@ THE SOFTWARE.
     <spotbugs.excludeFilterFile>${basedir}/src/spotbugs/excludeFilter.xml</spotbugs.excludeFilterFile>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <argLine/> <!-- TODO pending https://github.com/jenkinsci/pom/pull/142 -->
+    <bc-version>1.66</bc-version>
   </properties>
 
   <repositories>
@@ -165,13 +166,13 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.66</version>
+      <version>${bc-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.66</version>
+      <version>${bc-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrade both components together in one PR to preserve master as buildable.

Supersedes the dependabot PRs #404 and #400. 