### PR TITLE
Define `hudsonUrl` in WebSocket mode to fix agent installers

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -376,9 +376,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
 
     @Nonnull
     private URL toAgentListenerURL(@Nonnull String jenkinsUrl) throws MalformedURLException {
-        return jenkinsUrl.endsWith("/")
-                ? new URL(jenkinsUrl + "tcpSlaveAgentListener/")
-                : new URL(jenkinsUrl + "/tcpSlaveAgentListener/");
+        return new URL(jenkinsUrl + "tcpSlaveAgentListener/");
     }
 
     @Override


### PR DESCRIPTION
I noticed in CloudBees CI trying to launch a shared agent in WebSocket mode from the Java Web Start button an error indicating that the equivalent of https://github.com/jenkinsci/slave-installer-module/blob/8ab32a0616d147adef0d27fb51a359796e069eeb/src/main/java/org/jenkinsci/modules/slave_installer/impl/InstallerGui.java#L78 was throwing an NPE, despite the Jenkins root URL being configured. I could not reproduce a similar stack trace using an OSS agent connection, though the installer menu was not created either, so maybe the exception was just swallowed somewhere, or printed to the agent log which I forgot to check. Anyway, it seems clear from code that this `getHudsonUrl` method would have worked in TCP but not WebSocket mode.

Also cleaning up a trailing slash check introduced in #391.

Tested in context by building Jenkins core with this, then building CBCI operations center & connected controller with that, running both, hooking them up, and going through two scenarios:

* static agent on the CC
* shared agent on the OC

In both cases, used the JWS launch button and got a **File** from the agent installer (systemd in my case) as expected.