### PR TITLE
Fix Maven Shade Plugin warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,8 +230,21 @@ THE SOFTWARE.
                 <filter>
                   <artifact>args4j:args4j</artifact>
                   <excludes>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
                     <exclude>OSGI-OPT/**/*.html</exclude>
                     <exclude>OSGI-OPT/**/*.java</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.glassfish.tyrus.bundles:tyrus-standalone-client-jdk</artifact>
+                  <excludes>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.jenkins-ci:constant-pool-scanner</artifact>
+                  <excludes>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
                   </excludes>
                 </filter>
               </filters>


### PR DESCRIPTION
Fixes the following Maven Shade Plugin warning

```
[WARNING] args4j-2.33.jar, constant-pool-scanner-1.2.jar, remoting-999999-SNAPSHOT.jar, tyrus-standalone-client-jdk-2.1.2.jar define 1 overlapping resource: 
[WARNING]   - META-INF/MANIFEST.MF
```

by excluding the `MANIFEST.MF` for any dependencies, leaving only our own. Tested by ensuring that the warning is now gone and that the `MANIFEST.MF` in the delivered Remoting JAR is the same before and after this PR.