### PR TITLE
Test with `NullOutputStream.INSTANCE` instead of deprecated `NULL_OUTPUT_STREAM`

### DIFF
--- a/src/test/java/hudson/remoting/ChannelRunner.java
+++ b/src/test/java/hudson/remoting/ChannelRunner.java
@@ -24,7 +24,6 @@
 package hudson.remoting;
 
 import java.util.Objects;
-import java.util.function.Consumer;
 
 /**
  * Hides the logic of starting/stopping a channel for test,

--- a/src/test/java/hudson/remoting/DiagnosedStreamCorruptionExceptionTest.java
+++ b/src/test/java/hudson/remoting/DiagnosedStreamCorruptionExceptionTest.java
@@ -28,7 +28,7 @@ public class DiagnosedStreamCorruptionExceptionTest {
                 new ChannelBuilder("dummy",null)
                     .withMode(Mode.BINARY)
                     .withBaseLoader(getClass().getClassLoader())
-                    .negotiate(new ByteArrayInputStream(payload), NullOutputStream.NULL_OUTPUT_STREAM);
+                    .negotiate(new ByteArrayInputStream(payload), NullOutputStream.INSTANCE);
 
         verify(ct);
     }
@@ -63,7 +63,7 @@ public class DiagnosedStreamCorruptionExceptionTest {
                     new ChannelBuilder("dummy",null)
                         .withMode(Mode.BINARY)
                         .withBaseLoader(getClass().getClassLoader())
-                        .negotiate(in, NullOutputStream.NULL_OUTPUT_STREAM);
+                        .negotiate(in, NullOutputStream.INSTANCE);
 
             verify(ct);
         }

--- a/src/test/java/hudson/remoting/PipeTest.java
+++ b/src/test/java/hudson/remoting/PipeTest.java
@@ -319,7 +319,7 @@ public class PipeTest implements Serializable {
     private static class DevNullSink extends CallableBase<OutputStream, IOException> {
         @Override
         public OutputStream call() {
-            return new RemoteOutputStream(NullOutputStream.NULL_OUTPUT_STREAM);
+            return new RemoteOutputStream(NullOutputStream.INSTANCE);
         }
         private static final long serialVersionUID = 1L;
     }

--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -14,7 +14,6 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 

--- a/src/test/java/hudson/remoting/throughput/DumbReceiver.java
+++ b/src/test/java/hudson/remoting/throughput/DumbReceiver.java
@@ -16,7 +16,7 @@ public class DumbReceiver {
             System.out.println("Ready");
             try (Socket s = ss.accept()) {
                 System.out.println("Accepted");
-                IOUtils.copy(s.getInputStream(), NullOutputStream.NULL_OUTPUT_STREAM);
+                IOUtils.copy(s.getInputStream(), NullOutputStream.INSTANCE);
             }
         }
     }

--- a/src/test/java/hudson/remoting/throughput/Sender.java
+++ b/src/test/java/hudson/remoting/throughput/Sender.java
@@ -59,7 +59,7 @@ public class Sender {
     }
 
     private static byte[] digest(InputStream in) throws NoSuchAlgorithmException, IOException {
-        DigestOutputStream dos = new DigestOutputStream(NullOutputStream.NULL_OUTPUT_STREAM, MessageDigest.getInstance("MD5"));
+        DigestOutputStream dos = new DigestOutputStream(NullOutputStream.INSTANCE, MessageDigest.getInstance("MD5"));
         IOUtils.copy(in, dos);
         return dos.getMessageDigest().digest();
     }


### PR DESCRIPTION
use `NullOutputStream.INSTANCE` instead of deprecated `NullOutputStream.NULL_OUTPUT_STREAM` (in Tests) and removed two unused imports

<!-- Please describe your pull request here. -->

### Testing done

Ran all unit tests

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
