### PR TITLE
Adapt hamcrest methods

### DIFF
--- a/src/test/java/hudson/remoting/DefaultClassFilterTest.java
+++ b/src/test/java/hudson/remoting/DefaultClassFilterTest.java
@@ -24,8 +24,8 @@
 package hudson.remoting;
 
 import static hudson.remoting.DefaultClassFilterTest.BlackListMatcher.blacklisted;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Every.everyItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 

--- a/src/test/java/hudson/remoting/LauncherTest.java
+++ b/src/test/java/hudson/remoting/LauncherTest.java
@@ -10,10 +10,10 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.FileInputStream;
 import java.io.IOException;
 
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.is;
 
 public class LauncherTest {
 

--- a/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/HostPortTest.java
@@ -2,8 +2,8 @@ package org.jenkinsci.remoting.engine;
 
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class HostPortTest {
 

--- a/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerTest.java
@@ -46,8 +46,11 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.IOUtils;
 
-import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 import org.jenkinsci.remoting.engine.WorkDirManager.DirType;
 import org.junit.Assume;


### PR DESCRIPTION
With https://github.com/jenkinsci/remoting/pull/639 in mind, we can use native `hamcrest` imports, independent of the deprecated -core module.