### PR TITLE
Remove obsolete log alias.

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -117,7 +117,7 @@ public class Launcher {
      * If specified, this option overrides the default destination within {@link #workDir}.
      * If both this options and {@link #workDir} is not set, the log will not be generated.
      */
-    @Option(name="-agentLog", aliases = {"-slaveLog"}, usage="Local agent error log destination (overrides workDir)")
+    @Option(name="-agentLog", usage="Local agent error log destination (overrides workDir)")
     @CheckForNull
     public File agentLog = null;
 


### PR DESCRIPTION
It's time to remove the alias "-slaveLog" and only accept "-agentLog". It's been 4 years since "-slaveLog" was obsoleted as an alias and "-aliasLog" was made the correct term. It's possible that some people have continued to use the wrong term all that time, but at this point it's time to just remove the outdated term and make them update.