### PR TITLE
Add Java 11 and 17 to build/test matrix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-inline</artifactId>
       <version>4.4.0</version>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/hudson/remoting/CommandTransport.java
+++ b/src/main/java/hudson/remoting/CommandTransport.java
@@ -107,9 +107,9 @@ public abstract class CommandTransport {
      * 
      * For subtypes that prefer synchronous operation, extend from {@link SynchronousCommandTransport}.
      * 
-     * <h2>Closing the read pump</h2>
      * <p>
-     * {@link Channel} implements {@code Channel.CloseCommand} its own "end of command stream" marker, and
+     * <strong>Closing the read pump:</strong> {@link Channel} implements
+     * {@code Channel.CloseCommand} its own "end of command stream" marker, and
      * therefore under the orderly shutdown scenario, it doesn't rely on the transport to provide EOF-like
      * marker. Instead, {@link Channel} will call your {@link #closeRead()} (from the same thread
      * that invoked {@link CommandReceiver#handle(Command)}) to indicate that it is done with the reading.


### PR DESCRIPTION
Update the build/test matrix to include recent versions of Java, as is being done in other core components.