### PR TITLE
Allow Swarm to retry on failure

### DIFF
--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -28,6 +28,7 @@ import hudson.remoting.Engine;
 import hudson.remoting.EngineListener;
 import hudson.remoting.FileSystemJarCache;
 import hudson.remoting.Util;
+import java.io.UncheckedIOException;
 import org.jenkinsci.remoting.engine.WorkDirManager;
 import org.jenkinsci.remoting.util.PathUtils;
 import org.kohsuke.args4j.Argument;
@@ -433,7 +434,17 @@ public class Main {
                 justification = "Yes, we really want to exit in the case of severe error")
         public void error(Throwable t) {
             LOGGER.log(Level.SEVERE, t.getMessage(), t);
-            System.exit(-1);
+            if (Boolean.getBoolean(CuiListener.class.getName() + ".propagateExceptions")) {
+                if (t instanceof RuntimeException) {
+                    throw (RuntimeException) t;
+                } else if (t instanceof IOException) {
+                    throw new UncheckedIOException((IOException) t);
+                } else {
+                    throw new RuntimeException(t);
+                }
+            } else {
+                System.exit(-1);
+            }
         }
 
         @Override


### PR DESCRIPTION
### Problem

During a recent Jenkins upgrade, one of my Swarm clients (which are started with `-deleteExistingClients` so that they can reconnect to Jenkins after a controller restart) failed to reconnect. Jobs then eventually hit the `org.jenkinsci.plugins.workflow.support.pickles.ExecutorPickle.timeoutForNodeMillis` timeout and failed.

### Evaluation

Looking at the Swarm client logs, I saw that Swarm had successfully called `SwarmClient#createSwarmAgent` against the controller and had proceeded to delegate to Remoting. Remoting was then logging

```
2021-04-28 14:53:26 WARNING org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver isPortVisible Connection refused (Connection refused)
2021-04-28 14:53:26 SEVERE hudson.remoting.jnlp.Main$CuiListener error http://example.com/ provided port:12345 is not reachable
java.io.IOException: http://example.com/ provided port:12345 is not reachable
        at org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.resolve(JnlpAgentEndpointResolver.java:311)
        at hudson.remoting.Engine.innerRun(Engine.java:689)
        at hudson.remoting.Engine.run(Engine.java:514)
```

after which no further retries were taking place.

I could easily reproduce this artificially by modifying Remoting with

```java
diff --git a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
index 511cf5e6..e1e8a432 100644
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -355,7 +355,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
         try {
             s = new Socket();
             s.setReuseAddress(true);
-            SocketAddress sa = new InetSocketAddress(hostname, port);
+            SocketAddress sa = new InetSocketAddress(hostname, port + 37);
             s.connect(sa, 5000);
         } catch (IOException e) {
             LOGGER.warning(e.getMessage());
```

Tracing the execution, I found we were eventually reaching `hudson.remoting.jnlp.Main$CuiListener` which was calling `System.exit(-1)` to exit the process. Needless to say, the process can't keep retrying after that.

### Solution

Add a tunable to allow `hudson.remoting.jnlp.Main$CuiListener` to propagate the exception rather than forcefully exit the process in situations like these where Remoting is being consumed programmatically by higher-level code in Swarm.

### Testing Done

I confirmed that after modifying Swarm with

```java
diff --git a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
index 34c290f..53923d4 100644
--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -253,6 +253,9 @@ public class SwarmClient {
             args.add("-webSocket");
         }
 
+        // Prevent Remoting from killing the process on failure.
+        System.setProperty("hudson.remoting.jnlp.Main$CuiListener.propagateExceptions", "true");
+
         try {
             Main.main(args.toArray(new String[0]));
         } catch (InterruptedException | RuntimeException e) {
```

`hudson.remoting.jnlp.Main$CuiListener` no longer terminated the process and Swarm was able to retry.