### PR TITLE
[JENKINS-63520] Sequence the startup and receiving to avoid a deadlock.

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/protocol/ProtocolStack.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/ProtocolStack.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -147,6 +148,8 @@ public class ProtocolStack<T> implements Closeable, ByteBufferPool {
 
     private final TimeUnit handshakingUnits = TimeUnit.SECONDS;
 
+    private static final AtomicBoolean started = new AtomicBoolean(false);
+
     /**
      * Private constructor used by {@link Builder#build(ApplicationLayer)}
      *
@@ -179,6 +182,10 @@ public class ProtocolStack<T> implements Closeable, ByteBufferPool {
      */
     public static ProtocolStack.Builder on(NetworkLayer network) {
         return new Builder(network);
+    }
+
+    public static AtomicBoolean isStarted() {
+        return started;
     }
 
     /**
@@ -217,6 +224,7 @@ public class ProtocolStack<T> implements Closeable, ByteBufferPool {
         if (LOGGER.isLoggable(Level.FINEST)) {
             LOGGER.log(Level.FINEST, "[{0}] Started", name());
         }
+        started.set(true);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/remoting/protocol/ProtocolStack.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/ProtocolStack.java
@@ -31,9 +31,9 @@ import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -148,7 +148,7 @@ public class ProtocolStack<T> implements Closeable, ByteBufferPool {
 
     private final TimeUnit handshakingUnits = TimeUnit.SECONDS;
 
-    private static final AtomicBoolean started = new AtomicBoolean(false);
+    private static final CountDownLatch awaitStart = new CountDownLatch(1);
 
     /**
      * Private constructor used by {@link Builder#build(ApplicationLayer)}
@@ -184,8 +184,8 @@ public class ProtocolStack<T> implements Closeable, ByteBufferPool {
         return new Builder(network);
     }
 
-    public static AtomicBoolean isStarted() {
-        return started;
+    public static void waitForStart() throws InterruptedException {
+        awaitStart.await();
     }
 
     /**
@@ -224,7 +224,7 @@ public class ProtocolStack<T> implements Closeable, ByteBufferPool {
         if (LOGGER.isLoggable(Level.FINEST)) {
             LOGGER.log(Level.FINEST, "[{0}] Started", name());
         }
-        started.set(true);
+        awaitStart.countDown();
     }
 
     /**

--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/BIONetworkLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/BIONetworkLayer.java
@@ -37,6 +37,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jenkinsci.remoting.protocol.IOHub;
 import org.jenkinsci.remoting.protocol.NetworkLayer;
+import org.jenkinsci.remoting.protocol.ProtocolStack;
 import org.jenkinsci.remoting.util.ByteBufferQueue;
 import org.jenkinsci.remoting.util.IOUtils;
 
@@ -230,6 +231,15 @@ public class BIONetworkLayer extends NetworkLayer {
          */
         @Override
         public void run() {
+            while (!ProtocolStack.isStarted().get()) {
+                LOGGER.info("Waiting for ProtocolStack to start.");
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    LOGGER.warning("Interrupted while waiting for ProtocolStack to start.");
+                    return;
+                }
+            }
             synchronized (BIONetworkLayer.this) {
                 starting = false;
                 running = true;

--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/BIONetworkLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/BIONetworkLayer.java
@@ -231,14 +231,12 @@ public class BIONetworkLayer extends NetworkLayer {
          */
         @Override
         public void run() {
-            while (!ProtocolStack.isStarted().get()) {
-                LOGGER.info("Waiting for ProtocolStack to start.");
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    LOGGER.warning("Interrupted while waiting for ProtocolStack to start.");
-                    return;
-                }
+            LOGGER.info("Waiting for ProtocolStack to start.");
+            try {
+                ProtocolStack.waitForStart();
+            } catch (InterruptedException e) {
+                LOGGER.warning("Interrupted while waiting for ProtocolStack to start.");
+                return;
             }
             synchronized (BIONetworkLayer.this) {
                 starting = false;


### PR DESCRIPTION
See [JENKINS-63520](https://issues.jenkins.io/browse/JENKINS-63520).

Some users have reported a rare thread deadlock when starting an inbound TCP agent. There are no known reports of this occurring at other times. The reporter included a stack track showing information about the deadlock. It occurs when the agent ProtocolStack is still initializing and a message is received on the networking layer.

Personally, I've never observed the problem and have no way of testing it. I've tested normal behavior and this fix has worked fine.

This fix delays the processing of any received messages until after the ProtocolStack has fully initialized.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [n/p] Ensure you have provided tests - that demonstrates feature works or fixes the issue