### PR TITLE
Remove redundant `maven-assembly-plugin` version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,6 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.4.2</version>
         <configuration>
           <descriptors>
             <descriptor>src/assembly/agent-load-test.xml</descriptor>


### PR DESCRIPTION
This version is already defined in the parent POM.