### PR TITLE
JENKINS-65368: isPortVisible did not take into account any proxy

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -44,6 +44,7 @@ import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.NoRouteToHostException;
 import java.net.Proxy;
+import java.net.Proxy.Type;
 import java.net.ProxySelector;
 import java.net.Socket;
 import java.net.SocketAddress;
@@ -345,7 +346,8 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
         Socket s = null;
 
         try {
-            s = new Socket();
+            InetSocketAddress proxyToUse = getResolvedHttpProxyAddress(hostname,port);
+            s = proxyToUse == null ? new Socket() : new Socket(new Proxy(Type.HTTP, proxyToUse)); 
             s.setReuseAddress(true);
             SocketAddress sa = new InetSocketAddress(hostname, port);
             s.connect(sa, 5000);


### PR DESCRIPTION
JENKINS-65368: isPortVisible did not take into account any proxy, prohibiting the agent from connecting through a proxy.

Because of this, the agent would think the jnlp port is closed (when the port is exclusively accesible through the proxy) and will fail the connect.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- n/a Link to relevant pull requests, esp. upstream and downstream changes
- :( Ensure you have provided tests - that demonstrates feature works or fixes the issue. -> Wasn't able to come up with a test, added logging as proof.

Additional context: I've privately patched these two lines in my organization on many agent releases between 3.36 and the current, so i figured i should take the effort of bringing this fix to the release. Not sure why the corresponding issue was closed. Hope this PR finds you well.