### PR TITLE
Integrate SECURITY-2458 changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ THE SOFTWARE.
 
   <groupId>org.jenkins-ci.main</groupId>
   <artifactId>remoting</artifactId>
-  <version>4.11.1</version>
+  <version>${revision}${changelist}</version>
 
   <name>Jenkins remoting layer</name>
   <url>https://github.com/jenkinsci/remoting</url>
@@ -58,11 +58,11 @@ THE SOFTWARE.
     <connection>scm:git:git://github.com/jenkinsci/remoting.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/remoting.git</developerConnection>
     <url>https://github.com/jenkinsci/remoting</url>
-    <tag>remoting-4.11.1</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <properties>
-    <revision>4.12</revision>
+    <revision>4.11.2</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
     <build.type>private</build.type>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@ THE SOFTWARE.
   </scm>
 
   <properties>
-    <revision>4.11.2</revision>
+    <revision>4.12</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
     <build.type>private</build.type>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ THE SOFTWARE.
 
   <groupId>org.jenkins-ci.main</groupId>
   <artifactId>remoting</artifactId>
-  <version>${revision}${changelist}</version>
+  <version>4.11.1</version>
 
   <name>Jenkins remoting layer</name>
   <url>https://github.com/jenkinsci/remoting</url>
@@ -58,7 +58,7 @@ THE SOFTWARE.
     <connection>scm:git:git://github.com/jenkinsci/remoting.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/remoting.git</developerConnection>
     <url>https://github.com/jenkinsci/remoting</url>
-    <tag>${scmTag}</tag>
+    <tag>remoting-4.11.1</tag>
   </scm>
 
   <properties>

--- a/src/main/java/hudson/remoting/Callable.java
+++ b/src/main/java/hudson/remoting/Callable.java
@@ -36,6 +36,9 @@ import java.io.Serializable;
 /**
  * Represents computation to be done on a remote system.
  *
+ * <p>You probably don't want to implement this directly in Jenkins, instead choose {@code MasterToSlaveCallable},
+ * {@code NotReallyRoleSensitiveCallable}, or (in rare cases) {@code SlaveToMasterCallable}.</p>
+ *
  * @see Channel
  * @author Kohsuke Kawaguchi
  */

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1280,6 +1280,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
             // no specific role needed, which is somewhat dubious, but I can't think of any attack vector that involves this.
             // it would have been simpler if the setMaximumBytecodeLevel only controlled the local setting,
             // not the remote setting
+            checker.check(this);
         }
     }
 
@@ -1783,6 +1784,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
          */
         @Override
         public void checkRoles(RoleChecker checker) throws SecurityException {
+            checker.check(this);
         }
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/remoting/PingThread.java
+++ b/src/main/java/hudson/remoting/PingThread.java
@@ -153,7 +153,7 @@ public abstract class PingThread extends Thread {
         onDead();   // fall back
     }
 
-    private static final class Ping implements Callable<Void, IOException> {
+    static final class Ping implements Callable<Void, IOException> {
         private static final long serialVersionUID = 1L;
 
         @Override
@@ -164,6 +164,7 @@ public abstract class PingThread extends Thread {
         @Override
         public void checkRoles(RoleChecker checker) throws SecurityException {
             // this callable is literally no-op, can't get any safer than that
+            // TODO: Apply `checker.check(this)` after release and make this type private again
         }
     }
 

--- a/src/main/java/hudson/remoting/RequiredRoleCheckerWrapper.java
+++ b/src/main/java/hudson/remoting/RequiredRoleCheckerWrapper.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.remoting;
+
+import org.jenkinsci.remoting.Role;
+import org.jenkinsci.remoting.RoleChecker;
+import org.jenkinsci.remoting.RoleSensitive;
+
+import java.util.Collection;
+
+/**
+ * Implementation that can tell whether a {@code #check} method was invoked.
+ */
+/* package-private */ class RequiredRoleCheckerWrapper extends RoleChecker {
+    private boolean checked;
+
+    private RoleChecker roleChecker;
+
+    public RequiredRoleCheckerWrapper(RoleChecker roleChecker) {
+        this.roleChecker = roleChecker;
+    }
+
+    @Override
+    public void check(RoleSensitive subject, Role... expected) throws SecurityException {
+        checked = true;
+        roleChecker.check(subject, expected);
+    }
+
+    @Override
+    public void check(RoleSensitive subject, Role expected) throws SecurityException {
+        checked = true;
+        roleChecker.check(subject, expected);
+    }
+
+    @Override
+    public void check(RoleSensitive subject, Collection<Role> expected) throws SecurityException {
+        checked = true;
+        roleChecker.check(subject, expected);
+    }
+
+    public boolean isChecked() {
+        return checked;
+    }
+}

--- a/src/main/java/org/jenkinsci/remoting/RoleChecker.java
+++ b/src/main/java/org/jenkinsci/remoting/RoleChecker.java
@@ -28,7 +28,10 @@ public abstract class RoleChecker {
      *      Object whose role we are checking right now. Useful context information when reporting an error.
      * @param expected
      *      The current JVM that executes the callable should have one of these roles.
-     *      Never empty nor null.
+     *      Never null.
+     *      Use an empty collection to indicate that any channel can execute a given callable without restriction.
+     *      <strong>Unless you are extremely careful, this is likely to result in a security vulnerability.
+     *      Doing this is strongly discouraged.</strong>
      * @throws SecurityException
      *      Any exception thrown will prevent the callable from getting executed, but we recommend
      *      {@link SecurityException}


### PR DESCRIPTION
Context:
https://www.jenkins.io/doc/upgrade-guide/2.303/#SECURITY-2458
https://www.jenkins.io/doc/developer/security/remoting-callables/

Probably debatable whether we want to keep the new behavior to allow `RoleChecker#check(RoleSensitive)`; probably makes sense to amend this and just allow all remoting callables to ignore the role check (not just some). For now, this needs merging so that the released change is on `master` though.