### PR TITLE
Expand non-fatal JNLP agent endpoint resolution to do retries

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -115,7 +115,8 @@ public class Engine extends Thread {
 
     static boolean nonFatalJnlpAgentResolutionExceptions = Boolean.getBoolean(Engine.class.getName() + ".nonFatalJnlpAgentEndpointResolutionExceptions");
 
-    static int nonFatalJnlpAgentResolutionExceptionsMaxRetries = Integer.getInteger(Engine.class.getName() + ".nonFatalJnlpAgentResolutionExceptionsMaxRetries", 2);
+    // defaulting to -1 (infinite retries) keeping the behaviour for other consumers such as the swarm plugin
+    static int nonFatalJnlpAgentResolutionExceptionsMaxRetries = Integer.getInteger(Engine.class.getName() + ".nonFatalJnlpAgentResolutionExceptionsMaxRetries", -1);
 
     static int nonFatalJnlpAgentResolutionExceptionsIntervalInMillis = Integer.getInteger(Engine.class.getName() + ".nonFatalJnlpAgentResolutionExceptionsIntervalInMillis", 5000);
 
@@ -759,7 +760,10 @@ public class Engine extends Thread {
                     endpoint = resolver.resolve();
                 } catch (Exception e) {
                     if (nonFatalJnlpAgentResolutionExceptions) {
-                        if (connectionAttempts > nonFatalJnlpAgentResolutionExceptionsMaxRetries) {
+                        if (nonFatalJnlpAgentResolutionExceptionsMaxRetries < 0) {
+                            events.status("Could not resolve JNLP agent endpoint. Unlimited retries. Attempt #" + connectionAttempts, e);
+                            continue;
+                        } else if (connectionAttempts > nonFatalJnlpAgentResolutionExceptionsMaxRetries) {
                             events.status("Could not resolve JNLP agent endpoint. Max number of retries reached. Attempt #" + connectionAttempts, e);
                         } else {
                             events.status("Could not resolve JNLP agent endpoint. Attempt #" + connectionAttempts, e);

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -113,12 +113,12 @@ public class Engine extends Thread {
      */
     public static final String WEBSOCKET_COOKIE_HEADER = "Connection-Cookie";
 
-    static boolean nonFatalJnlpAgentResolutionExceptions = Boolean.getBoolean(Engine.class.getName() + ".nonFatalJnlpAgentEndpointResolutionExceptions");
+    static boolean nonFatalJnlpAgentEndpointResolutionExceptions = Boolean.getBoolean(Engine.class.getName() + ".nonFatalJnlpAgentEndpointResolutionExceptions");
 
     // defaulting to 0 retries in keeping with the behaviour for other consumers such as the swarm plugin
-    static int nonFatalJnlpAgentResolutionExceptionsMaxRetries = Integer.getInteger(Engine.class.getName() + ".nonFatalJnlpAgentResolutionExceptionsMaxRetries", 0);
+    static int nonFatalJnlpAgentEndpointResolutionExceptionsMaxRetries = Integer.getInteger(Engine.class.getName() + ".nonFatalJnlpAgentEndpointResolutionExceptionsMaxRetries", 0);
 
-    static int nonFatalJnlpAgentResolutionExceptionsIntervalInMillis = Integer.getInteger(Engine.class.getName() + ".nonFatalJnlpAgentResolutionExceptionsIntervalInMillis", 5000);
+    static int nonFatalJnlpAgentEndpointResolutionExceptionsIntervalInMillis = Integer.getInteger(Engine.class.getName() + ".nonFatalJnlpAgentEndpointResolutionExceptionsIntervalInMillis", 5000);
 
     /**
      * Thread pool that sets {@link #CURRENT}.
@@ -759,14 +759,14 @@ public class Engine extends Thread {
                 try {
                     endpoint = resolver.resolve();
                 } catch (Exception e) {
-                    if (nonFatalJnlpAgentResolutionExceptions) {
-                        if (connectionAttempts > nonFatalJnlpAgentResolutionExceptionsMaxRetries) {
+                    if (nonFatalJnlpAgentEndpointResolutionExceptions) {
+                        if (connectionAttempts > nonFatalJnlpAgentEndpointResolutionExceptionsMaxRetries) {
                             events.status("Could not resolve JNLP agent endpoint. Max number of retries reached. Attempt #" + connectionAttempts, e);
                         } else {
                             events.status("Could not resolve JNLP agent endpoint. Attempt #" + connectionAttempts, e);
                             try {
-                                if (nonFatalJnlpAgentResolutionExceptionsIntervalInMillis > 0) {
-                                    Thread.sleep(nonFatalJnlpAgentResolutionExceptionsIntervalInMillis);
+                                if (nonFatalJnlpAgentEndpointResolutionExceptionsIntervalInMillis > 0) {
+                                    Thread.sleep(nonFatalJnlpAgentEndpointResolutionExceptionsIntervalInMillis);
                                 }
                             } catch (InterruptedException ignored) {
                                 // Not much to do if we can't sleep. Run through the tries more quickly.

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -115,8 +115,8 @@ public class Engine extends Thread {
 
     static boolean nonFatalJnlpAgentResolutionExceptions = Boolean.getBoolean(Engine.class.getName() + ".nonFatalJnlpAgentEndpointResolutionExceptions");
 
-    // defaulting to -1 (infinite retries) keeping the behaviour for other consumers such as the swarm plugin
-    static int nonFatalJnlpAgentResolutionExceptionsMaxRetries = Integer.getInteger(Engine.class.getName() + ".nonFatalJnlpAgentResolutionExceptionsMaxRetries", -1);
+    // defaulting to 0 retries in keeping with the behaviour for other consumers such as the swarm plugin
+    static int nonFatalJnlpAgentResolutionExceptionsMaxRetries = Integer.getInteger(Engine.class.getName() + ".nonFatalJnlpAgentResolutionExceptionsMaxRetries", 0);
 
     static int nonFatalJnlpAgentResolutionExceptionsIntervalInMillis = Integer.getInteger(Engine.class.getName() + ".nonFatalJnlpAgentResolutionExceptionsIntervalInMillis", 5000);
 
@@ -760,10 +760,7 @@ public class Engine extends Thread {
                     endpoint = resolver.resolve();
                 } catch (Exception e) {
                     if (nonFatalJnlpAgentResolutionExceptions) {
-                        if (nonFatalJnlpAgentResolutionExceptionsMaxRetries < 0) {
-                            events.status("Could not resolve JNLP agent endpoint. Unlimited retries. Attempt #" + connectionAttempts, e);
-                            continue;
-                        } else if (connectionAttempts > nonFatalJnlpAgentResolutionExceptionsMaxRetries) {
+                        if (connectionAttempts > nonFatalJnlpAgentResolutionExceptionsMaxRetries) {
                             events.status("Could not resolve JNLP agent endpoint. Max number of retries reached. Attempt #" + connectionAttempts, e);
                         } else {
                             events.status("Could not resolve JNLP agent endpoint. Attempt #" + connectionAttempts, e);

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -746,7 +746,6 @@ public class Engine extends Thread {
         JnlpEndpointResolver resolver = createEndpointResolver(jenkinsUrls);
 
         try {
-            boolean first = true;
             int connectionAttempts = 0;
             while(true) {
                 if (connectionAttempts > 0 && noReconnect) {

--- a/src/test/java/hudson/remoting/EngineTest.java
+++ b/src/test/java/hudson/remoting/EngineTest.java
@@ -142,17 +142,12 @@ public class EngineTest {
     private static class NoReconnectException extends RuntimeException {}
 
     @Test
-    public void shouldReconnectOnJnlpAgentEndpointResolutionExceptions() {
+    public void shouldNotReconnectOnJnlpAgentEndpointResolutionExceptionsButWithStatus() {
         EngineListener l = new TestEngineListener() {
-            private int count;
-
             @Override
             public void status(String msg, Throwable t) {
                 System.err.println("Status: " + msg);
                 if (msg.startsWith("Could not resolve JNLP agent endpoint")) {
-                    count++;
-                }
-                if (count == 2) {
                     throw new ExpectedException();
                 }
             }
@@ -167,7 +162,7 @@ public class EngineTest {
         Engine.nonFatalJnlpAgentResolutionExceptions = true;
         try {
             Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
-            assertThrows("Should have tried at least twice", ExpectedException.class, () -> engine.run());
+            assertThrows("Message should have started with 'Could not resolve...'", ExpectedException.class, () -> engine.run());
         } finally {
             // reinstate the static value
             Engine.nonFatalJnlpAgentResolutionExceptions = false;

--- a/src/test/java/hudson/remoting/EngineTest.java
+++ b/src/test/java/hudson/remoting/EngineTest.java
@@ -159,13 +159,13 @@ public class EngineTest {
                 }
             }
         };
-        Engine.nonFatalJnlpAgentResolutionExceptions = true;
+        Engine.nonFatalJnlpAgentEndpointResolutionExceptions = true;
         try {
             Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
             assertThrows("Message should have started with 'Could not resolve...'", ExpectedException.class, () -> engine.run());
         } finally {
             // reinstate the static value
-            Engine.nonFatalJnlpAgentResolutionExceptions = false;
+            Engine.nonFatalJnlpAgentEndpointResolutionExceptions = false;
         }
     }
 
@@ -193,19 +193,19 @@ public class EngineTest {
             }
         };
 
-        int currentMaxRetries = Engine.nonFatalJnlpAgentResolutionExceptionsMaxRetries;
-        int currentIntervalInSeconds = Engine.nonFatalJnlpAgentResolutionExceptionsIntervalInMillis;
+        int currentMaxRetries = Engine.nonFatalJnlpAgentEndpointResolutionExceptionsMaxRetries;
+        int currentIntervalInSeconds = Engine.nonFatalJnlpAgentEndpointResolutionExceptionsIntervalInMillis;
         try {
-            Engine.nonFatalJnlpAgentResolutionExceptions = true;
-            Engine.nonFatalJnlpAgentResolutionExceptionsMaxRetries = 5;
-            Engine.nonFatalJnlpAgentResolutionExceptionsIntervalInMillis = 100;
+            Engine.nonFatalJnlpAgentEndpointResolutionExceptions = true;
+            Engine.nonFatalJnlpAgentEndpointResolutionExceptionsMaxRetries = 5;
+            Engine.nonFatalJnlpAgentEndpointResolutionExceptionsIntervalInMillis = 100;
             Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
             assertThrows("Should have tried at least five times", ExpectedException.class, () -> engine.run());
         } finally {
             // reinstate the static values
-            Engine.nonFatalJnlpAgentResolutionExceptions = false;
-            Engine.nonFatalJnlpAgentResolutionExceptionsMaxRetries = currentMaxRetries;
-            Engine.nonFatalJnlpAgentResolutionExceptionsIntervalInMillis = currentIntervalInSeconds;
+            Engine.nonFatalJnlpAgentEndpointResolutionExceptions = false;
+            Engine.nonFatalJnlpAgentEndpointResolutionExceptionsMaxRetries = currentMaxRetries;
+            Engine.nonFatalJnlpAgentEndpointResolutionExceptionsIntervalInMillis = currentIntervalInSeconds;
         }
     }
 

--- a/src/test/java/hudson/remoting/EngineTest.java
+++ b/src/test/java/hudson/remoting/EngineTest.java
@@ -39,6 +39,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -125,6 +126,95 @@ public class EngineTest {
         Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
         assertThat(engine.getAgentName(), is(AGENT_NAME));
     }
+
+    @Test
+    public void shouldNotReconnect() {
+        EngineListener l = new TestEngineListener() {
+            @Override
+            public void error(Throwable t) {
+                throw new NoReconnectException();
+            }
+        };
+        Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
+        assertThrows(NoReconnectException.class, () -> engine.run());
+    }
+
+    private static class NoReconnectException extends RuntimeException {}
+
+    @Test
+    public void shouldReconnectOnJnlpAgentEndpointResolutionExceptions() {
+        EngineListener l = new TestEngineListener() {
+            private int count;
+
+            @Override
+            public void status(String msg, Throwable t) {
+                System.err.println("Status: " + msg);
+                if (msg.startsWith("Could not resolve JNLP agent endpoint")) {
+                    count++;
+                }
+                if (count == 2) {
+                    throw new ExpectedException();
+                }
+            }
+
+            @Override
+            public void error(Throwable t) {
+                if (t instanceof RuntimeException) {
+                    throw (RuntimeException) t;
+                }
+            }
+        };
+        Engine.nonFatalJnlpAgentResolutionExceptions = true;
+        try {
+            Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
+            assertThrows("Should have tried at least twice", ExpectedException.class, () -> engine.run());
+        } finally {
+            // reinstate the static value
+            Engine.nonFatalJnlpAgentResolutionExceptions = false;
+        }
+    }
+
+    @Test
+    public void shouldReconnectOnJnlpAgentEndpointResolutionExceptionsMaxRetries() {
+        EngineListener l = new TestEngineListener() {
+            private int count;
+
+            @Override
+            public void status(String msg, Throwable t) {
+                System.err.println("Status: " + msg);
+                if (msg.startsWith("Could not resolve JNLP agent endpoint")) {
+                    count++;
+                }
+                if (count == 5) {
+                    throw new ExpectedException();
+                }
+            }
+
+            @Override
+            public void error(Throwable t) {
+                if (t instanceof RuntimeException) {
+                    throw (RuntimeException) t;
+                }
+            }
+        };
+
+        int currentMaxRetries = Engine.nonFatalJnlpAgentResolutionExceptionsMaxRetries;
+        int currentIntervalInSeconds = Engine.nonFatalJnlpAgentResolutionExceptionsIntervalInMillis;
+        try {
+            Engine.nonFatalJnlpAgentResolutionExceptions = true;
+            Engine.nonFatalJnlpAgentResolutionExceptionsMaxRetries = 5;
+            Engine.nonFatalJnlpAgentResolutionExceptionsIntervalInMillis = 100;
+            Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
+            assertThrows("Should have tried at least five times", ExpectedException.class, () -> engine.run());
+        } finally {
+            // reinstate the static values
+            Engine.nonFatalJnlpAgentResolutionExceptions = false;
+            Engine.nonFatalJnlpAgentResolutionExceptionsMaxRetries = currentMaxRetries;
+            Engine.nonFatalJnlpAgentResolutionExceptionsIntervalInMillis = currentIntervalInSeconds;
+        }
+    }
+
+    private static class ExpectedException extends RuntimeException {}
 
     private static class TestEngineListener implements EngineListener {
 


### PR DESCRIPTION
### What?

This PR adds two new system properties which can be used to further configure the retry attempts when using the `nonFatalJnlpAgentEndpointResolutionExceptions` property.

- `nonFatalJnlpAgentEndpointResolutionExceptionsMaxRetries`
    the number of retries before failing (defaults to 0 for backwards compatibility with the swarm plugin)
- `nonFatalJnlpAgentEndpointResolutionExceptionsIntervalInMillis`
    the interval in milliseconds before attempt to reconnect (defaults to 5000)

### Why?

The `nonFatalJnlpAgentEndpointResolutionExceptions` is currently used in the swarm plugin. The swarm plugin manages its own retry strategy.

In some envrionments with a flaky network, the JNLP endpoint resolution might simple fail due to a network issue. With standard incoming agents, the agent connection would fail at the first attempt and the build would fail.

These additional properties allow the configuration of retries in order to handle a flaky network.

### References

Follow-up #449, and initial fix before #608 hits.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
