### PR TITLE
Fix proxy authentication

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -894,7 +894,7 @@ public class Engine extends Thread {
             resolver = new JnlpAgentEndpointResolver(jenkinsUrls, credentials, proxyCredentials, tunnel,
                     sslSocketFactory, disableHttpsCertValidation);
         } else {
-            resolver = new JnlpAgentEndpointConfigurator(directConnection, instanceIdentity, protocols);
+            resolver = new JnlpAgentEndpointConfigurator(directConnection, instanceIdentity, protocols, proxyCredentials);
         }
         return resolver;
     }

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointConfigurator.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointConfigurator.java
@@ -37,11 +37,13 @@ public class JnlpAgentEndpointConfigurator extends JnlpEndpointResolver {
     private final String instanceIdentity;
     private final Set<String> protocols;
     private final String directionConnection;
+    private final String proxyCredentials;
 
-    public JnlpAgentEndpointConfigurator(String directConnection, String instanceIdentity, Set<String> protocols) {
+    public JnlpAgentEndpointConfigurator(String directConnection, String instanceIdentity, Set<String> protocols, String proxyCredentials) {
         this.directionConnection = directConnection;
         this.instanceIdentity = instanceIdentity;
         this.protocols = protocols;
+        this.proxyCredentials = proxyCredentials;
     }
 
     @Override
@@ -57,7 +59,7 @@ public class JnlpAgentEndpointConfigurator extends JnlpEndpointResolver {
         }
         HostPort hostPort = new HostPort(directionConnection);
 
-        return new JnlpAgentEndpoint(hostPort.getHost(), hostPort.getPort(), identity, protocols, null);
+        return new JnlpAgentEndpoint(hostPort.getHost(), hostPort.getPort(), identity, protocols, null, proxyCredentials);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -40,11 +40,13 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import java.io.IOException;
+import java.net.Authenticator;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.NoRouteToHostException;
+import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.Proxy.Type;
 import java.net.ProxySelector;
@@ -331,7 +333,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
                 }
 
                 //TODO: all the checks above do not make much sense if tunneling is enabled (JENKINS-52246)
-                return new JnlpAgentEndpoint(host, port, identity, agentProtocolNames, selectedJenkinsURL);
+                return new JnlpAgentEndpoint(host, port, identity, agentProtocolNames, selectedJenkinsURL, proxyCredentials);
             } finally {
                 con.disconnect();
             }
@@ -343,11 +345,30 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
     }
 
     @SuppressFBWarnings(value = "UNENCRYPTED_SOCKET", justification = "This just verifies connection to the port. No data is transmitted.")
-    private boolean isPortVisible(String hostname, int port) {
+    private synchronized boolean isPortVisible(String hostname, int port) {
         boolean exitStatus = false;
         Socket s = null;
 
+        Authenticator orig = null;
         try {
+            if (proxyCredentials != null) {
+                final int index = proxyCredentials.indexOf(':');
+                if (index < 0) {
+                    throw new IllegalArgumentException("Invalid credential");
+                }
+                orig = Authenticator.getDefault();
+                // Using Authenticator.setDefault is a bit ugly, but there is no other way to control the authenticator
+                // on the HTTPURLConnection object created internally by Socket.
+                Authenticator.setDefault(new Authenticator() {
+                    @Override
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        if (getRequestorType().equals(RequestorType.PROXY)) {
+                            return new PasswordAuthentication(proxyCredentials.substring(0, index), proxyCredentials.substring(index + 1).toCharArray());
+                        }
+                        return super.getPasswordAuthentication();
+                    }
+                });
+            }
             InetSocketAddress proxyToUse = getResolvedHttpProxyAddress(hostname,port);
             s = proxyToUse == null ? new Socket() : new Socket(new Proxy(Type.HTTP, proxyToUse)); 
             s.setReuseAddress(true);
@@ -365,6 +386,9 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
                 } catch (IOException e) {
                     LOGGER.warning(e.getMessage());
                 }
+            }
+            if (orig != null) {
+                Authenticator.setDefault(orig);
             }
         }
         return exitStatus;


### PR DESCRIPTION
While testing #677 I noticed that proxy authentication was broken even on trunk, no matter which combination of entrypoints and parameters I tried. If we advertise a `-proxyCredentials` flag, then it should at least work. This PR gets the flag to work as advertised.

### Testing done

Set up a Squid forward proxy that required authentication, then ran:

`java -Djdk.http.auth.tunneling.disabledSchemes= -Dhttp.proxyHost=${IP_ADDRESS} -Dhttp.proxyPort=3128 -jar target/remoting-999999-SNAPSHOT.jar -url ${JENKINS_URL} -secret ${SECRET} -name test -proxyCredentials ${USERNAME}:${PASSWORD}`

Before this PR it either failed either in the `isPortVisible` method or when trying to actually establish the tunnel. Now it works in both places.