### PR TITLE
Update to parent 1.63.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.60</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>access-modifier-annotation</artifactId>
-      <version>1.16</version>
+      <version>1.21</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/remoting/NoProxyEvaluator.java
+++ b/src/main/java/hudson/remoting/NoProxyEvaluator.java
@@ -23,6 +23,7 @@
  */
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkinsci.remoting.org.apache.commons.net.util.SubnetUtils;
 import org.jenkinsci.remoting.org.apache.commons.validator.routines.InetAddressValidator;
 import org.kohsuke.accmod.Restricted;
@@ -57,7 +58,7 @@ public class NoProxyEvaluator {
     }
 
     boolean shouldProxyHost(String host) {
-        if (host.toLowerCase(Locale.ROOT).equals("localhost")) {
+        if (isLocalhost(host)) {
             return false;
         }
         if (isIpAddress(host)) {
@@ -76,6 +77,11 @@ public class NoProxyEvaluator {
             }
         }
         return !matchesDomainHost(host);
+    }
+
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "host value is provided by administrator at launch")
+    private boolean isLocalhost(String host) {
+        return host.toLowerCase(Locale.ROOT).equals("localhost");
     }
 
     private static String getEnvironmentValue() {

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -574,12 +574,17 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
         for (String headerName : headerNames) {
             for (Map.Entry<String, List<String>> entry: headerFields.entrySet()) {
                 final String headerField = entry.getKey();
-                if (headerField != null && headerField.equalsIgnoreCase(headerName)) {
+                if (isMatchingHeader(headerName, headerField)) {
                     return entry.getValue();
                 }
             }
         }
         return null;
+    }
+
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "Header fields are provided by controller and header names are hardcoded.")
+    private static boolean isMatchingHeader(String headerName, String headerField) {
+        return headerField != null && headerField.equalsIgnoreCase(headerName);
     }
 
     @CheckForNull


### PR DESCRIPTION
The update is simple, but there's an interesting new findsecbugs pattern, IMPROPER_UNICODE. The behavior can be pretty devious. But, here we're getting the comparison values from the controller, hardcoded, or from the user/admin at launch. We have to trust these sources.

Alternatively we could drop the case-insensitive comparisons. It's possible that could cause a regression, though it's pretty unlikely.

Also update access-modifier-annotation to 1.21 in this PR because there's a dependency relationship via enforcer.