### PR TITLE
[JENKINS-65873] Use at most one thread to check classes

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -114,7 +114,7 @@ public class Engine extends Thread {
     /**
      * Thread pool that sets {@link #CURRENT}.
      */
-    private final ExecutorService executor = FIXED_THREAD_POOL != null ? Executors.newFixedThreadPool(FIXED_THREAD_POOL, getThreadFactory()) : Executors.newCachedThreadPool(getThreadFactory());
+    private final ExecutorService executor = FIXED_THREAD_POOL == null ? Executors.newCachedThreadPool(getThreadFactory()) : Executors.newFixedThreadPool(FIXED_THREAD_POOL, getThreadFactory());
 
     private NamingThreadFactory getThreadFactory() {
         return new NamingThreadFactory(new ThreadFactory() {

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -457,6 +457,12 @@ final class RemoteClassLoader extends URLClassLoader {
             throw (ClassFormatError) new ClassFormatError("Failed to load " + name).initCause(e);
         } catch (LinkageError e) {
             throw new LinkageError("Failed to load " + name, e);
+        } catch (OutOfMemoryError oom) {
+            String message = oom.getMessage();
+            if (message != null && message.contains("unable to create new native thread")) {
+                oom.addSuppressed(new Exception("Currently " + Thread.getAllStackTraces().size() + " threads, including " + Thread.activeCount() + " in the current thread group"));
+            }
+            throw oom;
         }
     }
 

--- a/src/main/java/org/jenkinsci/remoting/util/AnonymousClassWarnings.java
+++ b/src/main/java/org/jenkinsci/remoting/util/AnonymousClassWarnings.java
@@ -51,8 +51,7 @@ public class AnonymousClassWarnings {
     private static final Logger LOGGER = Logger.getLogger(AnonymousClassWarnings.class.getName());
     private static final Map<Class<?>, Boolean> checked = new WeakHashMap<>();
 
-    private final static boolean USE_SEPARATE_THREAD_POOL = Boolean.getBoolean(AnonymousClassWarnings.class.getName() + ".useSeparateThreadPool");
-    private final static ExecutorService THREAD_POOL =  USE_SEPARATE_THREAD_POOL ? new AtmostOneThreadExecutor(new NamingThreadFactory(new DaemonThreadFactory(), AnonymousClassWarnings.class.getSimpleName())) : null;
+    private final static ExecutorService THREAD_POOL =  new AtmostOneThreadExecutor(new NamingThreadFactory(new DaemonThreadFactory(), AnonymousClassWarnings.class.getSimpleName()));
 
     /**
      * Checks a class which is being either serialized or deserialized.
@@ -70,7 +69,7 @@ public class AnonymousClassWarnings {
         } else {
             // May not call methods like Class#isAnonymousClass synchronously, since these can in turn trigger remote class loading.
             try {
-                (USE_SEPARATE_THREAD_POOL ? THREAD_POOL : channel.executor).submit(() -> doCheck(clazz));
+                THREAD_POOL.submit(() -> doCheck(clazz));
             } catch (RejectedExecutionException x) {
                 // never mind, we tried
             }

--- a/src/main/java/org/jenkinsci/remoting/util/AnonymousClassWarnings.java
+++ b/src/main/java/org/jenkinsci/remoting/util/AnonymousClassWarnings.java
@@ -52,7 +52,7 @@ public class AnonymousClassWarnings {
     private static final Map<Class<?>, Boolean> checked = new WeakHashMap<>();
 
     private final static boolean USE_SEPARATE_THREAD_POOL = Boolean.getBoolean(AnonymousClassWarnings.class.getName() + ".useSeparateThreadPool");
-    private final static ExecutorService threadPool =  USE_SEPARATE_THREAD_POOL ? new AtmostOneThreadExecutor(new NamingThreadFactory(new DaemonThreadFactory(), AnonymousClassWarnings.class.getSimpleName())) : null;
+    private final static ExecutorService THREAD_POOL =  USE_SEPARATE_THREAD_POOL ? new AtmostOneThreadExecutor(new NamingThreadFactory(new DaemonThreadFactory(), AnonymousClassWarnings.class.getSimpleName())) : null;
 
     /**
      * Checks a class which is being either serialized or deserialized.
@@ -70,7 +70,7 @@ public class AnonymousClassWarnings {
         } else {
             // May not call methods like Class#isAnonymousClass synchronously, since these can in turn trigger remote class loading.
             try {
-                (USE_SEPARATE_THREAD_POOL ? threadPool : channel.executor).submit(() -> doCheck(clazz));
+                (USE_SEPARATE_THREAD_POOL ? THREAD_POOL : channel.executor).submit(() -> doCheck(clazz));
             } catch (RejectedExecutionException x) {
                 // never mind, we tried
             }


### PR DESCRIPTION
The current implementation reuses the ExecutorService from the channel, which is unbounded.

With a lot of classes to check on agent initialization, this can cause random errors like `java.lang.OutOfMemoryError: unable to create native thread: possibly out of memory or process/resource limits reached`

As there may be multiple factors at play here, this is adding a separate thread pool to perform class check. Backed by system property `org.jenkinsci.remoting.util.AnonymousClassWarnings.useSeparateThreadPool`.

Round 2: Since this doesn't seem to be the only factor, I have also added the system property `hudson.remoting.Engine.threadPoolSize`. Given an integer, it will replace the default unbounded cached thread pool by a fixed size based thread pool. Example `-Dhudson.remoting.Engine.threadPoolSize=10`. In case an OOM is raised, the current number of threads should be dumped in the stacktrace directly.

[JENKINS-65873](https://issues.jenkins.io/browse/JENKINS-65873)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
