### PR TITLE
Properly log when `X-Remoting-Capability` is missing rather than throwing an NPE

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -587,8 +587,13 @@ public class Engine extends Thread {
                             } else {
                                 addedHeaders.remove(Engine.WEBSOCKET_COOKIE_HEADER);
                             }
-                            remoteCapability = Capability.fromASCII(hr.getHeaders().get(Capability.KEY).get(0));
-                            LOGGER.fine(() -> "received " + remoteCapability);
+                            List<String> advertisedCapability = hr.getHeaders().get(Capability.KEY);
+                            if (advertisedCapability == null) {
+                                LOGGER.warning("Did not receive " + Capability.KEY + " header");
+                            } else {
+                                remoteCapability = Capability.fromASCII(advertisedCapability.get(0));
+                                LOGGER.fine(() -> "received " + remoteCapability);
+                            }
                         } catch (IOException x) {
                             events.error(x);
                         }


### PR DESCRIPTION
Should not happen in production since the controller should send this header, but for debugging purposes it is better to report this clearly.