### PR TITLE
[JENKINS-70531] Apply timeout on WebSocket write operations (and simplify `AbstractByteBufferCommandTransport`)

### DIFF
--- a/src/main/java/hudson/remoting/AbstractByteBufferCommandTransport.java
+++ b/src/main/java/hudson/remoting/AbstractByteBufferCommandTransport.java
@@ -152,8 +152,6 @@ public abstract class AbstractByteBufferCommandTransport extends CommandTranspor
      * Write the packet.
      *
      * @param headerAndData the header and data to write.
-     * @param header the header to write.
-     * @param data   the data to write.
      * @throws IOException if the data could not be written.
      */
     protected void write(ByteBuffer headerAndData) throws IOException {

--- a/src/main/java/hudson/remoting/AbstractByteBufferCommandTransport.java
+++ b/src/main/java/hudson/remoting/AbstractByteBufferCommandTransport.java
@@ -132,9 +132,9 @@ public abstract class AbstractByteBufferCommandTransport extends CommandTranspor
         if (combineBuffers) {
             writeChunkHeader = null;
             writeChunkBody = null;
-            writeChunkCombined = ByteBuffer.allocate(transportFrameSize + 2);
+            writeChunkCombined = ByteBuffer.allocate(transportFrameSize + ChunkHeader.SIZE);
         } else { // deprecated
-            writeChunkHeader = ByteBuffer.allocate(2);
+            writeChunkHeader = ByteBuffer.allocate(ChunkHeader.SIZE);
             writeChunkBody = ByteBuffer.allocate(transportFrameSize);
             writeChunkCombined = null;
         }
@@ -172,7 +172,7 @@ public abstract class AbstractByteBufferCommandTransport extends CommandTranspor
         while (data.hasRemaining() || readState == READ_STATE_COMMAND_READY) {
             switch (readState) {
                 case READ_STATE_NEED_HEADER:
-                    if (data.remaining() >= 2) {
+                    if (data.remaining() >= ChunkHeader.SIZE) {
                         // jump straight to state 2
                         readFrameHeader = ChunkHeader.read(data);
                         readFrameRemaining = ChunkHeader.length(readFrameHeader);
@@ -277,7 +277,7 @@ public abstract class AbstractByteBufferCommandTransport extends CommandTranspor
         this.transportFrameSize = transportFrameSize;
         // this is the only one that matters when it comes to sizing as we have to accept any frame size on receive
         if (writeChunkHeader == null) {
-            writeChunkCombined = ByteBuffer.allocate(transportFrameSize + 2);
+            writeChunkCombined = ByteBuffer.allocate(transportFrameSize + ChunkHeader.SIZE);
         } else {
             writeChunkBody = ByteBuffer.allocate(transportFrameSize);
         }
@@ -328,7 +328,7 @@ public abstract class AbstractByteBufferCommandTransport extends CommandTranspor
                     : (int) remaining; // # of bytes we send in this chunk
             if (writeChunkHeader == null) {
                 ((Buffer) writeChunkCombined).clear();
-                ((Buffer) writeChunkCombined).limit(frame + 2);
+                ((Buffer) writeChunkCombined).limit(frame + ChunkHeader.SIZE);
                 ChunkHeader.write(writeChunkCombined, frame, remaining > transportFrameSize);
                 sendStaging.get(writeChunkCombined);
                 ((Buffer) writeChunkCombined).flip();

--- a/src/main/java/hudson/remoting/AbstractByteBufferCommandTransport.java
+++ b/src/main/java/hudson/remoting/AbstractByteBufferCommandTransport.java
@@ -328,8 +328,8 @@ public abstract class AbstractByteBufferCommandTransport extends CommandTranspor
                     : (int) remaining; // # of bytes we send in this chunk
             if (writeChunkHeader == null) {
                 ((Buffer) writeChunkCombined).clear();
-                ChunkHeader.write(writeChunkCombined, frame, remaining > transportFrameSize);
                 ((Buffer) writeChunkCombined).limit(frame + 2);
+                ChunkHeader.write(writeChunkCombined, frame, remaining > transportFrameSize);
                 sendStaging.get(writeChunkCombined);
                 ((Buffer) writeChunkCombined).flip();
                 write(writeChunkCombined);

--- a/src/main/java/hudson/remoting/ChunkHeader.java
+++ b/src/main/java/hudson/remoting/ChunkHeader.java
@@ -7,13 +7,16 @@ import org.jenkinsci.remoting.util.ByteBufferQueue;
  * Parsing of the chunk header.
  *
  * <p>
- * The header is 2 bytes, in the network order. The first bit designates whether this chunk
+ * The header is {@link #SIZE} bytes, in the network order. The first bit designates whether this chunk
  * is the last chunk (0 if this is the last chunk), and the remaining 15 bits designate the
  * length of the chunk as unsigned number.
  *
  * @author Kohsuke Kawaguchi
  */
 public class ChunkHeader {
+
+    public static final int SIZE = 2;
+
     public static int read(ByteBuffer buf) {
         return parse(buf.get(), buf.get());
     }
@@ -57,7 +60,7 @@ public class ChunkHeader {
     }
 
     public static byte[] pack(int length, boolean hasMore) {
-        byte[] header = new byte[2];
+        byte[] header = new byte[SIZE];
         header[0] = (byte)((hasMore?0x80:0)|(length>>8));
         header[1] = (byte)(length);
         return header;

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -648,9 +648,18 @@ public class Engine extends Thread {
                         }
                         @Override
                         protected void write(ByteBuffer header, ByteBuffer data) throws IOException {
-                            LOGGER.finest(() -> "sending message of length + " + ChunkHeader.length(ChunkHeader.peek(header)));
-                            session.getBasicRemote().sendBinary(header, false);
-                            session.getBasicRemote().sendBinary(data, true);
+                            LOGGER.finest(() -> "sending message of length " + ChunkHeader.length(ChunkHeader.peek(header)));
+                            // RemoteEndpoint.Async seems to lack isLast overloads
+                            // adapted from https://stackoverflow.com/a/42170003/12916
+                            ByteBuffer headerAndData = ByteBuffer.allocate(header.remaining() + data.remaining());
+                            headerAndData.put(header.duplicate());
+                            headerAndData.put(data.duplicate());
+                            headerAndData.rewind();
+                            try {
+                                session.getAsyncRemote().sendBinary(headerAndData).get(5, TimeUnit.MINUTES);
+                            } catch (Exception x) {
+                                throw new IOException(x);
+                            }
                         }
 
                         @Override

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -649,7 +649,7 @@ public class Engine extends Thread {
                         }
                         @Override
                         protected void write(ByteBuffer headerAndData) throws IOException {
-                            LOGGER.finest(() -> "sending message of length " + (headerAndData.remaining() - 2));
+                            LOGGER.finest(() -> "sending message of length " + (headerAndData.remaining() - ChunkHeader.SIZE));
                             try {
                                 session.getAsyncRemote().sendBinary(headerAndData).get(5, TimeUnit.MINUTES);
                             } catch (Exception x) {

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -644,17 +644,12 @@ public class Engine extends Thread {
                     class Transport extends AbstractByteBufferCommandTransport {
                         final Session session;
                         Transport(Session session) {
+                            super(true);
                             this.session = session;
                         }
                         @Override
-                        protected void write(ByteBuffer header, ByteBuffer data) throws IOException {
-                            LOGGER.finest(() -> "sending message of length " + ChunkHeader.length(ChunkHeader.peek(header)));
-                            // RemoteEndpoint.Async seems to lack isLast overloads
-                            // adapted from https://stackoverflow.com/a/42170003/12916
-                            ByteBuffer headerAndData = ByteBuffer.allocate(header.remaining() + data.remaining());
-                            headerAndData.put(header.duplicate());
-                            headerAndData.put(data.duplicate());
-                            headerAndData.rewind();
+                        protected void write(ByteBuffer headerAndData) throws IOException {
+                            LOGGER.finest(() -> "sending message of length " + (headerAndData.remaining() - 2));
                             try {
                                 session.getAsyncRemote().sendBinary(headerAndData).get(5, TimeUnit.MINUTES);
                             } catch (Exception x) {

--- a/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/NioChannelHub.java
@@ -608,15 +608,15 @@ public class NioChannelHub implements Runnable, Closeable {
                                     t.closeR();
                                 }
 
-                                final byte[] buf = new byte[2]; // space for reading the chunk header
+                                final byte[] buf = new byte[ChunkHeader.SIZE];
                                 int pos=0;
                                 int packetSize=0;
                                 while (true) {
-                                    if (t.rb.peek(pos,buf)<buf.length)
+                                    if (t.rb.peek(pos,buf)<ChunkHeader.SIZE)
                                         break;  // we don't have enough to parse header
                                     int header = ChunkHeader.parse(buf);
                                     int chunk = ChunkHeader.length(header);
-                                    pos+=buf.length+chunk;
+                                    pos+=ChunkHeader.SIZE+chunk;
                                     packetSize+=chunk;
                                     boolean last = ChunkHeader.isLast(header);
                                     if (last && pos<=t.rb.readable()) {// do we have the whole packet in our buffer?
@@ -625,7 +625,7 @@ public class NioChannelHub implements Runnable, Closeable {
                                         int r_ptr = 0;
                                         do {
                                             int r = t.rb.readNonBlocking(buf);
-                                            assert r==buf.length;
+                                            assert r==ChunkHeader.SIZE;
                                             header = ChunkHeader.parse(buf);
                                             chunk = ChunkHeader.length(header);
                                             last = ChunkHeader.isLast(header);

--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/ChannelApplicationLayer.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/ChannelApplicationLayer.java
@@ -313,6 +313,7 @@ public class ChannelApplicationLayer extends ApplicationLayer<Future<Channel>> {
          * @param remoteCapability the remote capability
          */
         public ByteBufferCommandTransport(Capability remoteCapability) {
+            super(true);
             this.remoteCapability = remoteCapability;
         }
 
@@ -320,12 +321,11 @@ public class ChannelApplicationLayer extends ApplicationLayer<Future<Channel>> {
          * {@inheritDoc}
          */
         @Override
-        protected void write(ByteBuffer header, ByteBuffer data) throws IOException {
+        protected void write(ByteBuffer headerAndData) throws IOException {
             //TODO: Any way to get channel information here
             if (isWriteOpen()) {
                 try {
-                    ChannelApplicationLayer.this.write(header);
-                    ChannelApplicationLayer.this.write(data);
+                    ChannelApplicationLayer.this.write(headerAndData);
                 } catch (ClosedChannelException e) {
                     // Probably it should be another exception type at all
                     throw new ChannelClosedException(null, "Protocol stack cannot write data anymore. ChannelApplicationLayer reports that the NIO Channel is closed", e);


### PR DESCRIPTION
A user reported a WebSocket agent hanging indefinitely after a reload of nginx configuration

```
"pool-1-thread-… for … id=… / waiting for … id=…" #… daemon prio=5 os_prio=0 cpu=89.18ms elapsed=300.35s tid=… nid=… waiting on condition  […]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@11.0.17/Native Method)
        - parking to wait for  <…> (a java.util.concurrent.CountDownLatch$Sync)
        at java.util.concurrent.locks.LockSupport.park(java.base@11.0.17/LockSupport.java:194)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(java.base@11.0.17/AbstractQueuedSynchronizer.java:885)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(java.base@11.0.17/AbstractQueuedSynchronizer.java:1039)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(java.base@11.0.17/AbstractQueuedSynchronizer.java:1345)
        at java.util.concurrent.CountDownLatch.await(java.base@11.0.17/CountDownLatch.java:232)
        at io.jenkins.remoting.shaded.org.glassfish.tyrus.core.TyrusFuture.get(TyrusFuture.java:53)
        at io.jenkins.remoting.shaded.org.glassfish.tyrus.core.TyrusRemoteEndpoint$Basic.processFuture(TyrusRemoteEndpoint.java:149)
        at io.jenkins.remoting.shaded.org.glassfish.tyrus.core.TyrusRemoteEndpoint$Basic.sendBinary(TyrusRemoteEndpoint.java:131)
        at hudson.remoting.Engine$1AgentEndpoint$Transport.write(Engine.java:652)
        at hudson.remoting.AbstractByteBufferCommandTransport.write(AbstractByteBufferCommandTransport.java:303)
        at hudson.remoting.Channel.send(Channel.java:765)
        - locked <…> (a hudson.remoting.Channel)
        at hudson.remoting.Request.call(Request.java:167)
        - locked <…> (a hudson.remoting.RemoteInvocationHandler$RPCRequest)
        - locked <…> (a hudson.remoting.Channel)
        at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:288)
```

despite `PingThread` being explicitly enabled on the agent side (contra #85, pending https://github.com/jenkinsci/jenkins/pull/7580). Hypothesis: Tyrus is failing to detect the loss of the connection cleanly, and `Future.get()` without timeout never returns, and `PingThread` does not receive a `TimeoutException` or any other response. If true, we can try to apply a timeout (currently hard-coded to 5m), though this is a bit tricky since the asynch variant of the endpoint does not appear to support transmission of a sequence of buffers as part of a single binary frame.

Corresponding https://github.com/jenkinsci/jenkins/pull/7596 as well, though in this case it is the agent-side write that appears to be the culprit.

Iterative testing via `WebSocketAgentsTest`:

```bash
mvnd -Pquick-build install
mvnd -f ../jenkins -pl core,war -Pquick-build install
mvnd -f ../jenkins -pl test -Dtest=WebSocketAgentsTest
```

Not tested in any realistic context.