### PR TITLE
Improve documentation, removing more instances of 'slave' term.

### DIFF
--- a/docs/inbound-agent.md
+++ b/docs/inbound-agent.md
@@ -18,7 +18,7 @@ Part of the agent status page for inbound agents looks something like this:
 This shows a couple of launch methods, but there are other mechanisms.
 If you use a different mechanism than clicking the "Launch" button, this page contains parameters that you will need. 
 The long string of hex digits is a secret key that the client needs to establish the connection. 
-Depending on how you connect you may also need the agent name, "AgentName" in this example, or the (misnamed) jnlpUrl, "https://myjenkins.example.com/computer/AgentName/slave-agent.jnlp".
+Depending on how you connect you may also need the agent name, "AgentName" in this example, or the (misnamed) jnlpUrl, "https://myjenkins.example.com/computer/AgentName/jenkins-agent.jnlp".
 
 ### "Launch" button
 This is the only launch mechanism that actually uses JNLP.

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -59,7 +59,7 @@ import static java.util.logging.Level.WARNING;
  * Entry point to JNLP agent.
  *
  * <p>
- * See also <tt>slave-agent.jnlp.jelly</tt> in the core.
+ * See also <tt>jenkins-agent.jnlp.jelly</tt> in the core.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/src/main/java/hudson/remoting/jnlp/package-info.java
+++ b/src/main/java/hudson/remoting/jnlp/package-info.java
@@ -26,6 +26,6 @@
  *
  * <p>
  * This involves in getting the connection parameters through command line,
- * which is provided from <tt>slave-agent.jnlp.jelly</tt> file in the core.
+ * which is provided from <tt>jenkins-agent.jnlp.jelly</tt> file in the core.
  */
 package hudson.remoting.jnlp;


### PR DESCRIPTION
This cleans up a few more instances of incorrect terminology in documentation.

This only fully makes sense with jenkinsci/jenkins#35452, but I consider the two to be fully independent. Without that change in core, the file name in the documentation here doesn't exist, but that's a minor concern as things get updated and coordinated. Old and new agents work fine with or without the core change.