### PR TITLE
JENKINS-71856 - Replace TeeOutputStream with Apache commons implementation

### DIFF
--- a/src/main/java/hudson/remoting/TeeOutputStream.java
+++ b/src/main/java/hudson/remoting/TeeOutputStream.java
@@ -24,7 +24,6 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-
 /**
  * @deprecated Use instead {@link org.apache.commons.io.output.TeeOutputStream}
  * 

--- a/src/main/java/hudson/remoting/TeeOutputStream.java
+++ b/src/main/java/hudson/remoting/TeeOutputStream.java
@@ -24,13 +24,17 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+
 /**
+ * @deprecated Use instead {@link org.apache.commons.io.output.TeeOutputStream}
+ * 
  * Classic splitter of OutputStream. Named after the unix 'tee'
  * command. It allows a stream to be branched off so there
  * are now two streams.
  *
  * @version $Id: TeeOutputStream.java 610010 2008-01-08 14:50:59Z niallp $
  */
+@Deprecated
 @Restricted(NoExternalUse.class)
 public class TeeOutputStream extends FilterOutputStream {
 

--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -28,7 +28,7 @@ package org.jenkinsci.remoting.engine;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.remoting.TeeOutputStream;
+import org.apache.commons.io.output.TeeOutputStream;
 import org.jenkinsci.remoting.util.PathUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;


### PR DESCRIPTION
Per the [JIRA issue](https://issues.jenkins.io/browse/JENKINS-71856) , this internal implementation of TeeOutputStream seems to have an obvious issue of double writing to the second `OutputStream`. It's apparently gone un-fixed because this implementation has only been used in one place which is likely to be rarely seen by human eyes. Other uses of `TeeInputStream` around the Jenkins codebase use an alternate (and apparently more correct) implementation of `TeeInputStream` from Apache commons which does not suffer from the double write.

This PR replaces the only internal usage of the internal TeeOutputStream with the Apache Commons implementation, and marks the internal class as deprecated with a link.

Of note, this change will likely fix the issue reported in https://issues.jenkins.io/browse/JENKINS-38520 which was closed as could not reproduce. I did not confirm it because I never experienced that issue personally and the reproduction and confirmation of the fix would be very time consuming. Also, it seems extremely likely to be connected on the surface.

### Testing done
The following code demonstrates the bug and simple fix by switching imports.  I ran the groovy code locally to confirm the fix, and also @MarkEWaite stated in the JIRA he confirmed the same behavior in Groovy console on latest Jenkins.

I am not planning to add anything the test suite here because there were no existing tests for `TeeOutputStream` and the test I would add would be a pure sanity test of a class from a third-party library (and apache commons at that) which isn't appropriate for multiple reasons.

```groovy
import hudson.remoting.TeeOutputStream  
//import org.apache.commons.io.output.TeeOutputStream 

File file = new File("test.txt")
File file2 = new File("test2.txt")
OutputStream os = new FileOutputStream(file)
OutputStream os2 = new FileOutputStream(file2)
TeeOutputStream tos = new TeeOutputStream(os, os2)
PrintWriter writer = tos.newPrintWriter()
writer.write("testing ")
writer.flush()
assert file.getText() == "testing "
assert file2.getText() == "testing testing "
```


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
