### PR TITLE
Undo the Dependabot proposed update for the Websocket library.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.glassfish.tyrus.bundles</groupId>
       <artifactId>tyrus-standalone-client-jdk</artifactId>
-      <version>2.0.0</version>
+      <version>1.17</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
It causes related failures in Jenkins tests.
We can wait for the next update or try later to resolve the failures.
At this point, I just don't want to have this added complexity in this release.

(I could have just the revert feature, but since the change got in before other changes, I decided to do a regular PR to keep a record.)