### PR TITLE
Deprecating `PermanentConnectionRefusalException`

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/protocol/impl/PermanentConnectionRefusalException.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/impl/PermanentConnectionRefusalException.java
@@ -25,9 +25,10 @@ package org.jenkinsci.remoting.protocol.impl;
 
 /**
  * An exception to flag that the connection has been rejected and no further connection attempts should be made.
- *
+ * @deprecated Does not actually do what it claims; only affects logging levels.
  * @since 3.0
  */
+@Deprecated
 public class PermanentConnectionRefusalException extends ConnectionRefusalException {
     /**
      * {@inheritDoc}


### PR DESCRIPTION
From this class’ Javadoc

> no further connection attempts should be made

you would infer that throwing this error would produce different behavior compared to `ConnectionRefusalException`: rather than temporarily refusing a connection but letting the agent retry, the agent would immediately give up and exit. Yet it does not appear to actually do that, and from what I can tell going back to its introduction in #92 it never did.

First of all, no code actually uses this exception type currently. https://github.com/jenkinsci/remoting/blob/3b293d50275b7da9dffdd5354d2a744fbbf7c072/src/main/java/org/jenkinsci/remoting/protocol/impl/ConnectionHeadersFilterLayer.java#L378-L379 is merely wrapping an exception already caught. https://github.com/jenkinsci/remoting/blob/3b293d50275b7da9dffdd5354d2a744fbbf7c072/src/main/java/org/jenkinsci/remoting/protocol/impl/ConnectionHeadersFilterLayer.java#L324-L337 only runs on the agent side if the server side https://github.com/jenkinsci/remoting/blob/3b293d50275b7da9dffdd5354d2a744fbbf7c072/src/main/java/org/jenkinsci/remoting/protocol/impl/ConnectionHeadersFilterLayer.java#L225-L226 sent it. There are no known usages outside this repository.

So what happens if you try to use it?

```diff
diff --git src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol4Handler.java src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol4Handler.java
index 679d3ed0..323f27b2 100644
--- src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol4Handler.java
+++ src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol4Handler.java
@@ -58,6 +58,7 @@ import org.jenkinsci.remoting.protocol.impl.ChannelApplicationLayer;
 import org.jenkinsci.remoting.protocol.impl.ConnectionHeadersFilterLayer;
 import org.jenkinsci.remoting.protocol.impl.ConnectionRefusalException;
 import org.jenkinsci.remoting.protocol.impl.NIONetworkLayer;
+import org.jenkinsci.remoting.protocol.impl.PermanentConnectionRefusalException;
 import org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer;
 import org.jenkinsci.remoting.util.IOUtils;
 
@@ -291,7 +292,7 @@ public class JnlpProtocol4Handler extends JnlpProtocolHandler<Jnlp4ConnectionSta
             if (!client) {
                 String clientName = headers.get(JnlpConnectionState.CLIENT_NAME_KEY);
                 if (clientDatabase == null || !clientDatabase.exists(clientName)) {
-                    throw new ConnectionRefusalException("Unknown client name: " + clientName);
+                    throw new PermanentConnectionRefusalException("Unknown client name: " + clientName);
                 }
                 X509Certificate certificate = event.getCertificate();
                 JnlpClientDatabase.ValidationResult validation = certificate == null
```

looks like it would cause this error message to become fatal. Let us try it:

```java
public final class UnknownClientNameTest {
    @Rule public final JenkinsRule r = new JenkinsRule();
    @Test public void run() throws Exception {
        System.out.println(new ProcessBuilder(
            "java",
            "-cp", Which.jarFile(Main.class).getAbsolutePath(),
            Main.class.getName(),
            "-url", r.getURL().toString(),
            "whatever",
            "nonexistent"
        ).inheritIO().start().waitFor());
    }
}
```

without the above patch (but with #675 reverted just in case, though it does not actually matter since that is about an earlier stage) prints among other things

```
INFO: [JNLP4-connect connection to localhost/127.0.0.1:…] Local headers refused by remote: Unknown client name: nonexistent
```

sleeps ten seconds then repeats, indefinitely. Switching to `PermanentConnectionRefusalException` changes the log message

```
WARNING: [JNLP4-connect connection to localhost/127.0.0.1:…] Local headers permanently rejected by remote: Unknown client name: nonexistent
```

but the behavior is identical otherwise: the agent keeps on running until you kill the test, repeating this warning every ten seconds.

https://github.com/jenkinsci/remoting/blob/3b293d50275b7da9dffdd5354d2a744fbbf7c072/src/test/java/org/jenkinsci/remoting/protocol/impl/ConnectionHeadersFilterLayerTest.java#L169-L170 asserts that the “permanent” status is correctly transferred from server to client (I suppose via the `ERROR` vs. `FATAL` distinction). But all the test asserts is that the expected type of cause is preserved; https://github.com/jenkinsci/remoting/blob/3b293d50275b7da9dffdd5354d2a744fbbf7c072/src/test/java/org/jenkinsci/remoting/protocol/impl/ConnectionHeadersFilterLayerTest.java#L250-L253 (“refuses” rather than “rejects”) also assumes that the connection was closed: it is not testing the higher-level behavior of the `innerRun` loop.

Since the class does not work as advertised, is not currently used, and probably would not be desirable even if it did work, I am deprecating it to avoid confusion.
