### PR TITLE
[JENKINS-61212] Update Tyrus (WebSocket client) to 1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.glassfish.tyrus.bundles</groupId>
       <artifactId>tyrus-standalone-client-jdk</artifactId>
-      <version>1.17</version>
+      <version>1.18</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
**Untested** but may fix [JENKINS-61212](https://issues.jenkins.io/browse/JENKINS-61212) by picking up https://github.com/eclipse-ee4j/tyrus/pull/707. Also see https://github.com/jenkinsci/jenkins/pull/5716 for the CLI.
