### PR TITLE
Reference new tcp-agent-listener endpoint

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -151,7 +151,7 @@ public class Engine extends Thread {
      *
      * <p>
      * This value is determined from {@link #candidateUrls} after a successful connection.
-     * Note that this URL <b>DOES NOT</b> have "tcpSlaveAgentListener" in it.
+     * Note that this URL <b>DOES NOT</b> have "tcp-agent-listener" in it.
      */
     @CheckForNull
     private URL hudsonUrl;
@@ -639,7 +639,7 @@ public class Engine extends Thread {
                 }
                 events.onDisconnect();
                 while (true) {
-                    // Unlike JnlpAgentEndpointResolver, we do not use $jenkins/tcpSlaveAgentListener/, as that will be a 404 if the TCP port is disabled.
+                    // Unlike JnlpAgentEndpointResolver, we do not use $jenkins/tcp-agent-listener/, as that will be a 404 if the TCP port is disabled.
                     URL ping = new URL(candidateUrls.get(0), "login");
                     try {
                         HttpURLConnection conn = (HttpURLConnection) ping.openConnection();

--- a/src/main/java/org/jenkinsci/remoting/RoleSensitive.java
+++ b/src/main/java/org/jenkinsci/remoting/RoleSensitive.java
@@ -38,5 +38,7 @@ public interface RoleSensitive {
      *      receive {@link AbstractMethodError}, and treat that as if the invocation of
      *      {@code checker.check(this,Role.UNKNOWN)} has happened.
      */
+    // TODO Update Javadoc once https://github.com/jenkinsci/jenkins/pull/5494 is updated
+    // TODO Update Javadoc once developer documentation is migrated to jenkins.io/doc/developer
     void checkRoles(RoleChecker checker) throws SecurityException;
 }

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -377,8 +377,8 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
     @Nonnull
     private URL toAgentListenerURL(@Nonnull String jenkinsUrl) throws MalformedURLException {
         return jenkinsUrl.endsWith("/")
-                ? new URL(jenkinsUrl + "tcpSlaveAgentListener/")
-                : new URL(jenkinsUrl + "/tcpSlaveAgentListener/");
+                ? new URL(jenkinsUrl + "tcp-agent-listener/")
+                : new URL(jenkinsUrl + "/tcp-agent-listener/");
     }
 
     @Override


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/jenkins/pull/5495

It is unclear to me what the compatibility requirements of remoting are. This is a very simple patch that assumes remoting can be older (~minimum version defined in core), but never newer.

Also noting two TODOs where further cleanup can be done once https://github.com/jenkinsci/jenkins/pull/5494 is released or developer documentation migrated away from the wiki.