### PR TITLE
Managing test flakes

### DIFF
--- a/src/test/java/hudson/remoting/ChannelTest.java
+++ b/src/test/java/hudson/remoting/ChannelTest.java
@@ -26,6 +26,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jenkinsci.remoting.RoleChecker;
 import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.jvnet.hudson.test.Issue;
@@ -268,6 +269,7 @@ public class ChannelTest {
      * Checks if {@link UserRequest}s can be executed during the pending close operation.
      * @throws Exception Test Error
      */
+    @Disabled("TODO flake timed out after 15 seconds")
     @Issue("JENKINS-45023")
     @ParameterizedTest
     @MethodSource(ChannelRunners.PROVIDER_METHOD)
@@ -294,6 +296,7 @@ public class ChannelTest {
      * Checks if {@link UserRequest}s can be executed during the pending close operation.
      * @throws Exception Test Error
      */
+    @Disabled("TODO flake timed out after 15 seconds")
     @Issue("JENKINS-45294")
     @ParameterizedTest
     @MethodSource(ChannelRunners.PROVIDER_METHOD)

--- a/src/test/java/hudson/remoting/ClassRemoting2Test.java
+++ b/src/test/java/hudson/remoting/ClassRemoting2Test.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Stream;
 import org.junit.After;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.jvnet.hudson.test.Issue;
@@ -200,6 +201,7 @@ public class ClassRemoting2Test {
         });
     }
 
+    @Disabled("TODO first call consistently flakes: Remote call on north failed")
     @Issue("JENKINS-61103")
     @ParameterizedTest
     @MethodSource(PROVIDER_METHOD)

--- a/src/test/java/hudson/remoting/ClassRemotingTest.java
+++ b/src/test/java/hudson/remoting/ClassRemotingTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.jvnet.hudson.test.Issue;
@@ -50,6 +51,7 @@ public class ClassRemotingTest {
     static final String TESTCALLABLE_TRANSFORMED_CLASSNAME = "hudson.rem0ting.TestCallable";
     static final String TESTLINKAGE_TRANSFORMED_CLASSNAME = "hudson.rem0ting.TestLinkage";
 
+    @Disabled("TODO flakes: Artificial testing interrupt.")
     @ParameterizedTest
     @MethodSource(ChannelRunners.PROVIDER_METHOD)
     public void test1(ChannelRunner channelRunner) throws Throwable {
@@ -84,6 +86,7 @@ public class ClassRemotingTest {
         });
     }
 
+    @Disabled("TODO flakes: Artificial testing interrupt.")
     @Issue("JENKINS-6604")
     @ParameterizedTest
     @MethodSource(ChannelRunners.PROVIDER_METHOD)
@@ -109,6 +112,7 @@ public class ClassRemotingTest {
         });
     }
 
+    @Disabled("TODO flakes: Artificial testing interrupt.")
     @ParameterizedTest
     @MethodSource(ChannelRunners.PROVIDER_METHOD)
     public void testClassCreation_TestCallable(ChannelRunner channelRunner) throws Exception {
@@ -142,6 +146,7 @@ public class ClassRemotingTest {
         });
     }
 
+    @Disabled("TODO flakes: Remote call on north failed")
     @Issue("JENKINS-61103")
     @ParameterizedTest
     @MethodSource(ChannelRunners.PROVIDER_METHOD)
@@ -156,6 +161,7 @@ public class ClassRemotingTest {
         });
     }
 
+    @Disabled("TODO flakes: Remote call on north failed")
     @Issue("JENKINS-61103")
     @ParameterizedTest
     @MethodSource(ChannelRunners.PROVIDER_METHOD)

--- a/src/test/java/hudson/remoting/PrefetchTest.java
+++ b/src/test/java/hudson/remoting/PrefetchTest.java
@@ -26,7 +26,6 @@ package hudson.remoting;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Ignore;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.objectweb.asm.ClassReader;
@@ -36,7 +35,6 @@ import java.io.IOException;
 /**
  * @author Kohsuke Kawaguchi
  */
