### PR TITLE
Better logging of controller URL from `JnlpAgentEndpointResolver`

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -411,7 +411,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
                             new String[] {firstUrl, e.getClass().getName(), e.getMessage()});
                 } catch (IOException e) {
                     // report the failure
-                    LOGGER.log(INFO, "Failed to connect to " + firstUrl + ". Will try again", e);
+                    LOGGER.log(INFO, e, () -> "Failed to connect to " + firstUrl + ". Will try again");
                 }
             }
         } finally {


### PR DESCRIPTION
Otherwise it is not necessarily clear from log messages where the agent was _trying_ to connect.