### PR TITLE
`JNLP4-connect-proxy` connection protocol

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol4ProxyHandler.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol4ProxyHandler.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.remoting.engine;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.remoting.Channel;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.logging.Logger;
+
+/**
+ * Passes {@link JnlpConnectionState#CLIENT_NAME_KEY} using an HTTP-style header and lets the server decide how to handle that.
+ */
+public final class JnlpProtocol4ProxyHandler extends JnlpProtocolHandler<JnlpConnectionState> {
+
+    public static final String NAME = "JNLP4-connect-proxy";
+
+    private static final Logger LOGGER = Logger.getLogger(JnlpProtocol4ProxyHandler.class.getName());
+
+    private final JnlpProtocol4Handler delegate;
+
+    public JnlpProtocol4ProxyHandler(JnlpProtocol4Handler delegate) {
+        super(null, false); // unused, API design mistakes
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    @NonNull
+    public Future<Channel> connect(@NonNull Socket socket, @NonNull Map<String, String> headers, @NonNull List<? extends JnlpConnectionStateListener> listeners) throws IOException {
+        LOGGER.fine("sending my name");
+        DataOutputStream dos = new DataOutputStream(socket.getOutputStream());
+        dos.writeUTF("Protocol:" + NAME);
+        LOGGER.fine(() -> "connecting with headers " + headers);
+        String nodeName = headers.get(JnlpConnectionState.CLIENT_NAME_KEY);
+        if (nodeName == null) {
+            throw new IOException("expecting " + JnlpConnectionState.CLIENT_NAME_KEY);
+        }
+        PrintStream ps = new PrintStream(socket.getOutputStream(), true, StandardCharsets.UTF_8);
+        // HTTP-style headers
+        ps.println(JnlpConnectionState.CLIENT_NAME_KEY + ": " + nodeName);
+        ps.println();
+        LOGGER.fine("sent headers, now delegating to regular protocol");
+        return delegate.connect(socket, headers, listeners);
+    }
+
+    @Override
+    @NonNull
+    public Future<Channel> handle(@NonNull Socket socket, @NonNull Map<String, String> headers, @NonNull List<? extends JnlpConnectionStateListener> listeners) throws IOException {
+        throw new UnsupportedOperationException("unused, API design mistake");
+    }
+
+    @Override
+    @NonNull
+    protected JnlpConnectionState createConnectionState(@NonNull Socket socket, @NonNull List<? extends JnlpConnectionStateListener> listeners) throws IOException {
+        throw new UnsupportedOperationException("unused, API design mistake");
+    }
+
+}

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocolHandlerFactory.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocolHandlerFactory.java
@@ -161,7 +161,9 @@ public class JnlpProtocolHandlerFactory {
     public List<JnlpProtocolHandler<? extends JnlpConnectionState>> handlers() {
         List<JnlpProtocolHandler<? extends JnlpConnectionState>> result = new ArrayList<>();
         if (ioHub != null && context != null) {
-            result.add(new JnlpProtocol4Handler(clientDatabase, threadPool, ioHub, context, needClientAuth, preferNio));
+            JnlpProtocol4Handler jnlpProtocol4Handler = new JnlpProtocol4Handler(clientDatabase, threadPool, ioHub, context, needClientAuth, preferNio);
+            result.add(new JnlpProtocol4ProxyHandler(jnlpProtocol4Handler));
+            result.add(jnlpProtocol4Handler);
         }
         return result;
     }


### PR DESCRIPTION
Introduces an agent protocol used by CloudBees CI to intercept TCP connection requests and route them specially to the controller, by determining the agent name before proceeding with the connection. Ideally this could simply be added as a header to be interpreted by `TcpSlaveAgentListener.ConnectionHandler` like in #685, but unfortunately the TCP meta-protocol only allows the protocol _name_ to be sent, and not any other metadata: https://github.com/jenkinsci/remoting/blob/b329c48ba7fca39a3f59e593ba88490d1ea669df/src/main/java/org/jenkinsci/remoting/protocol/impl/AgentProtocolClientFilterLayer.java#L56 The other obvious choice in the stack https://github.com/jenkinsci/remoting/blob/b329c48ba7fca39a3f59e593ba88490d1ea669df/src/main/java/org/jenkinsci/remoting/engine/JnlpProtocol4Handler.java#L175-L182 would be the acknowledgement layer, but again this was built to only accept a single fixed string https://github.com/jenkinsci/remoting/blob/b329c48ba7fca39a3f59e593ba88490d1ea669df/src/main/java/org/jenkinsci/remoting/protocol/impl/AckFilterLayer.java#L94 and not offer any other extensibility while retaining compatibility: https://github.com/jenkinsci/remoting/blob/b329c48ba7fca39a3f59e593ba88490d1ea669df/src/main/java/org/jenkinsci/remoting/protocol/impl/AckFilterLayer.java#L142-L145 Routing at a lower layer would be much harder, so this was the most straightforward technique I could find.

An agent connecting to Jenkins core will simply skip this protocol since the server does not offer it: https://github.com/jenkinsci/remoting/blob/b329c48ba7fca39a3f59e593ba88490d1ea669df/src/main/java/hudson/remoting/Engine.java#L815-L818

If you wish to implement the server side of the protocol from inside Jenkins, it will look something like this:

```java
@Extension
public final class MyHandler extends AgentProtocol {
    @Override
    public String getName() {
        return JnlpProtocol4ProxyHandler.NAME;
    }
    @Override
    public String getDisplayName() {
        return "My handler";
    }
    @Override
    public void handle(Socket socket) throws IOException, InterruptedException {
        var agentIO = socket.getChannel();
        var br = new BufferedReader(Channels.newReader(agentIO, StandardCharsets.UTF_8));
        var headers = new HashMap<String, String>();
        while (true) {
            var line = br.readLine();
            if (line.isBlank()) {
                break;
            }
            var colon = line.indexOf(':');
            headers.put(line.substring(0, colon).trim(), line.substring(colon + 1).trim());
        }
        var nodeName = headers.get(JnlpConnectionState.CLIENT_NAME_KEY);
        // Do nothing special (handle with default protocol):
        var protocol = new DataInputStream(SocketChannelStream.in(socket)).readUTF();
        var delegate = ExtensionList.lookupSingleton(JnlpSlaveAgentProtocol4.class);
        if (!protocol.equals("Protocol:" + delegate.getName())) {
            throw new IOException("Unexpected protocol header: " + protocol);
        }
        delegate.handle(socket);
    }
}
```
