### PR TITLE
Remove redundant `project.reporting.outputEncoding` and `project.build.outputEncoding` properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,6 @@ THE SOFTWARE.
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
     <build.type>private</build.type>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.excludeFilterFile>${basedir}/src/spotbugs/excludeFilter.xml</spotbugs.excludeFilterFile>
     <spotbugs.threshold>Low</spotbugs.threshold>


### PR DESCRIPTION
These have been in the parent POM since https://github.com/jenkinsci/pom/pull/257 which was released in 1.76.