### PR TITLE
Restore `SSLContextRule` tests

### DIFF
--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocolHandlerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpProtocolHandlerTest.java
@@ -62,13 +62,13 @@ public class JnlpProtocolHandlerTest {
     private static RSAKeyPairRule clientKey = new RSAKeyPairRule();
     private static RSAKeyPairRule serverKey = new RSAKeyPairRule();
     private static RSAKeyPairRule caRootKey = new RSAKeyPairRule();
-    private static X509CertificateRule caRootCert = X509CertificateRule.create("caRoot", caRootKey, caRootKey);
-    private static X509CertificateRule clientCert = X509CertificateRule.create("client", clientKey, caRootKey);
-    private static X509CertificateRule serverCert = X509CertificateRule.create("server", serverKey, caRootKey);
+    private static X509CertificateRule caRootCert = X509CertificateRule.create("caRoot", caRootKey, caRootKey, null);
+    private static X509CertificateRule clientCert = X509CertificateRule.create("client", clientKey, caRootKey, caRootCert);
+    private static X509CertificateRule serverCert = X509CertificateRule.create("server", serverKey, caRootKey, caRootCert);
     private static X509CertificateRule expiredClientCert =
-            X509CertificateRule.create("expiredClient", clientKey, caRootKey, -10, -5, TimeUnit.DAYS);
+            X509CertificateRule.create("expiredClient", clientKey, caRootKey, caRootCert, -10, -5, TimeUnit.DAYS);
     private static X509CertificateRule notYetValidServerCert =
-            X509CertificateRule.create("notYetValidServer", serverKey, caRootKey, +5, +10, TimeUnit.DAYS);
+            X509CertificateRule.create("notYetValidServer", serverKey, caRootKey, caRootCert, +5, +10, TimeUnit.DAYS);
     private static SSLContextRule clientCtx =
             new SSLContextRule("client")
                     .as(clientKey, clientCert, caRootCert)

--- a/src/test/java/org/jenkinsci/remoting/protocol/cert/BlindTrustX509ExtendedTrustManagerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/cert/BlindTrustX509ExtendedTrustManagerTest.java
@@ -40,7 +40,7 @@ public class BlindTrustX509ExtendedTrustManagerTest {
 
     public static RSAKeyPairRule key = new RSAKeyPairRule("main");
 
-    public static X509CertificateRule cert = new X509CertificateRule("main", key, key, -1, 1, TimeUnit.HOURS);
+    public static X509CertificateRule cert = new X509CertificateRule("main", key, key, null, -1, 1, TimeUnit.HOURS);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(key)

--- a/src/test/java/org/jenkinsci/remoting/protocol/cert/PublicKeyMatchingX509ExtendedTrustManagerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/cert/PublicKeyMatchingX509ExtendedTrustManagerTest.java
@@ -42,8 +42,8 @@ public class PublicKeyMatchingX509ExtendedTrustManagerTest {
     public static RSAKeyPairRule key = new RSAKeyPairRule("main");
     public static RSAKeyPairRule altKey = new RSAKeyPairRule("main");
 
-    public static X509CertificateRule cert = new X509CertificateRule("main", key, key, -1, 1, TimeUnit.HOURS);
-    public static X509CertificateRule altCert = new X509CertificateRule("main", altKey, altKey, -1, 1, TimeUnit.HOURS);
+    public static X509CertificateRule cert = new X509CertificateRule("main", key, key, null, -1, 1, TimeUnit.HOURS);
+    public static X509CertificateRule altCert = new X509CertificateRule("main", altKey, altKey, null,  -1, 1, TimeUnit.HOURS);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(key)

--- a/src/test/java/org/jenkinsci/remoting/protocol/cert/SSLContextRule.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/cert/SSLContextRule.java
@@ -23,8 +23,6 @@
  */
 package org.jenkinsci.remoting.protocol.cert;
 
-import static org.junit.Assume.assumeNoException;
-
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -52,7 +50,6 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedTrustManager;
-import org.jenkinsci.remoting.util.VersionNumber;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -96,13 +93,7 @@ public class SSLContextRule implements TestRule {
                 for (int i = 0; i < key.chain.length; i++) {
                     chain[i] = key.chain[i].certificate();
                 }
-                try {
-                    store.setKeyEntry("alias-" + id, key.key.getPrivate(), password, chain);
-                } catch (KeyStoreException e) {
-                    if (new VersionNumber(System.getProperty("java.specification.version")).isNewerThanOrEqualTo(new VersionNumber("11")) && e.getMessage().contains("Certificate chain is not valid")) {
-                        assumeNoException("TODO: needs triage", e);
-                    }
-                }
+                store.setKeyEntry("alias-" + id, key.key.getPrivate(), password, chain);
                 id++;
             }
         }

--- a/src/test/java/org/jenkinsci/remoting/protocol/cert/ValidityCheckingX509ExtendedTrustManagerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/cert/ValidityCheckingX509ExtendedTrustManagerTest.java
@@ -41,8 +41,8 @@ public class ValidityCheckingX509ExtendedTrustManagerTest {
 
     public static RSAKeyPairRule key = new RSAKeyPairRule("main");
 
-    public static X509CertificateRule cert = new X509CertificateRule("main", key, key, -1, 1, TimeUnit.HOURS);
-    public static X509CertificateRule expired = new X509CertificateRule("main", key, key, -100, -99, TimeUnit.HOURS);
+    public static X509CertificateRule cert = new X509CertificateRule("main", key, key, null, -1, 1, TimeUnit.HOURS);
+    public static X509CertificateRule expired = new X509CertificateRule("main", key, key, null, -100, -99, TimeUnit.HOURS);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(key)

--- a/src/test/java/org/jenkinsci/remoting/protocol/impl/SSLEngineFilterLayerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/impl/SSLEngineFilterLayerTest.java
@@ -72,13 +72,13 @@ public class SSLEngineFilterLayerTest {
     private static RSAKeyPairRule clientKey = new RSAKeyPairRule();
     private static RSAKeyPairRule serverKey = new RSAKeyPairRule();
     private static RSAKeyPairRule caRootKey = new RSAKeyPairRule();
-    private static X509CertificateRule caRootCert = X509CertificateRule.create("caRoot", caRootKey, caRootKey);
-    private static X509CertificateRule clientCert = X509CertificateRule.create("client", clientKey, caRootKey);
-    private static X509CertificateRule serverCert = X509CertificateRule.create("server", serverKey, caRootKey);
+    private static X509CertificateRule caRootCert = X509CertificateRule.create("caRoot", caRootKey, caRootKey, null);
+    private static X509CertificateRule clientCert = X509CertificateRule.create("client", clientKey, caRootKey, caRootCert);
+    private static X509CertificateRule serverCert = X509CertificateRule.create("server", serverKey, caRootKey, caRootCert);
     private static X509CertificateRule expiredClientCert =
-            X509CertificateRule.create("expiredClient", clientKey, caRootKey, -10, -5, TimeUnit.DAYS);
+            X509CertificateRule.create("expiredClient", clientKey, caRootKey, caRootCert, -10, -5, TimeUnit.DAYS);
     private static X509CertificateRule notYetValidServerCert =
-            X509CertificateRule.create("notYetValidServer", serverKey, caRootKey, +5, +10, TimeUnit.DAYS);
+            X509CertificateRule.create("notYetValidServer", serverKey, caRootKey, caRootCert, +5, +10, TimeUnit.DAYS);
     private static SSLContextRule clientCtx =
             new SSLContextRule("client")
                     .as(clientKey, clientCert, caRootCert)


### PR DESCRIPTION
When updating this repository to use Java 11 in #495, I took a shortcut and skipped the `SSLContextRule` tests rather than fixing them. This PR undoes that change, restoring the tests and getting them to work on Java 11.

They had started failing with "Certificate chain is not valid" errors. Looking into this further I found that the first argument to `X509v3CertificateBuilder`, which is supposed to be the signer/issuer, was actually a subject. This made no sense except for self-signed certificates, but apparently worked on older versions of Java. To fix this I changed the test logic to plumb through the root certificate in any certificate chains. With this object plumbed through, we could call its `getSubjectX500Principal()` method as recommended in the Bouncy Castle documentation to get the correct first argument to pass when building the X509 certificate. And with that the tests pass again on Java 11.