### PR TITLE
Allow JNLP agent endpoint resolution exceptions to be non-fatal for Swarm

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -688,7 +688,11 @@ public class Engine extends Thread {
                 try {
                     endpoint = resolver.resolve();
                 } catch (Exception e) {
-                    events.error(e);
+                    if (Boolean.getBoolean(Engine.class.getName() + ".nonFatalJnlpAgentEndpointResolutionExceptions")) {
+                        events.status("Could not resolve JNLP agent endpoint", e);
+                    } else {
+                        events.error(e);
+                    }
                     return;
                 }
                 if (endpoint == null) {


### PR DESCRIPTION
### Background

See [JENKINS-57831](https://issues.jenkins.io/browse/JENKINS-57831). A more conservative version of #448.

### Problem

During a recent Jenkins upgrade, one of my Swarm clients (which are started with `-deleteExistingClients` so that they can reconnect to Jenkins after a controller restart) failed to reconnect. Jobs then eventually hit the `org.jenkinsci.plugins.workflow.support.pickles.ExecutorPickle.timeoutForNodeMillis` timeout and failed.

### Evaluation

Looking at the Swarm client logs, I saw that Swarm had successfully called `SwarmClient#createSwarmAgent` against the controller and had proceeded to delegate to Remoting. Remoting was then logging

```
2021-04-28 14:53:26 WARNING org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver isPortVisible Connection refused (Connection refused)
2021-04-28 14:53:26 SEVERE hudson.remoting.jnlp.Main$CuiListener error http://example.com/ provided port:12345 is not reachable
java.io.IOException: http://example.com/ provided port:12345 is not reachable
        at org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.resolve(JnlpAgentEndpointResolver.java:311)
        at hudson.remoting.Engine.innerRun(Engine.java:689)
        at hudson.remoting.Engine.run(Engine.java:514)
```

after which no further retries were taking place.

I could easily reproduce this artificially by modifying Remoting with

```java
diff --git a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
index 511cf5e6..e1e8a432 100644
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -355,7 +355,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
         try {
             s = new Socket();
             s.setReuseAddress(true);
-            SocketAddress sa = new InetSocketAddress(hostname, port);
+            SocketAddress sa = new InetSocketAddress(hostname, port + 37);
             s.connect(sa, 5000);
         } catch (IOException e) {
             LOGGER.warning(e.getMessage());
```

Tracing the execution, I found we were eventually reaching `hudson.remoting.jnlp.Main$CuiListener` which was calling `System.exit(-1)` to exit the process. Needless to say, the process can't keep retrying after that.

### Solution

Add a tunable to make JNLP agent endpoint resolution exceptions non-fatal for situations like these where Remoting is being consumed programmatically by higher-level code in Swarm. Swarm is capable of retrying on JNLP agent endpoint resolution failure.

### Testing Done

I confirmed that after modifying Swarm with

```java
diff --git a/client/src/main/java/hudson/plugins/swarm/Client.java b/client/src/main/java/hudson/plugins/swarm/Client.java
index e0ddc8f..a051b3f 100644
--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -184,6 +184,9 @@ public class Client {
                     labelFileWatcherThread.start();
                 }
 
+                // Prevent Remoting from killing the process on JNLP agent endpoint resolution exceptions.
+                System.setProperty("hudson.remoting.Engine.nonFatalJnlpAgentEndpointResolutionExceptions", "true");
+
                 /*
                  * Note that any instances of InterruptedException or RuntimeException thrown
                  * internally by the next two lines get wrapped in RetryException.
```

`hudson.remoting.jnlp.Main$CuiListener` no longer terminated the process and Swarm was able to retry.