### PR TITLE
Remove 2s timeout in `PipeTest.testReaderCloseWhileWriterIsStillWriting`

### DIFF
--- a/src/test/java/hudson/remoting/PipeTest.java
+++ b/src/test/java/hudson/remoting/PipeTest.java
@@ -38,7 +38,6 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.junit.jupiter.api.Disabled;
@@ -87,7 +86,7 @@ public class PipeTest implements Serializable {
                 assertEquals(in.read(), 0);
             }
 
-            final ExecutionException e = assertThrows(ExecutionException.class, () -> f.get(2, TimeUnit.SECONDS));
+            final ExecutionException e = assertThrows(ExecutionException.class, () -> f.get());
             assertThat(e.getCause(), instanceOf(IOException.class));
         });
     }


### PR DESCRIPTION
https://github.com/jenkinsci/remoting/pull/593#discussion_r994877261 superseded by https://github.com/jenkinsci/remoting/pull/593/commits/f918dff7060eb7abfa53eced7bbbb4ca0b7bf072