### PR TITLE
Remove redundant `all-tests` profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -391,17 +391,6 @@ THE SOFTWARE.
 
   <profiles>
     <profile>
-      <id>all-tests</id>
-      <activation>
-        <property>
-          <name>!test</name>
-        </property>
-      </activation>
-      <properties>
-        <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-      </properties>
-    </profile>
-    <profile>
       <id>jacoco</id>
       <build>
         <plugins>


### PR DESCRIPTION
This has been in the parent POM since https://github.com/jenkinsci/pom/pull/273 which was released in 1.79.