### PR TITLE
fix: add exponential backoff

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@ THE SOFTWARE.
 
   <dependencies>
     <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-retry</artifactId>
+      <version>1.7.1</version>
+    </dependency>
+    <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
       <version>2.33</version>

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -31,11 +31,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.Socket;
-import java.net.URI;
-import java.net.URL;
+import java.net.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.UnresolvedAddressException;
 import java.nio.file.Path;
@@ -925,18 +921,18 @@ public class Engine extends Thread {
      * @param endpoint Connection endpoint
      * @throws IOException Connection failure or invalid parameter specification
      */
-    private Socket connectTcp(@NonNull JnlpAgentEndpoint endpoint) throws IOException, InterruptedException {
+    private Socket connectTcp(@NonNull JnlpAgentEndpoint endpoint) {
         String msg = "Connecting to " + endpoint.getHost() + ':' + endpoint.getPort();
         events.status(msg);
 
-        AtomicReference<Socket> s = new AtomicReference<>();
+        AtomicReference<Socket> socketRef = new AtomicReference<>();
 
         Supplier<Boolean> tcpSupplier = () -> {
             try {
                 Socket socket = endpoint.open(SOCKET_TIMEOUT);
                 socket.setKeepAlive(keepAlive);
 
-                s.set(socket);
+                socketRef.set(socket);
             } catch (IOException x) {
                 LOGGER.log(Level.WARNING, "Can't open TCP connection", x);
                 return Boolean.TRUE;
@@ -951,8 +947,8 @@ public class Engine extends Thread {
             throw new IllegalStateException("TCP socket is not initialized");
         }
 
-        if (s.get() != null) {
-            return s.get();
+        if (socketRef.get() != null) {
+            return socketRef.get();
         }
 
         throw new IllegalStateException("TCP socket is not initialized");

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -77,9 +77,9 @@ public class Main {
             usage="(deprecated; now always headless)")
     public boolean headlessMode;
 
-    @Option(name = "-ws-retry-attempts",
-            usage = "WebSocket connect backoff retry attempts")
-    public int wsRetryAttempts = 30;
+    @Option(name = "-retry-attempts",
+            usage = "Agent connect backoff retry attempts")
+    public int retryAttempts = 20;
 
     @Option(name="-url",
             usage="Specify the Jenkins root URLs to connect to.")
@@ -309,7 +309,7 @@ public class Main {
             engine.setJarCache(new FileSystemJarCache(jarCache,true));
         engine.setNoReconnect(noReconnect);
         engine.setKeepAlive(!noKeepAlive);
-        engine.setWsRetryAttempts(wsRetryAttempts);
+        engine.setRetryAttempts(retryAttempts);
 
         if (disableHttpsCertValidation) {
             LOGGER.log(WARNING, "Certificate validation for HTTPs endpoints is disabled");

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -77,6 +77,10 @@ public class Main {
             usage="(deprecated; now always headless)")
     public boolean headlessMode;
 
+    @Option(name = "-ws-retry-attempts",
+            usage = "WebSocket connect backoff retry attempts")
+    public int wsRetryAttempts = 30;
+
     @Option(name="-url",
             usage="Specify the Jenkins root URLs to connect to.")
     public List<URL> urls = new ArrayList<>();
@@ -305,6 +309,7 @@ public class Main {
             engine.setJarCache(new FileSystemJarCache(jarCache,true));
         engine.setNoReconnect(noReconnect);
         engine.setKeepAlive(!noKeepAlive);
+        engine.setWsRetryAttempts(wsRetryAttempts);
 
         if (disableHttpsCertValidation) {
             LOGGER.log(WARNING, "Certificate validation for HTTPs endpoints is disabled");

--- a/src/test/java/hudson/remoting/EngineTest.java
+++ b/src/test/java/hudson/remoting/EngineTest.java
@@ -96,9 +96,9 @@ public class EngineTest {
         AtomicInteger count = new AtomicInteger(0);
 
         Engine.exponentialRetry(15,
-                () -> count.getAndIncrement() < 10);
+                () -> count.getAndIncrement() < 3);
 
-        assertEquals(11, count.get());
+        assertEquals(4, count.get());
     }
 
     @Test

--- a/src/test/java/hudson/remoting/EngineTest.java
+++ b/src/test/java/hudson/remoting/EngineTest.java
@@ -33,7 +33,6 @@ import org.jvnet.hudson.test.Issue;
 
 import java.io.File;
 import java.net.URL;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -92,7 +91,7 @@ public class EngineTest {
     }
 
     @Test
-    public void retryTest() {
+    public void shouldPerformRetryCount() {
         AtomicInteger count = new AtomicInteger(0);
 
         Engine.exponentialRetry(15,


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I faced with DNS/timeout issues during agent initialization
WebSocket mode
```
io.jenkins.remoting.shaded.javax.websocket.DeploymentException: Connection failed.
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.container.jdk.client.JdkClientContainer$1.call(JdkClientContainer.java:187)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.container.jdk.client.JdkClientContainer$1.call(JdkClientContainer.java:107)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.container.jdk.client.JdkClientContainer.openClientSocket(JdkClientContainer.java:192)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.client.ClientManager$3$1.run(ClientManager.java:647)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.client.ClientManager$3.run(ClientManager.java:696)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.client.ClientManager$SameThreadExecutorService.execute(ClientManager.java:849)
	at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:112)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.client.ClientManager.connectToServer(ClientManager.java:493)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.client.ClientManager.connectToServer(ClientManager.java:337)
	at hudson.remoting.Engine.runWebSocket(Engine.java:656)
	at hudson.remoting.Engine.run(Engine.java:495)
Caused by: java.nio.channels.UnresolvedAddressException
	at sun.nio.ch.Net.checkAddress(Net.java:104)
	at sun.nio.ch.UnixAsynchronousSocketChannelImpl.implConnect(UnixAsynchronousSocketChannelImpl.java:302)
	at sun.nio.ch.AsynchronousSocketChannelImpl.connect(AsynchronousSocketChannelImpl.java:210)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.container.jdk.client.TransportFilter.handleConnect(TransportFilter.java:184)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.container.jdk.client.Filter.connect(Filter.java:80)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.container.jdk.client.Filter.connect(Filter.java:83)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.container.jdk.client.Filter.connect(Filter.java:83)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.container.jdk.client.ClientFilter.connect(ClientFilter.java:99)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.container.jdk.client.JdkClientContainer.connectSynchronously(JdkClientContainer.java:326)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.container.jdk.client.JdkClientContainer.access$700(JdkClientContainer.java:58)
	at io.jenkins.remoting.shaded.org.glassfish.tyrus.container.jdk.client.JdkClientContainer$1.call(JdkClientContainer.java:156)
	... 12 more
```
TCP socket mode
```
java.io.IOException: Failed to connect to http://jenkins-url/tcpSlaveAgentListener/: connect timed out
	at org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.resolve(JnlpAgentEndpointResolver.java:214)
	at hudson.remoting.Engine.innerRun(Engine.java:733)
	at hudson.remoting.Engine.run(Engine.java:539)
Caused by: java.net.SocketTimeoutException: connect timed out
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:607)
	at sun.net.NetworkClient.doConnect(NetworkClient.java:175)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:463)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:558)
	at sun.net.www.http.HttpClient.<init>(HttpClient.java:242)
	at sun.net.www.http.HttpClient.New(HttpClient.java:339)
	at sun.net.www.http.HttpClient.New(HttpClient.java:357)
	at sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:1228)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1162)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1056)
	at sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:990)
	at org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.resolve(JnlpAgentEndpointResolver.java:211)
	... 2 more
```

I'm trying to detect exact issue. Seems it relates to some K8s/JDK networking corner case.
Anyway the PR introduces exponential backoff workaround which resolves the issue on source code level. It can help to avoid potential network issues.

<!--
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
-->

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
