### PR TITLE
JENKINS-67928 Prevent infinite loop in case of closed SSL connection

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/SSLEngineFilterLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/SSLEngineFilterLayer.java
@@ -348,6 +348,8 @@ public class SSLEngineFilterLayer extends FilterLayer {
                     switch (result.getStatus()) {
                         case BUFFER_UNDERFLOW:
                     /* we need more data */
+                        case CLOSED:
+                    /* connection is already closed */
                             done = true;
                             break;
                         case BUFFER_OVERFLOW:
@@ -367,8 +369,6 @@ public class SSLEngineFilterLayer extends FilterLayer {
                                 next().onRecv(appBuffer);
                                 appBuffer.clear();
                             }
-                            break;
-                        case CLOSED:
                             break;
                     }
                     handshakeStatus = sslEngine.getHandshakeStatus();


### PR DESCRIPTION
**Background**
I've found increased CPU load at my Jenkins instance.
The root cause of CPU load was a thread that is stuck in an infinite loop in SSLEngineFilterLayer.java
The remote agent was already terminated by kubernetes-plugin and the SSL connection is closed, but the thread is still working because can't exit from the while loop.

**Solution**
Set _done_ flag in case of receiving `SSLEngineResult.Status.CLOSED` from `sslEngine.unwrap(tempBuffer, appBuffer)`.
This change is allowed to return execution flow to `NIONetworkLayer.ready()` where the thread will handle ClosedChannelException.

**Libraries versions**
Jenkins core - 2.319.3
kubernetes - 1.31.3
remoting - 4.11.2

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

