### PR TITLE
Disable stacktraces from ExportTable entries by default

### DIFF
--- a/src/main/java/hudson/remoting/ExportTable.java
+++ b/src/main/java/hudson/remoting/ExportTable.java
@@ -491,7 +491,7 @@ final class ExportTable {
      */
     public static int UNEXPORT_LOG_SIZE = Integer.getInteger(ExportTable.class.getName()+".unexportLogSize",1024);
 
-    static boolean EXPORT_TRACES = Boolean.getBoolean(ExportTable.class.getName() + "exportTraces");
+    static boolean EXPORT_TRACES = Boolean.getBoolean(ExportTable.class.getName() + ".exportTraces");
 
     private static final Logger LOGGER = Logger.getLogger(ExportTable.class.getName());
 }

--- a/src/test/java/hudson/remoting/ExportTableTest.java
+++ b/src/test/java/hudson/remoting/ExportTableTest.java
@@ -11,21 +11,25 @@ import java.util.concurrent.ExecutionException;
  */
 public class ExportTableTest extends TestCase {
     public void testDiagnosis() throws Exception {
-        ExportTable.EXPORT_TRACES = true;
-        ExportTable e = new ExportTable();
-
-        int i = e.export(Object.class, "foo");
-        assertEquals("foo", e.get(i));
-
-        e.unexportByOid(i);
         try {
-            e.get(i);
-            fail();
-        } catch (ExecutionException x) {
-            StringWriter sw = new StringWriter();
-            x.printStackTrace(new PrintWriter(sw));
-            assertTrue(sw.toString().contains("Object was recently deallocated"));
-            assertTrue(sw.toString().contains("ExportTable.export"));
+            ExportTable.EXPORT_TRACES = true;
+            ExportTable e = new ExportTable();
+
+            int i = e.export(Object.class, "foo");
+            assertEquals("foo", e.get(i));
+
+            e.unexportByOid(i);
+            try {
+                e.get(i);
+                fail();
+            } catch (ExecutionException x) {
+                StringWriter sw = new StringWriter();
+                x.printStackTrace(new PrintWriter(sw));
+                assertTrue(sw.toString().contains("Object was recently deallocated"));
+                assertTrue(sw.toString().contains("ExportTable.export"));
+            }
+        } finally {
+            ExportTable.EXPORT_TRACES = false;
         }
     }
 }

--- a/src/test/java/hudson/remoting/ExportTableTest.java
+++ b/src/test/java/hudson/remoting/ExportTableTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ExecutionException;
  */
 public class ExportTableTest extends TestCase {
     public void testDiagnosis() throws Exception {
+        ExportTable.EXPORT_TRACES = true;
         ExportTable e = new ExportTable();
 
         int i = e.export(Object.class, "foo");


### PR DESCRIPTION
Not certain if this is a good idea but the idea spawned from [JENKINS-63975](https://issues.jenkins.io/browse/JENKINS-63975) as stacktraces seem to take a considerable amount of memory usage in Jenkins and as far as I understand it, it is entirely for debugging.

Although I'm not certain how often this workflow is used in the real world, if its very rare this ever happens perhaps its better to disable by default.