### PR TITLE
JENKINS-66446 Agent reconnects on Java 11 and websocket

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -683,10 +683,21 @@ public class Engine extends Thread {
                     }
                     TimeUnit.SECONDS.sleep(10);
                 }
-                events.onReconnect();
+                reconnect();
             }
         } catch (Exception e) {
             events.error(e);
+        }
+    }
+
+    private void reconnect() {
+        try {
+            events.status("Performing onReconnect operation.");
+            events.onReconnect();
+            events.status("onReconnect operation completed.");
+        } catch (NoClassDefFoundError e) {
+            events.status("onReconnect operation failed.");
+            LOGGER.log(Level.FINE, "Reconnection error.", e);
         }
     }
 
@@ -828,14 +839,7 @@ public class Engine extends Thread {
                 // try to connect back to the server every 10 secs.
                 resolver.waitForReady();
 
-                try {
-                    events.status("Performing onReconnect operation.");
-                    events.onReconnect();
-                    events.status("onReconnect operation completed.");
-                } catch (NoClassDefFoundError e) {
-                    events.status("onReconnect operation failed.");
-                    LOGGER.log(Level.FINE, "Reconnection error.", e);
-                }
+                reconnect();
             }
         } catch (Throwable e) {
             events.error(e);

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -697,7 +697,7 @@ public class Engine extends Thread {
             events.status("onReconnect operation completed.");
         } catch (NoClassDefFoundError e) {
             events.status("onReconnect operation failed.");
-            LOGGER.log(Level.FINE, "Reconnection error.", e);
+            LOGGER.log(Level.WARNING, "Reconnection error.", e);
         }
     }
 


### PR DESCRIPTION
Extracts the logic from https://github.com/jenkinsci/remoting/pull/295 which wasn't re-used in the websocket protocol

See https://issues.jenkins.io/browse/JENKINS-66446

To reproduce:

1. Use Java 11 on the agent
2. Create a Permanent agent with websocket protocol enabled
3. Restart the controller
4. It should fail to reconnect the agent with a `NoClassDefFoundError: jenkins/slaves/restarter/JnlpSlaveRestarterInstaller`
5. Repeat steps with this patch, reconnects just fine