### PR TITLE
[JENKINS-40700] Enable current engine to hold the communication protocol

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -158,6 +158,7 @@ public class Engine extends Thread {
     private final String agentName;
     private boolean webSocket;
     private String credentials;
+    private String protocolName;
     private String proxyCredentials = System.getProperty("proxyCredentials");
 
     /**
@@ -625,6 +626,7 @@ public class Engine extends Thread {
                 while (ch.get() == null) {
                     Thread.sleep(100);
                 }
+                this.protocolName = "WebSocket";
                 events.status("Connected");
                 ch.get().join();
                 events.status("Terminated");
@@ -750,6 +752,7 @@ public class Engine extends Thread {
 
                         // On success do not try other protocols.
                         if (channel != null) {
+                            this.protocolName = protocol.getName();
                             break;
                         }
 
@@ -996,6 +999,10 @@ public class Engine extends Thread {
     public String getAgentName() {
         // This is used by various external components that need to get the name from the engine.
         return agentName;
+    }
+
+    public String getProtocolName() {
+        return this.protocolName;
     }
 
     private class EngineJnlpConnectionStateListener extends JnlpConnectionStateListener {


### PR DESCRIPTION
I'm working on the ticket below for my first contribution to Jenkins!
[[JENKINS-40700] Display communication  protocol in agent logs](https://issues.jenkins.io/browse/JENKINS-40700)

As it is difficult to know the communication protocol from the established channel on the controller side, I propose holding the communication protocol name on the agent side. It is much simpler than holding it on the controller side.  

So, what I do here is
- Save the protocol name when the channel is established
- Create an endpoint to provide the protocol name

~I'll submit another PR that uses this feature on the controller side to [jenkinsci / jenkins](https://github.com/jenkinsci/jenkins) soon.~
I submitted the PR that uses this feature on the controller side to  [jenkinsci / jenkins](https://github.com/jenkinsci/jenkins).
link: https://github.com/jenkinsci/jenkins/pull/5459

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue