### PR TITLE
Custom connection headers

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -158,6 +158,7 @@ public class Engine extends Thread {
     private final String secretKey;
     private final String agentName;
     private boolean webSocket;
+    private Map<String, String> connectionHeaders;
     private String credentials;
     private String protocolName;
     private String proxyCredentials = System.getProperty("proxyCredentials");
@@ -350,6 +351,10 @@ public class Engine extends Thread {
         this.webSocket = webSocket;
     }
 
+    public void setConnectionHeaders(@Nonnull Map<String, String> connectionHeaders) {
+        this.connectionHeaders = connectionHeaders;
+    }
+
     /**
      * If set, connect to the specified host and port instead of connecting directly to Jenkins.
      * @param tunnel Value. {@code null} to disable tunneling
@@ -534,6 +539,11 @@ public class Engine extends Thread {
                         headers.put(JnlpConnectionState.SECRET_KEY, Collections.singletonList(secretKey));
                         headers.put(Capability.KEY, Collections.singletonList(localCap));
                         // TODO use JnlpConnectionState.COOKIE_KEY somehow (see EngineJnlpConnectionStateListener.afterChannel)
+                        if (connectionHeaders != null) {
+                            for (Map.Entry<String, String> entry : connectionHeaders.entrySet()) {
+                                headers.put(entry.getKey(), Collections.singletonList(entry.getValue()));
+                            }
+                        }
                         LOGGER.fine(() -> "Sending: " + headers);
                     }
                     @Override
@@ -673,6 +683,11 @@ public class Engine extends Thread {
         final Map<String,String> headers = new HashMap<>();
         headers.put(JnlpConnectionState.CLIENT_NAME_KEY, agentName);
         headers.put(JnlpConnectionState.SECRET_KEY, secretKey);
+        if (connectionHeaders != null) {
+            for (Map.Entry<String, String> entry : connectionHeaders.entrySet()) {
+                headers.put(entry.getKey(), entry.getValue());
+            }
+        }
         List<String> jenkinsUrls = new ArrayList<>();
         for (URL url: candidateUrls) {
             jenkinsUrls.add(url.toExternalForm());

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -28,6 +28,7 @@ import hudson.remoting.Engine;
 import hudson.remoting.EngineListener;
 import hudson.remoting.FileSystemJarCache;
 import hudson.remoting.Util;
+import java.util.Map;
 import org.jenkinsci.remoting.engine.WorkDirManager;
 import org.jenkinsci.remoting.util.PathUtils;
 import org.kohsuke.args4j.Argument;
@@ -85,6 +86,11 @@ public class Main {
             depends="-url",
             forbids={"-direct", "-tunnel", "-credentials", "-proxyCredentials", "-cert", "-disableHttpsCertValidation", "-noKeepAlive"})
     public boolean webSocket;
+
+    @Option(name="-connectionHeader",
+            usage="Additional connection header to set, eg for authenticating with reverse proxies. To specify multiple headers, call this flag multiple times, one with each header",
+            metaVar = "NAME=VALUE")
+    public Map<String, String> connectionHeaders;
 
     @Option(name="-credentials",metaVar="USER:PASSWORD",
             usage="HTTP BASIC AUTH header to pass in for making HTTP requests.")
@@ -300,6 +306,8 @@ public class Main {
                 headlessMode ? new CuiListener() : new GuiListener(),
                 urls, args.get(0), agentName, directConnection, instanceIdentity, new HashSet<>(protocols));
         engine.setWebSocket(webSocket);
+        if(connectionHeaders !=null)
+            engine.setConnectionHeaders(connectionHeaders);
         if(tunnel!=null)
             engine.setTunnel(tunnel);
         if(credentials!=null)


### PR DESCRIPTION
Add the -connectionHeaders flag to add additional custom headers to the connection request.

These additional headers are then used when connecting to jenkins either via JNLP or websockets. 

Use-case: You have a reverse proxy in front of jenkins that requires custom headers to authenticate/route correctly.


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
