### PR TITLE
Update maven-assembly plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.3.0</version>
         <configuration>
           <descriptors>
             <descriptor>src/assembly/agent-load-test.xml</descriptor>


### PR DESCRIPTION
This started as a dependabot update but when I tried to kick CI again, the bot removed that PR. Here it's recreated as a self-standing change.