### PR TITLE
Set tarLongFileMode to enable building on systems with large UID / GID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@ THE SOFTWARE.
             <descriptor>src/assembly/agent-load-test.xml</descriptor>
           </descriptors>
           <attach>false</attach>
-          <tarLongFileMode>posix</tarLongFileMode> <!-- MASSEMBLY-728 -->
+          <tarLongFileMode>posix</tarLongFileMode> <!-- https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#tarFileModes -->
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,7 @@ THE SOFTWARE.
             <descriptor>src/assembly/agent-load-test.xml</descriptor>
           </descriptors>
           <attach>false</attach>
+          <tarLongFileMode>posix</tarLongFileMode> <!-- MASSEMBLY-728 -->
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Building this plugin on a system with large UID / GID fails due to
```
user id '<< Long UID >>' is too big ( > 2097151 )
```

This is a known issue of assembly-plugin, using POSIX `tarLongFileMode` solves it.

- https://issues.apache.org/jira/browse/MASSEMBLY-728
- https://stackoverflow.com/questions/30246705/mvn-failure-on-build
- https://stackoverflow.com/questions/33819438/maven-assembly-plugin-group-id-1377585961-is-too-big-error

---------------------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
