### PR TITLE
`PipeTest.testReaderCloseWhileWriterIsStillWriting` is flaky; disabling

### DIFF
--- a/src/test/java/hudson/remoting/PipeTest.java
+++ b/src/test/java/hudson/remoting/PipeTest.java
@@ -74,6 +74,7 @@ public class PipeTest implements Serializable {
      * Have the reader close the read end of the pipe while the writer is still writing.
      * The writer should pick up a failure.
      */
+    @Disabled("TODO flaky")
     @Issue("JENKINS-8592")
     @For(Pipe.class)
     @ParameterizedTest


### PR DESCRIPTION
#612, https://github.com/jenkinsci/remoting/pull/593#discussion_r994877261
