### PR TITLE
Added missing `@NonNull` and `@CheckForNull` annotations

### DIFF
--- a/src/main/java/hudson/remoting/ClassLoaderHolder.java
+++ b/src/main/java/hudson/remoting/ClassLoaderHolder.java
@@ -20,7 +20,7 @@ public class ClassLoaderHolder implements SerializableOnlyOverRemoting {
     @CheckForNull
     private transient ClassLoader classLoader;
 
-    public ClassLoaderHolder(ClassLoader classLoader) {
+    public ClassLoaderHolder(@CheckForNull ClassLoader classLoader) {
         this.classLoader = classLoader;
     }
 

--- a/src/main/java/hudson/remoting/ClassicCommandTransport.java
+++ b/src/main/java/hudson/remoting/ClassicCommandTransport.java
@@ -1,5 +1,6 @@
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.remoting.Channel.Mode;
 
@@ -35,7 +36,7 @@ import java.io.StreamCorruptedException;
      */
     private final OutputStream rawOut;
 
-    /*package*/ ClassicCommandTransport(ObjectInputStream ois, ObjectOutputStream oos, FlightRecorderInputStream rawIn, OutputStream rawOut, Capability remoteCapability) {
+    /*package*/ ClassicCommandTransport(ObjectInputStream ois, ObjectOutputStream oos, @CheckForNull FlightRecorderInputStream rawIn, OutputStream rawOut, Capability remoteCapability) {
         this.ois = ois;
         this.oos = oos;
         this.rawIn= rawIn;

--- a/src/main/java/hudson/remoting/RequiredRoleCheckerWrapper.java
+++ b/src/main/java/hudson/remoting/RequiredRoleCheckerWrapper.java
@@ -23,6 +23,7 @@
  */
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.remoting.Role;
 import org.jenkinsci.remoting.RoleChecker;
 import org.jenkinsci.remoting.RoleSensitive;
@@ -42,19 +43,19 @@ import java.util.Collection;
     }
 
     @Override
-    public void check(RoleSensitive subject, Role... expected) throws SecurityException {
+    public void check(@NonNull RoleSensitive subject, Role... expected) throws SecurityException {
         checked = true;
         roleChecker.check(subject, expected);
     }
 
     @Override
-    public void check(RoleSensitive subject, Role expected) throws SecurityException {
+    public void check(@NonNull RoleSensitive subject, @NonNull Role expected) throws SecurityException {
         checked = true;
         roleChecker.check(subject, expected);
     }
 
     @Override
-    public void check(RoleSensitive subject, Collection<Role> expected) throws SecurityException {
+    public void check(@NonNull RoleSensitive subject, @NonNull Collection<Role> expected) throws SecurityException {
         checked = true;
         roleChecker.check(subject, expected);
     }

--- a/src/test/java/hudson/remoting/ChunkedInputStreamTest.java
+++ b/src/test/java/hudson/remoting/ChunkedInputStreamTest.java
@@ -1,5 +1,6 @@
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.remoting.pipe.RandomWorkload;
 import hudson.remoting.pipe.Workload;
 import org.jenkinsci.remoting.nio.FifoBuffer;
@@ -111,7 +112,7 @@ public class ChunkedInputStreamTest extends Assert {
         }
 
         @Override
-        public void write(byte[] b, int off, int len) throws IOException {
+        public void write(@NonNull byte[] b, int off, int len) throws IOException {
             out.write(b, off, len);
             ((ChunkedOutputStream)out).sendBreak();
         }


### PR DESCRIPTION
Added missing `@NonNull` and `@CheckForNull` annotations on overrides

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
