### PR TITLE
Suppress some uninteresting stack traces when channel is closed

### DIFF
--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -213,7 +213,7 @@ final class UserRequest<RSP,EXC extends Throwable> extends Request<UserRequest.R
                     Thread.currentThread().setContextClassLoader(old);
                 }
             } catch (LinkageError e) {
-                LOGGER.log(Level.WARNING, "LinkageError while performing " + toString(), e);
+                LOGGER.log(channel.isClosingOrClosed() ? Level.FINE : Level.WARNING, "LinkageError while performing " + toString(), e);
                 throw e;
             } finally {
                 Channel.setCurrent(oldc);


### PR DESCRIPTION
Irritated while running https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/195:

```
… hudson.remoting.JarCacheSupport$DownloadRunnable run
WARNING: Failed to resolve a jar 96455c4416b1dfc9256f9617336c0f7d
java.io.IOException: Failed to write to …/remoting/jarCache/96/455C4416B1DFC9256F9617336C0F7D.jar
	at hudson.remoting.FileSystemJarCache.retrieve(FileSystemJarCache.java:148)
	at hudson.remoting.JarCacheSupport$DownloadRunnable.run(JarCacheSupport.java:113)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.AtmostOneThreadExecutor$Worker.run(AtmostOneThreadExecutor.java:121)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.IOException: Backing channel 'JNLP4-connect connection to localhost/127.0.0.1:… is disconnected.
	at hudson.remoting.RemoteInvocationHandler.channelOrFail(RemoteInvocationHandler.java:215)
	at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:285)
	at com.sun.proxy.$Proxy4.writeJarTo(Unknown Source)
	at hudson.remoting.FileSystemJarCache.retrieve(FileSystemJarCache.java:115)
	... 5 more
Caused by: hudson.remoting.Channel$OrderlyShutdown: Command Close created at
	at hudson.remoting.Channel$CloseCommand.execute(Channel.java:1314)
	at hudson.remoting.Channel$1.handle(Channel.java:606)
	at hudson.remoting.AbstractByteBufferCommandTransport.processCommand(AbstractByteBufferCommandTransport.java:204)
	at hudson.remoting.AbstractByteBufferCommandTransport.receive(AbstractByteBufferCommandTransport.java:190)
	at org.jenkinsci.remoting.protocol.impl.ChannelApplicationLayer.onRead(ChannelApplicationLayer.java:214)
	at org.jenkinsci.remoting.protocol.ApplicationLayer.onRecv(ApplicationLayer.java:206)
	at org.jenkinsci.remoting.protocol.ProtocolStack$Ptr.onRecv(ProtocolStack.java:677)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.processRead(SSLEngineFilterLayer.java:368)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.onRecv(SSLEngineFilterLayer.java:118)
	at org.jenkinsci.remoting.protocol.ProtocolStack$Ptr.onRecv(ProtocolStack.java:677)
	at org.jenkinsci.remoting.protocol.NetworkLayer.onRead(NetworkLayer.java:136)
	at org.jenkinsci.remoting.protocol.impl.BIONetworkLayer.access$2200(BIONetworkLayer.java:50)
	at org.jenkinsci.remoting.protocol.impl.BIONetworkLayer$Reader.run(BIONetworkLayer.java:292)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:121)
	... 1 more
Caused by: Command Close created at
	at hudson.remoting.Command.<init>(Command.java:70)
	at hudson.remoting.Channel$CloseCommand.<init>(Channel.java:1307)
	at hudson.remoting.Channel$CloseCommand.<init>(Channel.java:1305)
	at hudson.remoting.Channel.close(Channel.java:1481)
	at hudson.remoting.Channel.close(Channel.java:1448)
	at org.jvnet.hudson.test.ChannelShutdownListener.onTearDown(ChannelShutdownListener.java:45)
	at org.jvnet.hudson.test.JenkinsRule.after(JenkinsRule.java:498)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:625)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	... 1 more
```

and

```
… hudson.remoting.jnlp.Main$CuiListener status
INFO: Terminated
… hudson.remoting.UserRequest perform
WARNING: LinkageError while performing UserRequest:hudson.Launcher$RemoteLauncher$KillTask@…
java.lang.NoClassDefFoundError: hudson/util/ProcessTree$OSProcess
	at hudson.util.ProcessTree.<clinit>(ProcessTree.java:507)
	at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1168)
	at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1158)
	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:376)
	at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:121)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: Could not load class hudson.util.ProcessTree$OSProcess after 1 tries.
	at hudson.remoting.RemoteClassLoader.loadRemoteClass(RemoteClassLoader.java:316)
	at hudson.remoting.RemoteClassLoader.loadWithMultiClassLoader(RemoteClassLoader.java:269)
	at hudson.remoting.RemoteClassLoader.findClass(RemoteClassLoader.java:228)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	... 12 more
```

Also see https://github.com/jenkinsci/jenkins-test-harness/pull/431 & https://github.com/jenkinsci/jenkins/pull/6555.
