### PR TITLE
Don't set null SecurityManager on Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,11 @@ THE SOFTWARE.
       <version>9.3</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>version-number</artifactId>
+      <version>1.10</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -249,6 +249,7 @@ public class Main {
      * Main without the argument handling.
      */
     public static void _main(String[] args) throws IOException, InterruptedException, CmdLineException {
+        // TODO skip this on Java 17+ as it prints a warning, otherwise needed for JavaWebStart agents (JENKINS-67000, JENKINS-67913)
         if (JavaSpecificationVersion.forCurrentJVM().isOlderThan(new VersionNumber("17"))) {
             try {
                 System.setSecurityManager(null);

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -31,6 +31,9 @@ import hudson.remoting.EngineListener;
 import hudson.remoting.FileSystemJarCache;
 import hudson.remoting.Util;
 import java.util.Map;
+
+import hudson.util.VersionNumber;
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import org.jenkinsci.remoting.engine.WorkDirManager;
 import org.jenkinsci.remoting.util.PathUtils;
 import org.kohsuke.args4j.Argument;
@@ -246,12 +249,12 @@ public class Main {
      * Main without the argument handling.
      */
     public static void _main(String[] args) throws IOException, InterruptedException, CmdLineException {
-        // TODO skip this on Java 17+ (e.g. io.jenkins.lib.versionnumber.JavaSpecificationVersion) as it prints a warning
-        // otherwise needed for JavaWebStart agents (JENKINS-67000)
-        try {
-            System.setSecurityManager(null);
-        } catch (SecurityException e) {
-            // ignore
+        if (JavaSpecificationVersion.forCurrentJVM().isOlderThan(new VersionNumber("17"))) {
+            try {
+                System.setSecurityManager(null);
+            } catch (SecurityException e) {
+                // ignore
+            }
         }
 
         // if we run in Mac, put the menu bar where the user expects it


### PR DESCRIPTION
Sets a null Security Manager on Java < 17 only.

- #507 
- #481
- [JENKINS-67000](https://issues.jenkins.io/browse/JENKINS-67000)
- [JENKINS-67913](https://issues.jenkins.io/browse/JENKINS-67913)

--------------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
