### PR TITLE
Upgrade Bouncy Castle from 1.70 to 1.71

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@ THE SOFTWARE.
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.excludeFilterFile>${basedir}/src/spotbugs/excludeFilter.xml</spotbugs.excludeFilterFile>
     <spotbugs.threshold>Low</spotbugs.threshold>
-    <bc-version>1.70</bc-version>
+    <bc-version>1.71</bc-version>
   </properties>
 
   <dependencies>
@@ -147,13 +147,13 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <version>${bc-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
       <version>${bc-version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Like https://github.com/jenkinsci/bouncycastle-api-plugin/pull/91 but for Remoting tests. Per the documentation:

> **Packaging Change (users of 1.70 or earlier):** BC 1.71 changed the `jdk15on` jars to `jdk18on` so the base has now moved to Java 8. For earlier JVMs, or containers/applications that cannot cope with multi-release jars, you should now use the `jdk15to18` jars.

Jenkins core has supported multi-release JARs since https://github.com/jenkinsci/jenkins/pull/5635, so this should be no problem.