### PR TITLE
Allow all remoting callables to bypass role check

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1274,13 +1274,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
             Channel.currentOrFail().maximumBytecodeLevel = level;
             return null;
         }
-
-        @Override
-        public void checkRoles(RoleChecker checker) throws SecurityException {
-            // no specific role needed, which is somewhat dubious, but I can't think of any attack vector that involves this.
-            // it would have been simpler if the setMaximumBytecodeLevel only controlled the local setting,
-            // not the remote setting
-        }
+        // no specific role needed, which is somewhat dubious, but I can't think of any attack vector that involves this.
+        // it would have been simpler if the setMaximumBytecodeLevel only controlled the local setting,
+        // not the remote setting
     }
 
     /**
@@ -1774,17 +1770,12 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
             Channel.currentOrFail().syncLocalIO();
             return null;
         }
-
-        /**
+        /*
          * This callable is needed for the proper operation of pipes.
          * In the worst case it causes a bit of wasted CPU cycles without any side-effect,
          * and one can always refuse to read/write from/to pipe, so this layer need not provide
          * any security.
          */
-        @Override
-        public void checkRoles(RoleChecker checker) throws SecurityException {
-        }
-
         private static final long serialVersionUID = 1L;
     }
 

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -53,7 +53,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1264,7 +1263,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         }
         call(new SetMaximumBytecodeLevel(level));
     }
