### PR TITLE
Add url to fix dependabot release notes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@ THE SOFTWARE.
   <version>${revision}${changelist}</version>
 
   <name>Jenkins remoting layer</name>
+  <url>https://github.com/jenkinsci/remoting</url>
   <description>
     Contains the bootstrap code to bridge separate JVMs into a single semi-shared space.
     Reusable outside Jenkins.


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/5292 was originally pointing to the parent pom's release notes