### PR TITLE
[JENKINS-70105] Slow down websocket re-connect

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -685,6 +685,7 @@ public class Engine extends Thread {
                 }
                 events.onDisconnect();
                 while (true) {
+                    TimeUnit.SECONDS.sleep(10);
                     // Unlike JnlpAgentEndpointResolver, we do not use $jenkins/tcpSlaveAgentListener/, as that will be a 404 if the TCP port is disabled.
                     URL ping = new URL(hudsonUrl, "login");
                     try {
@@ -699,7 +700,6 @@ public class Engine extends Thread {
                     } catch (IOException x) {
                         events.status(ping + " is not ready", x);
                     }
-                    TimeUnit.SECONDS.sleep(10);
                 }
                 reconnect();
             }


### PR DESCRIPTION
More information in [JENKINS-70105](https://issues.jenkins.io/browse/JENKINS-70105).

This is aligned with the existent inbound tcp agent re-connect logic, which is waiting for 10 seconds before each re-try.
The original logic was waiting 10 seconds only if the controller was not responding.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
