### PR TITLE
[JENKINS-65873] Throttle anonymous class warnings to a single thread

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/util/AnonymousClassWarnings.java
+++ b/src/main/java/org/jenkinsci/remoting/util/AnonymousClassWarnings.java
@@ -26,8 +26,11 @@ package org.jenkinsci.remoting.util;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.remoting.AtmostOneThreadExecutor;
 import hudson.remoting.Channel;
 
+import hudson.remoting.DaemonThreadFactory;
+import hudson.remoting.NamingThreadFactory;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
@@ -35,6 +38,7 @@ import java.net.URL;
 import java.security.CodeSource;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.logging.Logger;
 
@@ -46,6 +50,8 @@ public class AnonymousClassWarnings {
 
     private static final Logger LOGGER = Logger.getLogger(AnonymousClassWarnings.class.getName());
     private static final Map<Class<?>, Boolean> checked = new WeakHashMap<>();
+
+    private final static ExecutorService THREAD_POOL =  new AtmostOneThreadExecutor(new NamingThreadFactory(new DaemonThreadFactory(), AnonymousClassWarnings.class.getSimpleName()));
 
     /**
      * Checks a class which is being either serialized or deserialized.
@@ -63,7 +69,7 @@ public class AnonymousClassWarnings {
         } else {
             // May not call methods like Class#isAnonymousClass synchronously, since these can in turn trigger remote class loading.
             try {
-                channel.executor.submit(() -> doCheck(clazz));
+                THREAD_POOL.submit(() -> doCheck(clazz));
             } catch (RejectedExecutionException x) {
                 // never mind, we tried
             }


### PR DESCRIPTION
Split from #505.

Anonymous class check is done async and is not a critical process, so it shouldn't use more than one thread at a time.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
