### PR TITLE
JENKINS-65046:Dynamic Class Loading Fails In Reflection

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -150,7 +150,10 @@ public class Launcher {
         $addURL.setAccessible(true);
 
         for(String token : pathList.split(File.pathSeparator))
-            $addURL.invoke(ClassLoader.getSystemClassLoader(),new File(token).toURI().toURL());
+        { 
+        	URL[] urls= {new File(token).toURI().toURL()};
+        	$addURL.invoke(URLClassLoader.newInstance(urls),urls[0]);
+        }
 
         // fix up the system.class.path to pretend that those jar files
         // are given through CLASSPATH or something.


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
After updating from java 8 to java 11 getting the below error:-
Exception in thread "main" java.lang.IllegalArgumentException: object is not an instance of declaring class
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:566)
at hudson.remoting.Launcher.addClasspath(Launcher.java:129)

On analysing the remoting source code found that the hudson.remoting.Launcher.addClasspath invokes URLClassLoader and passes the instance using ClassLoader.getSystemClassLoader().
However in java 11, this seems like an illegal operation as ClassLoader.getSystemClassLoader() does not get the instance of  URLClassLoader due to which we are getting the error "object is not an instance of declaring class".

To fix this issue what updated the addClasspath method to invoke the URLClassLoader using a new instance of the class.

Reference:-
GitIssues:-
https://github.com/redhat-developer/rsp-server/issues/274
https://github.com/redhat-developer/rsp-server/issues/275

Jira:-
https://issues.jenkins.io/browse/JENKINS-65046
https://issues.jenkins.io/browse/JENKINS-64831
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
