### PR TITLE
Migrate from SettableFuture to CompletableFuture in tests

### DIFF
--- a/src/test/java/org/jenkinsci/remoting/engine/HandlerLoopbackLoadStress.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/HandlerLoopbackLoadStress.java
@@ -46,7 +46,7 @@ import org.jenkinsci.remoting.protocol.IOHub;
 import org.jenkinsci.remoting.protocol.IOHubReadyListener;
 import org.jenkinsci.remoting.protocol.IOHubRegistrationCallback;
 import org.jenkinsci.remoting.protocol.cert.BlindTrustX509ExtendedTrustManager;
-import org.jenkinsci.remoting.util.SettableFuture;
+import java.util.concurrent.CompletableFuture;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
@@ -130,7 +130,7 @@ public class HandlerLoopbackLoadStress {
 
     private final JnlpProtocolHandler<? extends JnlpConnectionState> handler;
 
-    private final SettableFuture<SocketAddress> addr = SettableFuture.create();
+    private final CompletableFuture<SocketAddress> addr = new CompletableFuture<>();
     private final Random entropy = new Random();
 
     private final RuntimeMXBean runtimeMXBean;
@@ -844,7 +844,7 @@ public class HandlerLoopbackLoadStress {
     private class Acceptor implements IOHubReadyListener, IOHubRegistrationCallback {
         private final ServerSocketChannel channel;
         private final AtomicInteger clientCount = new AtomicInteger();
-        public SettableFuture<Void> registered = SettableFuture.create();
+        public CompletableFuture<Void> registered = new CompletableFuture<>();
         private SelectionKey selectionKey;
 
         private Acceptor(ServerSocketChannel channel) {
@@ -891,9 +891,9 @@ public class HandlerLoopbackLoadStress {
             SocketAddress localAddress;
             try {
                 localAddress = serverSocketChannel.getLocalAddress();
-                addr.set(localAddress);
+                addr.complete(localAddress);
             } catch (IOException e) {
-                addr.setException(e);
+                addr.completeExceptionally(e);
                 return;
             }
             try {
@@ -901,7 +901,7 @@ public class HandlerLoopbackLoadStress {
             } catch (Exception e) {
                 // ignore
             }
-            registered.set(null);
+            registered.complete(null);
         }
 
         @Override

--- a/src/test/java/org/jenkinsci/remoting/protocol/IOBufferMatcher.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/IOBufferMatcher.java
@@ -23,7 +23,7 @@
  */
 package org.jenkinsci.remoting.protocol;
 
-import com.google.common.util.concurrent.SettableFuture;
+import java.util.concurrent.CompletableFuture;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.Matcher;
@@ -72,7 +72,7 @@ public abstract class IOBufferMatcher {
     private final String name;
     private final ByteArrayOutputStream recv = new ByteArrayOutputStream();
     private final WritableByteChannel channel = Channels.newChannel(recv);
-    private final SettableFuture<IOException> closed = SettableFuture.create();
+    private final CompletableFuture<IOException> closed = new CompletableFuture<>();
     private final CountDownLatch anything = new CountDownLatch(1);
     private final Lock state = new ReentrantLock();
     private final Condition changed = state.newCondition();
@@ -108,7 +108,7 @@ public abstract class IOBufferMatcher {
 
     private void innerClose(@Nonnull IOException cause) {
         if (!closed.isDone()) {
-            closed.set(cause);
+            closed.complete(cause);
             anything.countDown();
             state.lock();
             try {

--- a/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackLoopbackLoadStress.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackLoopbackLoadStress.java
@@ -23,7 +23,7 @@
  */
 package org.jenkinsci.remoting.protocol;
 
-import com.google.common.util.concurrent.SettableFuture;
+import java.util.concurrent.CompletableFuture;
 import hudson.remoting.Callable;
 import hudson.remoting.Channel;
 import org.apache.commons.io.IOUtils;
@@ -105,7 +105,7 @@ public class ProtocolStackLoopbackLoadStress {
 
     private final Acceptor acceptor;
 
-    private final SettableFuture<SocketAddress> addr = SettableFuture.create();
+    private final CompletableFuture<SocketAddress> addr = new CompletableFuture<>();
     private final Random entropy = new Random();
 
     public ProtocolStackLoopbackLoadStress(boolean nio, boolean ssl)
@@ -244,9 +244,9 @@ public class ProtocolStackLoopbackLoadStress {
             SocketAddress localAddress;
             try {
                 localAddress = serverSocketChannel.getLocalAddress();
-                addr.set(localAddress);
+                addr.complete(localAddress);
             } catch (IOException e) {
-                addr.setException(e);
+                addr.completeExceptionally(e);
                 return;
             }
             try {


### PR DESCRIPTION
According to [this guide](https://github.com/krka/java8-future-guide), `SettableFuture.create()` can be replaced with Java 8's `new CompletableFuture()`. I did so for any test code that used `SettableFuture`. Note that modifying usages of `SettableFuture` in non-test code has binary compatibility implications, so I did not touch non-test code in order to eliminate any risk of regression.