### PR TITLE
Undeprecate KeyUtils.fingerprint

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/util/KeyUtils.java
+++ b/src/main/java/org/jenkinsci/remoting/util/KeyUtils.java
@@ -95,7 +95,6 @@ public final class KeyUtils {
      */
     @Nonnull
     @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Used for fingerprinting, not security.")
-    @Deprecated
     public static String fingerprint(@CheckForNull Key key) {
         if (key == null) {
             return "null";


### PR DESCRIPTION
Contrary to the conversation in #361, this method was already used in `remoting`, and it is used in https://github.com/jenkinsci/jenkins/pull/5044 since that was basically a copy & inline of this method.