-@Ignore
 public class PrefetchTest {
     @ParameterizedTest
     @MethodSource(ChannelRunners.PROVIDER_METHOD)

--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import org.junit.jupiter.api.Disabled;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -212,6 +213,7 @@ public class PrefetchingTest implements Serializable {
     /**
      * Unlike {@link #testGetResources(ChannelRunner)}, the URL should begin with file:... before the jar file gets cached
      */
+    @Disabled("TODO flakes: jar:file:/tmp/remoting-cache….jar!/test/hello.txt::hello ==> expected: <true> but was: <false>")
     @ParameterizedTest
     @MethodSource(ChannelRunners.PROVIDER_METHOD)
     public void testGetResources_precache(ChannelRunner channelRunner) throws Exception {

--- a/src/test/java/hudson/remoting/RegExpBenchmark.java
+++ b/src/test/java/hudson/remoting/RegExpBenchmark.java
@@ -23,7 +23,6 @@
  */
 package hudson.remoting;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -33,8 +32,9 @@ import java.util.Locale;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.regex.Pattern;
+import org.junit.jupiter.api.Disabled;
 
-@Ignore("This is not a test just a benchmark and is here for ease of running")
+@Disabled("This is not a test just a benchmark and is here for ease of running")
 public class RegExpBenchmark {
     
     final Pattern p1 = Pattern.compile("^org\\.codehaus\\.groovy\\.runtime\\..*");

--- a/src/test/java/org/jenkinsci/remoting/protocol/IOHubTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/IOHubTest.java
@@ -49,6 +49,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Disabled;
 
 public class IOHubTest {
 
@@ -99,7 +100,8 @@ public class IOHubTest {
         srv.configureBlocking(false);
         final AtomicReference<SelectionKey> key = new AtomicReference<>();
         final AtomicBoolean oops = new AtomicBoolean(false);
-        hub.hub().register(srv, new IOHubReadyListener() {
+        IOHub h = hub.hub();
+        h.register(srv, new IOHubReadyListener() {
 
             final AtomicInteger count = new AtomicInteger(0);
 
@@ -114,7 +116,7 @@ public class IOHubTest {
                     } catch (IOException e) {
                         // ignore
                     }
-                    hub.hub().addInterestAccept(key.get());
+                    h.addInterestAccept(key.get());
                 } else {
                     oops.set(true);
                 }
@@ -203,6 +205,7 @@ public class IOHubTest {
         }
     }
 
+    @Disabled("TODO flakes: Read timed out; or expected java.net.SocketTimeoutException to be thrown, but nothing was thrown")
     @Test
     public void noReadyCallbackIfInterestRemoved() throws Exception {
         final ServerSocketChannel srv = ServerSocketChannel.open();
@@ -210,7 +213,8 @@ public class IOHubTest {
         srv.configureBlocking(false);
         final AtomicReference<SelectionKey> key = new AtomicReference<>();
         final AtomicBoolean oops = new AtomicBoolean(false);
-        hub.hub().register(srv, new IOHubReadyListener() {
+        IOHub h = hub.hub();
+        h.register(srv, new IOHubReadyListener() {
 
             final AtomicInteger count = new AtomicInteger(0);
 
@@ -225,7 +229,7 @@ public class IOHubTest {
                     } catch (IOException e) {
                         // ignore
                     }
-                    hub.hub().addInterestAccept(key.get());
+                    h.addInterestAccept(key.get());
                 } else {
                     oops.set(true);
                 }
@@ -255,7 +259,7 @@ public class IOHubTest {
             client.connect(srv.getLocalAddress(), 100);
             assertThat(IOUtils.toString(client.getInputStream(), StandardCharsets.UTF_8), is("Go away #1"));
         }
-        hub.hub().removeInterestAccept(key.get());
+        h.removeInterestAccept(key.get());
         // wait for the interest accept to be removed
         while ((key.get().interestOps() & SelectionKey.OP_ACCEPT) != 0) {
             Thread.sleep(10);
@@ -268,7 +272,7 @@ public class IOHubTest {
                     () -> assertThat(IOUtils.toString(client.getInputStream(), StandardCharsets.UTF_8), is("Go away #2")));
             assertThat(e.getMessage(), containsString("timed out"));
 
-            hub.hub().addInterestAccept(key.get());
+            h.addInterestAccept(key.get());
             assertThat(IOUtils.toString(client.getInputStream(), StandardCharsets.UTF_8), is("Go away #2"));
             assertThat("Only ever called ready with accept true", oops.get(), is(false));
         }

--- a/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackImplTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackImplTest.java
@@ -64,6 +64,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.Disabled;
 
 public class ProtocolStackImplTest {
 
@@ -447,7 +448,6 @@ public class ProtocolStackImplTest {
     }
 
     @Test
-    @Repeat(16)
     public void pipeChannelFullProtocolBIO() throws Exception {
         Pipe eastToWest = Pipe.open();
         Pipe westToEast = Pipe.open();
@@ -479,7 +479,6 @@ public class ProtocolStackImplTest {
     }
 
     @Test
-    @Repeat(16)
     public void socketChannelFullProtocolBIO() throws Exception {
         ServerSocketChannel eastServer = ServerSocketChannel.open();
         eastServer.socket().bind(new InetSocketAddress(0));
@@ -516,7 +515,6 @@ public class ProtocolStackImplTest {
     }
 
     @Test
-    @Repeat(16)
     public void pipeFullProtocolNIO() throws Exception {
         Pipe eastToWest = Pipe.open();
         Pipe westToEast = Pipe.open();
@@ -549,7 +547,6 @@ public class ProtocolStackImplTest {
     }
 
     @Test
-    @Repeat(16)
     public void socketChannelFullProtocolNIO() throws Exception {
         ServerSocketChannel eastServer = ServerSocketChannel.open();
         eastServer.socket().bind(new InetSocketAddress(0));
@@ -750,6 +747,7 @@ public class ProtocolStackImplTest {
         assertThat(se.getCause(), instanceOf(ConnectionRefusalException.class));
     }
 
+    @Disabled("TODO flake: ConnectionRefusal Incorrect acknowledgement received, expected 0x000341436b got 0x0000000000")
     @Test
     @Repeat(16)
     public void pipeChannelFullProtocolNIO_invalidAck() throws Exception {
@@ -796,6 +794,7 @@ public class ProtocolStackImplTest {
                 ClosedChannelException.class)));
     }
 
+    @Disabled("TODO flake: ConnectionRefusalException: Incorrect acknowledgement received, expected 0x000341436b got 0x0000000000")
     @Test
     @Repeat(16)
     public void socketChannelFullProtocolNIO_invalidAck() throws Exception {


### PR DESCRIPTION
Some failures observed in CI, but mainly just running

```bash
mvn test -DforkCount=.45C
```

(about five concurrent tests on my machine) over and over. Surprisingly hard to get a clean run; #142 masks poor tests and we do not yet have the infrastructure to track flakes (maybe Launchable could).