### PR TITLE
Remove hardcode of JKS for use other key stores

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -483,7 +483,7 @@ public class Engine extends Thread {
                 char[] password = "password".toCharArray();
                 KeyStore store;
                 try {
-                    store = KeyStore.getInstance("JKS");
+                    store = KeyStore.getInstance(KeyStore.getDefaultType());
                 } catch (KeyStoreException e) {
                     throw new IllegalStateException("Java runtime specification requires support for JKS key store", e);
                 }

--- a/src/test/java/org/jenkinsci/remoting/engine/HandlerLoopbackLoadStress.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/HandlerLoopbackLoadStress.java
@@ -187,7 +187,7 @@ public class HandlerLoopbackLoadStress {
 
         char[] password = "password".toCharArray();
 
-        KeyStore store = KeyStore.getInstance("jks");
+        KeyStore store = KeyStore.getInstance(KeyStore.getDefaultType());
         store.load(null, password);
         store.setKeyEntry("alias", keyPair.getPrivate(), password, new Certificate[]{certificate});
 

--- a/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackLoopbackLoadStress.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackLoopbackLoadStress.java
@@ -154,7 +154,7 @@ public class ProtocolStackLoopbackLoadStress {
 
         char[] password = "password".toCharArray();
 
-        KeyStore store = KeyStore.getInstance("jks");
+        KeyStore store = KeyStore.getInstance(KeyStore.getDefaultType());
         store.load(null, password);
         store.setKeyEntry("alias", keyPair.getPrivate(), password, new Certificate[]{certificate});
 

--- a/src/test/java/org/jenkinsci/remoting/protocol/cert/SSLContextRule.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/cert/SSLContextRule.java
@@ -78,7 +78,7 @@ public class SSLContextRule implements TestRule {
                                            @CheckForNull List<KeyWithChain> keys,
                                            @NonNull char[] password)
             throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
-        KeyStore store = KeyStore.getInstance("jks");
+        KeyStore store = KeyStore.getInstance(KeyStore.getDefaultType());
         int id = 1;
         store.load(null, password);
         if (certificates != null) {


### PR DESCRIPTION
I suggest removing the hardcode with JKS Keystore to allow using other Keystores. For example, BCFKS provided in the FIPS version of Bouncy Castle.
More info here:
https://groups.google.com/g/jenkinsci-dev/c/YkEG_oSR1mw