### PR TITLE
Prevent ProxyException from throwing StackOverflowError on cyclic errors by breaking cycles

### DIFF
--- a/src/test/java/hudson/remoting/ProxyExceptionTest.java
+++ b/src/test/java/hudson/remoting/ProxyExceptionTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.remoting;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class ProxyExceptionTest {
+
+    @Test
+    public void breaksCyclesInCauses() {
+        Exception cyclic1 = new Exception("cyclic1");
+        Exception cyclic2 = new Exception("cyclic2", cyclic1);
+        cyclic1.initCause(cyclic2);
+        ProxyException pe1 = new ProxyException(cyclic1);
+        assertThat(pe1.getMessage(), is(cyclic1.toString()));
+        assertThat(pe1.getStackTrace(), is(cyclic1.getStackTrace()));
+        ProxyException pe2 = pe1.getCause();
+        assertThat(pe2.getMessage(), is(cyclic2.toString()));
+        assertThat(pe2.getStackTrace(), is(cyclic2.getStackTrace()));
+        assertThat(pe2.getCause(), is(nullValue()));
+    }
+
+    @Test
+    public void breaksCyclesInSuppressedExceptions() {
+        Exception cyclic1 = new Exception("cyclic1");
+        Exception cyclic2 = new Exception("cyclic2");
+        cyclic1.addSuppressed(cyclic2);
+        cyclic2.addSuppressed(cyclic1);
+        ProxyException pe1 = new ProxyException(cyclic1);
+        assertThat(pe1.getMessage(), is(cyclic1.toString()));
+        assertThat(pe1.getStackTrace(), is(cyclic1.getStackTrace()));
+        ProxyException pe2 = (ProxyException)pe1.getSuppressed()[0];
+        assertThat(pe2.getMessage(), is(cyclic2.toString()));
+        assertThat(pe2.getStackTrace(), is(cyclic2.getStackTrace()));
+        assertThat(pe2.getSuppressed(), is(emptyArray()));
+    }
+}


### PR DESCRIPTION
`ProxyException` currently throws a `StackOverflowError` if passed a `Throwable` which contains cycles in its graph of causes and suppressed throwables. This PR fixes that issue by breaking cycles when proxying throwables.

In particular, this is relevant for Pipeline, which uses `ProxyException` to create serializable versions of errors in some cases. See [ErrorAction](https://github.com/jenkinsci/workflow-api-plugin/blob/646def1087f9b2730a3b4f9e575c56e0fc13b492/src/main/java/org/jenkinsci/plugins/workflow/actions/ErrorAction.java) and https://github.com/jenkinsci/workflow-api-plugin/pull/286.

<!-- Please describe your pull request here. -->

### Testing done

Automated tests added.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