-    /* package */ static final class SetMaximumBytecodeLevel implements Callable<Void,RuntimeException> {
+    private static final class SetMaximumBytecodeLevel implements InternalCallable<Void,RuntimeException> {
         private static final long serialVersionUID = 1;
         private final short level;
         SetMaximumBytecodeLevel(short level) {
@@ -1769,7 +1768,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         }
     }
 
-    /* package */ static final class IOSyncer implements Callable<Object, InterruptedException> {
+    private static final class IOSyncer implements InternalCallable<Object, InterruptedException> {
         @Override
         public Object call() throws InterruptedException {
             Channel.currentOrFail().syncLocalIO();

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1264,7 +1264,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         }
         call(new SetMaximumBytecodeLevel(level));
     }
-    private static final class SetMaximumBytecodeLevel implements Callable<Void,RuntimeException> {
+    /* package */ static final class SetMaximumBytecodeLevel implements Callable<Void,RuntimeException> {
         private static final long serialVersionUID = 1;
         private final short level;
         SetMaximumBytecodeLevel(short level) {
@@ -1281,7 +1281,6 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
             // no specific role needed, which is somewhat dubious, but I can't think of any attack vector that involves this.
             // it would have been simpler if the setMaximumBytecodeLevel only controlled the local setting,
             // not the remote setting
-            checker.check(this);
         }
     }
 
@@ -1770,7 +1769,7 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         }
     }
 
-    private static final class IOSyncer implements Callable<Object, InterruptedException> {
+    /* package */ static final class IOSyncer implements Callable<Object, InterruptedException> {
         @Override
         public Object call() throws InterruptedException {
             Channel.currentOrFail().syncLocalIO();
@@ -1785,7 +1784,6 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
          */
         @Override
         public void checkRoles(RoleChecker checker) throws SecurityException {
-            checker.check(this);
         }
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/remoting/ChannelBuilder.java
+++ b/src/main/java/hudson/remoting/ChannelBuilder.java
@@ -48,16 +48,9 @@ public class ChannelBuilder {
     private static final Logger LOGGER = Logger.getLogger(ChannelBuilder.class.getName());
     private static /* non-final for Groovy */ boolean CALLABLES_CAN_IGNORE_ROLECHECKER = Boolean.getBoolean(ChannelBuilder.class.getName() + ".allCallablesCanIgnoreRoleChecker");
 
-    private static final Set<String> REMOTING_CALLABLES = new HashSet<>();
     private static final Set<String> SPECIFIC_CALLABLES_CAN_IGNORE_ROLECHECKER = new HashSet<>();
 
     static {
-        REMOTING_CALLABLES.add(RemoteInvocationHandler.RPCRequest.class.getName());
-        REMOTING_CALLABLES.add(RemoteInvocationHandler.UserRPCRequest.class.getName());
-        REMOTING_CALLABLES.add(PingThread.Ping.class.getName());
-        REMOTING_CALLABLES.add(Channel.SetMaximumBytecodeLevel.class.getName());
-        REMOTING_CALLABLES.add(Channel.IOSyncer.class.getName());
-
         final String propertyName = ChannelBuilder.class.getName() + ".specificCallablesCanIgnoreRoleChecker";
         final String property = System.getProperty(propertyName);
         if (property != null) {
@@ -312,8 +305,8 @@ public class ChannelBuilder {
             return false;
         }
 
-        if (REMOTING_CALLABLES.contains(callable.getClass().getName())) {
-            LOGGER.log(Level.FINE, () -> "Callable " + callable.getClass().getName() + " is a remoting built-in callable");
+        if (callable instanceof InternalCallable) {
+            LOGGER.log(Level.FINE, () -> "Callable " + callable.getClass().getName() + " is a remoting built-in callable allowed to bypass the role check");
         }
 
         if (SPECIFIC_CALLABLES_CAN_IGNORE_ROLECHECKER.contains(callable.getClass().getName())) {

--- a/src/main/java/hudson/remoting/ChannelBuilder.java
+++ b/src/main/java/hudson/remoting/ChannelBuilder.java
@@ -307,6 +307,7 @@ public class ChannelBuilder {
 
         if (callable instanceof InternalCallable) {
             LOGGER.log(Level.FINE, () -> "Callable " + callable.getClass().getName() + " is a remoting built-in callable allowed to bypass the role check");
+            return false;
         }
 
         if (SPECIFIC_CALLABLES_CAN_IGNORE_ROLECHECKER.contains(callable.getClass().getName())) {

--- a/src/main/java/hudson/remoting/ChannelBuilder.java
+++ b/src/main/java/hudson/remoting/ChannelBuilder.java
@@ -312,7 +312,7 @@ public class ChannelBuilder {
             return false;
         }
 
-        if (REMOTING_CALLABLES.contains(callable.getClass().getName()))) {
+        if (REMOTING_CALLABLES.contains(callable.getClass().getName())) {
             LOGGER.log(Level.FINE, () -> "Callable " + callable.getClass().getName() + " is a remoting built-in callable");
         }
 

--- a/src/main/java/hudson/remoting/ChannelBuilder.java
+++ b/src/main/java/hudson/remoting/ChannelBuilder.java
@@ -301,17 +301,17 @@ public class ChannelBuilder {
 
     private static boolean isCallableProhibitedByRequiredRoleCheck(Callable<?, ?> callable) {
         if (CALLABLES_CAN_IGNORE_ROLECHECKER) {
-            LOGGER.log(Level.FINE, () -> "Allowing all callables to ignore RoleChecker");
+            LOGGER.fine(() -> "Allowing all callables to ignore RoleChecker");
             return false;
         }
 
         if (callable instanceof InternalCallable) {
-            LOGGER.log(Level.FINE, () -> "Callable " + callable.getClass().getName() + " is a remoting built-in callable allowed to bypass the role check");
+            LOGGER.fine(() -> "Callable " + callable.getClass().getName() + " is a remoting built-in callable allowed to bypass the role check");
             return false;
         }
 
         if (SPECIFIC_CALLABLES_CAN_IGNORE_ROLECHECKER.contains(callable.getClass().getName())) {
-            LOGGER.log(Level.FINE, () -> "Callable " + callable.getClass().getName() + " is allowed through override");
+            LOGGER.fine(() -> "Callable " + callable.getClass().getName() + " is allowed through override");
             return false;
         }
 

--- a/src/main/java/hudson/remoting/InternalCallable.java
+++ b/src/main/java/hudson/remoting/InternalCallable.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.remoting;
+
+/**
+ * For remoting internal use only: {@link hudson.remoting.Callable}s implement
+ * this marker interface to be allowed to bypass the required role check of
+ * {@link hudson.remoting.RequiredRoleCheckerWrapper}.
+ *
+ * @since TODO
+ */
+/* package */ interface InternalCallable<V, T extends Throwable> extends Callable<V, T> {
+}

--- a/src/main/java/hudson/remoting/InternalCallable.java
+++ b/src/main/java/hudson/remoting/InternalCallable.java
@@ -30,7 +30,11 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 /**
  * For remoting internal use only: {@link hudson.remoting.Callable}s implement
  * this marker interface to be allowed to bypass the required role check of
- * {@link hudson.remoting.RequiredRoleCheckerWrapper}.
+ * {@link hudson.remoting.RequiredRoleCheckerWrapper}, as the application-defined
+ * roles are unknown to remoting.
+ * Callables defined in Jenkins need to extend {@code MasterToSlaveCallable} or
+ * (rarely) {@code SlaveToMasterCallable}, or (almost never) implement
+ * their own role checks.
  *
  * @since TODO
  */

--- a/src/main/java/hudson/remoting/InternalCallable.java
+++ b/src/main/java/hudson/remoting/InternalCallable.java
@@ -23,6 +23,10 @@
  */
 package hudson.remoting;
 
+import org.jenkinsci.remoting.RoleChecker;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
 /**
  * For remoting internal use only: {@link hudson.remoting.Callable}s implement
  * this marker interface to be allowed to bypass the required role check of
@@ -30,5 +34,10 @@ package hudson.remoting;
  *
  * @since TODO
  */
+@Restricted(NoExternalUse.class)
 /* package */ interface InternalCallable<V, T extends Throwable> extends Callable<V, T> {
+    @Override
+    default void checkRoles(RoleChecker checker) throws SecurityException {
+        // no-op
+    }
 }

--- a/src/main/java/hudson/remoting/PingThread.java
+++ b/src/main/java/hudson/remoting/PingThread.java
@@ -160,11 +160,6 @@ public abstract class PingThread extends Thread {
         public Void call() throws IOException {
             return null;
         }
-
-        @Override
-        public void checkRoles(RoleChecker checker) throws SecurityException {
-            // this callable is literally no-op, can't get any safer than that
-        }
     }
 
     private static final Logger LOGGER = Logger.getLogger(PingThread.class.getName());

--- a/src/main/java/hudson/remoting/PingThread.java
+++ b/src/main/java/hudson/remoting/PingThread.java
@@ -153,7 +153,7 @@ public abstract class PingThread extends Thread {
         onDead();   // fall back
     }
 
-    static final class Ping implements Callable<Void, IOException> {
+    private static final class Ping implements InternalCallable<Void, IOException> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/src/main/java/hudson/remoting/PingThread.java
+++ b/src/main/java/hudson/remoting/PingThread.java
@@ -164,7 +164,6 @@ public abstract class PingThread extends Thread {
         @Override
         public void checkRoles(RoleChecker checker) throws SecurityException {
             // this callable is literally no-op, can't get any safer than that
-            // TODO: Apply `checker.check(this)` after release and make this type private again
         }
     }
 

--- a/src/main/java/hudson/remoting/RemoteInvocationHandler.java
+++ b/src/main/java/hudson/remoting/RemoteInvocationHandler.java
@@ -852,6 +852,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
      * @see UserRPCRequest
      */
     static class RPCRequest extends Request<Serializable,Throwable> implements DelegatingCallable<Serializable,Throwable>, InternalCallable<Serializable, Throwable> {
+        // this callable only executes public methods exported by this side, so these methods are assumed to be safe
         /**
          * Target object id to invoke.
          */
@@ -900,11 +901,6 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         @Override
         public Serializable call() throws Throwable {
             return perform(getChannelOrFail());
-        }
-
-        @Override
-        public void checkRoles(RoleChecker checker) throws SecurityException {
-            // this callable only executes public methods exported by this side, so these methods are assumed to be safe
         }
 
         @Override

--- a/src/main/java/hudson/remoting/RemoteInvocationHandler.java
+++ b/src/main/java/hudson/remoting/RemoteInvocationHandler.java
@@ -991,7 +991,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
      * this can be used to send a method call to user-level objects, and
      * classes for the parameters and the return value are sent remotely if needed.
      */
-    private static class UserRPCRequest extends RPCRequest {
+    /* package */ static class UserRPCRequest extends RPCRequest {
 
         private static final long serialVersionUID = -9185841650347902580L;
 

--- a/src/main/java/hudson/remoting/RemoteInvocationHandler.java
+++ b/src/main/java/hudson/remoting/RemoteInvocationHandler.java
@@ -851,7 +851,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
      *
      * @see UserRPCRequest
      */
-    static class RPCRequest extends Request<Serializable,Throwable> implements DelegatingCallable<Serializable,Throwable> {
+    static class RPCRequest extends Request<Serializable,Throwable> implements DelegatingCallable<Serializable,Throwable>, InternalCallable<Serializable, Throwable> {
         /**
          * Target object id to invoke.
          */
@@ -991,7 +991,7 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
      * this can be used to send a method call to user-level objects, and
      * classes for the parameters and the return value are sent remotely if needed.
      */
-    /* package */ static class UserRPCRequest extends RPCRequest {
+    private static class UserRPCRequest extends RPCRequest {
 
         private static final long serialVersionUID = -9185841650347902580L;
 

--- a/src/main/java/org/jenkinsci/remoting/RoleChecker.java
+++ b/src/main/java/org/jenkinsci/remoting/RoleChecker.java
@@ -28,10 +28,7 @@ public abstract class RoleChecker {
      *      Object whose role we are checking right now. Useful context information when reporting an error.
      * @param expected
      *      The current JVM that executes the callable should have one of these roles.
-     *      Never null.
-     *      Use an empty collection to indicate that any channel can execute a given callable without restriction.
-     *      <strong>Unless you are extremely careful, this is likely to result in a security vulnerability.
-     *      Doing this is strongly discouraged.</strong>
+     *      Never null or empty.
      * @throws SecurityException
      *      Any exception thrown will prevent the callable from getting executed, but we recommend
      *      {@link SecurityException}

--- a/src/main/java/org/jenkinsci/remoting/RoleChecker.java
+++ b/src/main/java/org/jenkinsci/remoting/RoleChecker.java
@@ -28,7 +28,7 @@ public abstract class RoleChecker {
      *      Object whose role we are checking right now. Useful context information when reporting an error.
      * @param expected
      *      The current JVM that executes the callable should have one of these roles.
-     *      Never null or empty.
+     *      Never empty nor null.
      * @throws SecurityException
      *      Any exception thrown will prevent the callable from getting executed, but we recommend
      *      {@link SecurityException}


### PR DESCRIPTION
This removes the need to support `RoleChecker#check(RoleSensitive)`

Downstream PR: https://github.com/jenkinsci/jenkins/pull/5901

Corresponding docs update: https://github.com/jenkins-infra/jenkins.io/pull/4707

----

During development of the [SECURITY-2458 security hardening](https://www.jenkins.io/doc/book/security/controller-isolation/required-role-check/), we noticed some `Callable`s defined in remoting would be rejected; but they couldn't perform a real role check, because application-level roles aren't known to remoting.

Additionally, I thought it might be useful to allow calling `RoleChecker#check(RoleSensitive, Role...)` without any `Role`, to indicate that a `Callable` doesn't wish to limit where it can execute. Unfortunately this didn't work for `RPCRequest` because it would prevent classloading, as that's what exposes classloaders. Beyond that, there was some pushback about allowing explicit role checks without any roles in user code, so much so that [the developer docs](https://www.jenkins.io/doc/developer/security/remoting-callables/#mandatory-role-checks) say we'll suspend distribution of any plugin that does this (which isn't really helpful).

For 2.303.3 and 2.319, we ended up with a kind of hybrid approach: Some `Callable`s did the `RoleChecker#check(RoleSensitive)`, others were explicitly exempted from the role check requirement. And because of the former, we added support for `RoleChecker#check(RoleSensitive)` to core -- while documenting that nobody should use it.

----

This PR cleans this up: It restores the expectation that all user-defined `Callable`s perform a non-empty role check with an actual role. `Callable`s defined in remoting, unaware of application-level roles, do not need to perform a real role check. `InternalCallable` represents that that.

**Please squash-merge this PR.**