### PR TITLE
Allow setting of custom websocket headers

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -351,6 +351,11 @@ public class Engine extends Thread {
         this.webSocket = webSocket;
     }
 
+    /**
+     * Sets map of custom websocket headers. These headers will be applied to the websocket connection to Jenkins.
+     *
+     * @param webSocketHeaders a map of the headers to apply to the websocket connection
+     */
     public void setWebSocketHeaders(@Nonnull Map<String, String> webSocketHeaders) {
         this.webSocketHeaders = webSocketHeaders;
     }

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -158,6 +158,7 @@ public class Engine extends Thread {
     private final String secretKey;
     private final String agentName;
     private boolean webSocket;
+    private Map<String, String> webSocketHeaders;
     private String credentials;
     private String protocolName;
     private String proxyCredentials = System.getProperty("proxyCredentials");
@@ -350,6 +351,10 @@ public class Engine extends Thread {
         this.webSocket = webSocket;
     }
 
+    public void setWebSocketHeaders(@Nonnull Map<String, String> webSocketHeaders) {
+        this.webSocketHeaders = webSocketHeaders;
+    }
+
     /**
      * If set, connect to the specified host and port instead of connecting directly to Jenkins.
      * @param tunnel Value. {@code null} to disable tunneling
@@ -534,6 +539,11 @@ public class Engine extends Thread {
                         headers.put(JnlpConnectionState.SECRET_KEY, Collections.singletonList(secretKey));
                         headers.put(Capability.KEY, Collections.singletonList(localCap));
                         // TODO use JnlpConnectionState.COOKIE_KEY somehow (see EngineJnlpConnectionStateListener.afterChannel)
+                        if (webSocketHeaders != null) {
+                            for (Map.Entry<String, String> entry : webSocketHeaders.entrySet()) {
+                                headers.put(entry.getKey(), Collections.singletonList(entry.getValue()));
+                            }
+                        }
                         LOGGER.fine(() -> "Sending: " + headers);
                     }
                     @Override

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -28,6 +28,7 @@ import hudson.remoting.Engine;
 import hudson.remoting.EngineListener;
 import hudson.remoting.FileSystemJarCache;
 import hudson.remoting.Util;
+import java.util.Map;
 import org.jenkinsci.remoting.engine.WorkDirManager;
 import org.jenkinsci.remoting.util.PathUtils;
 import org.kohsuke.args4j.Argument;
@@ -85,6 +86,12 @@ public class Main {
             depends="-url",
             forbids={"-direct", "-tunnel", "-credentials", "-proxyCredentials", "-cert", "-disableHttpsCertValidation", "-noKeepAlive"})
     public boolean webSocket;
+
+    @Option(name="-webSocketHeader",
+            usage="Additional WebSocket header to set, eg for authenticating with reverse proxies. To specify multiple headers, call this flag multiple times, one with each header",
+            metaVar = "NAME=VALUE",
+            depends="-webSocket")
+    public Map<String, String> webSocketHeaders;
 
     @Option(name="-credentials",metaVar="USER:PASSWORD",
             usage="HTTP BASIC AUTH header to pass in for making HTTP requests.")
@@ -300,6 +307,8 @@ public class Main {
                 headlessMode ? new CuiListener() : new GuiListener(),
                 urls, args.get(0), agentName, directConnection, instanceIdentity, new HashSet<>(protocols));
         engine.setWebSocket(webSocket);
+        if(webSocketHeaders!=null)
+            engine.setWebSocketHeaders(webSocketHeaders);
         if(tunnel!=null)
             engine.setTunnel(tunnel);
         if(credentials!=null)


### PR DESCRIPTION
Add the -websocketHeader flag to add additional custom headers to the connection request.

These additional headers are then used when connecting to jenkins via websockets.

Use-case: You have a reverse proxy in front of jenkins that requires custom headers to authenticate/route correctly.

Supercedes #455 

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
