### PR TITLE
Hamcrest internal cleanup

### DIFF
--- a/src/test/java/hudson/remoting/DefaultClassFilterTest.java
+++ b/src/test/java/hudson/remoting/DefaultClassFilterTest.java
@@ -24,9 +24,9 @@
 package hudson.remoting;
 
 import static hudson.remoting.DefaultClassFilterTest.BlackListMatcher.blacklisted;
+import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.Every.everyItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;

--- a/src/test/java/hudson/remoting/LauncherTest.java
+++ b/src/test/java/hudson/remoting/LauncherTest.java
@@ -11,7 +11,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 

--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -19,10 +19,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.AllOf.allOf;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.hamcrest.core.StringEndsWith.endsWith;
-import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
With https://github.com/jenkinsci/remoting/pull/640 in mind, we can make use of the non-deprecated methods of the -core module here too.