### PR TITLE
[JENKINS-40700] Enable Launcher to hold the communication protocol.

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -1009,6 +1009,14 @@ public class Engine extends Thread {
         return agentName;
     }
 
+    /**
+     * Get the name of the communication protocol used in this Engine instance.
+     * When the channel is not established by Engine (that is, {@link Engine#current()}) returns null),
+     * use {@link Launcher#getCommunicationProtocolName()} instead.
+     *
+     * @return the communication protocol name.
+     * @since 4.8
+     */
     public String getProtocolName() {
         return this.protocolName;
     }


### PR DESCRIPTION
I'm working on the ticket below.
[[JENKINS-40700] Display communication  protocol in agent logs](https://issues.jenkins.io/browse/JENKINS-40700)

And this is the continuation of #450.
#450 enables the current Engine to hold the name of the using communication protocol such as `JNLP4-connect`.

This PR enables Launcher to hold communication protocol name such as `TCP (remote: client)` or `Standard in/out`

I submitted the PR that uses this feature on the controller side to [jenkinsci / jenkins](https://github.com/jenkinsci/jenkins).
link: jenkinsci/jenkins#5459

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
