### PR TITLE
Remove args4j `OSGI-OPT` files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,15 @@ THE SOFTWARE.
             <phase>package</phase>
             <configuration>
               <createDependencyReducedPom>false</createDependencyReducedPom>
+              <filters>
+                <filter>
+                  <artifact>args4j:args4j</artifact>
+                  <excludes>
+                    <exclude>OSGI-OPT/**/*.html</exclude>
+                    <exclude>OSGI-OPT/**/*.java</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <relocations>
                 <relocation>
                   <pattern>javax.websocket</pattern>


### PR DESCRIPTION
In https://github.com/jenkinsci/jenkins/pull/6658 I noticed that `remoting.jar` was shipping a bunch of Java and HTML files in `OSGI-OPT` that are also contained in `args4j-2.33.jar`, which was tripping up `ClassPathTest` in Jenkins core. It is probably a bug that these files are included in `args4j-2.33.jar` in the first place, but since we do not have direct control over that library and [my last pull request from July 4, 2021](https://github.com/kohsuke/args4j/pull/182) remains unacknowledged 11 months later, the least we can do is not propagate this error in `remoting.jar`. This PR filters out these unneeded files. To test this PR, I successfully ran `ClassPathTest` from https://github.com/jenkinsci/jenkins/pull/6658 with these exclusions removed.