### PR TITLE
Ignore reflection exception for Java > 8

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -150,8 +150,13 @@ public class Launcher {
         Method $addURL = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
         $addURL.setAccessible(true);
 
-        for(String token : pathList.split(File.pathSeparator))
-            $addURL.invoke(ClassLoader.getSystemClassLoader(),new File(token).toURI().toURL());
+        try {
+            for(String token : pathList.split(File.pathSeparator))
+                $addURL.invoke(ClassLoader.getSystemClassLoader(),new File(token).toURI().toURL());
+        } catch (IllegalArgumentException ex) {
+            // looks like Java > 8 ... ignore it ...
+            LOGGER.log(Level.WARNING, "Cannot do reflection - ignore it...", ex);
+        }
 
         // fix up the system.class.path to pretend that those jar files
         // are given through CLASSPATH or something.


### PR DESCRIPTION
Ignore reflection exception for Java > 8 to make selenium plugin usable for Java 11.

Jenkins moves to Java 11 👍 but the jenkins plugin (https://plugins.jenkins.io/selenium/) does not work with Java 11 (see https://support.cloudbees.com/hc/en-us/articles/360031995252-Selenium-plugin-issue-in-Java-11-SSH-connection-closed) 👎 

This fix catches the reflection exception and enables the selenium plugin again 👍 

Sure a better fix, would be to update somehow the selenium plugin, but this is not maintained anymore and the more important, it uses an official path (see below). So this fix may enables more plugins to work with Java 11. The path is the following:

hudson.plugins.selenium.process.SeleniumProcessUtils calls hudson.slaves.Channels.newJVM (jenkins-core)
hudson.slaves.Channels.newJVM calls hudson.remoting.Launcher (using the -cp argument and this fails for Java > 8)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira (linked to support.cloudbees.com)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue