### PR TITLE
[JENKINS-68542] Rename the header used for connection cookie

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -110,9 +110,9 @@ public class Engine extends Thread {
     public static final String REMOTING_MINIMUM_VERSION_HEADER = "X-Remoting-Minimum-Version";
 
     /**
-     * The property name for the cookie name key for websockets.
+     * The header name to be used for the connection cookie when using websockets.
      */
-    public static final String WEBSOCKET_COOKIE_KEY = "Connection-Cookie";
+    public static final String WEBSOCKET_COOKIE_HEADER = "Connection-Cookie";
 
     /**
      * Thread pool that sets {@link #CURRENT}.
@@ -582,11 +582,11 @@ public class Engine extends Thread {
                             }
                         }
                         try {
-                            List<String> cookies = hr.getHeaders().get(Engine.WEBSOCKET_COOKIE_KEY);
+                            List<String> cookies = hr.getHeaders().get(Engine.WEBSOCKET_COOKIE_HEADER);
                             if (cookies != null && !cookies.isEmpty()) {
-                                addedHeaders.put(Engine.WEBSOCKET_COOKIE_KEY, Collections.singletonList(cookies.get(0)));
+                                addedHeaders.put(Engine.WEBSOCKET_COOKIE_HEADER, Collections.singletonList(cookies.get(0)));
                             } else {
-                                addedHeaders.remove(Engine.WEBSOCKET_COOKIE_KEY);
+                                addedHeaders.remove(Engine.WEBSOCKET_COOKIE_HEADER);
                             }
                             remoteCapability = Capability.fromASCII(hr.getHeaders().get(Capability.KEY).get(0));
                             LOGGER.fine(() -> "received " + remoteCapability);

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -110,6 +110,11 @@ public class Engine extends Thread {
     public static final String REMOTING_MINIMUM_VERSION_HEADER = "X-Remoting-Minimum-Version";
 
     /**
+     * The property name for the cookie name key for websockets.
+     */
+    public static final String WEBSOCKET_COOKIE_KEY = "Connection-Cookie";
+
+    /**
      * Thread pool that sets {@link #CURRENT}.
      */
     private final ExecutorService executor = Executors.newCachedThreadPool(new ThreadFactory() {
@@ -577,11 +582,11 @@ public class Engine extends Thread {
                             }
                         }
                         try {
-                            List<String> cookies = hr.getHeaders().get(JnlpConnectionState.COOKIE_KEY);
+                            List<String> cookies = hr.getHeaders().get(Engine.WEBSOCKET_COOKIE_KEY);
                             if (cookies != null && !cookies.isEmpty()) {
-                                addedHeaders.put(JnlpConnectionState.COOKIE_KEY, Collections.singletonList(cookies.get(0)));
+                                addedHeaders.put(Engine.WEBSOCKET_COOKIE_KEY, Collections.singletonList(cookies.get(0)));
                             } else {
-                                addedHeaders.remove(JnlpConnectionState.COOKIE_KEY);
+                                addedHeaders.remove(Engine.WEBSOCKET_COOKIE_KEY);
                             }
                             remoteCapability = Capability.fromASCII(hr.getHeaders().get(Capability.KEY).get(0));
                             LOGGER.fine(() -> "received " + remoteCapability);

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpConnectionState.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpConnectionState.java
@@ -66,7 +66,7 @@ public class JnlpConnectionState {
     /**
      * The property name for the cookie name key.
      */
-    public static final String COOKIE_KEY = "Connection-Cookie";
+    public static final String COOKIE_KEY = "JnlpAgentProtocol.cookie";
 
     /**
      * Socket connection to the agent.

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpConnectionState.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpConnectionState.java
@@ -66,7 +66,7 @@ public class JnlpConnectionState {
     /**
      * The property name for the cookie name key.
      */
-    public static final String COOKIE_KEY = "JnlpAgentProtocol.cookie";
+    public static final String COOKIE_KEY = "Connection-Cookie";
 
     /**
      * Socket connection to the agent.


### PR DESCRIPTION
Follows-up #537, needed for https://github.com/jenkinsci/jenkins/pull/6576

The previous value was not a valid HTTP header name and could get
filtered by reverse proxies such as nginx, causing the previous fix not to work when using such setup.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
