### PR TITLE
JENKINS-66915: Don't die when reconnect fails.

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -861,7 +861,7 @@ public class Engine extends Thread {
     }
 
     private void onConnectionRejected(String greeting) throws InterruptedException {
-        events.error(new Exception("The server rejected the connection: " + greeting));
+        events.status("reconnect rejected, sleeping 10s: ", new Exception("The server rejected the connection: " + greeting));
         TimeUnit.SECONDS.sleep(10);
     }
 


### PR DESCRIPTION
Don't die when reconnect fails. Instead do the 10s sleep as intentionally written in the code.

The current code will do a retry if the connection with master fail, but if the new connection attempt fails, it will exit. Instead it should retry after 10s.

See issue: https://issues.jenkins.io/browse/JENKINS-66915

I am currently running this fix in our system and its working fine.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

