### PR TITLE
Support `-cert` and `-noCertificateCheck` in WebSocket mode

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -46,6 +46,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -76,7 +77,11 @@ import jakarta.websocket.Endpoint;
 import jakarta.websocket.EndpointConfig;
 import jakarta.websocket.HandshakeResponse;
 import jakarta.websocket.Session;
+import jakarta.websocket.WebSocketContainer;
 import net.jcip.annotations.NotThreadSafe;
+import org.glassfish.tyrus.client.ClientManager;
+import org.glassfish.tyrus.client.ClientProperties;
+import org.glassfish.tyrus.client.SslEngineConfigurator;
 import org.jenkinsci.remoting.engine.Jnlp4ConnectionState;
 import org.jenkinsci.remoting.engine.JnlpAgentEndpoint;
 import org.jenkinsci.remoting.engine.JnlpAgentEndpointConfigurator;
@@ -94,6 +99,8 @@ import org.jenkinsci.remoting.protocol.cert.PublicKeyMatchingX509ExtendedTrustMa
 import org.jenkinsci.remoting.protocol.impl.ConnectionRefusalException;
 import org.jenkinsci.remoting.util.KeyUtils;
 import org.jenkinsci.remoting.util.VersionNumber;
+import org.jenkinsci.remoting.util.https.NoCheckHostnameVerifier;
+import org.jenkinsci.remoting.util.https.NoCheckTrustManager;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -682,7 +689,19 @@ public class Engine extends Thread {
                 }
                 hudsonUrl = candidateUrls.get(0);
                 String wsUrl = hudsonUrl.toString().replaceFirst("^http", "ws");
-                ContainerProvider.getWebSocketContainer().connectToServer(new AgentEndpoint(),
+                WebSocketContainer container = ContainerProvider.getWebSocketContainer();
+                if (container instanceof ClientManager) {
+                    ClientManager client = (ClientManager) container;
+                    SSLContext sslContext = getSSLContext(candidateCertificates, disableHttpsCertValidation);
+                    if (sslContext != null) {
+                        SslEngineConfigurator sslEngineConfigurator = new SslEngineConfigurator(sslContext);
+                        if (disableHttpsCertValidation) {
+                            sslEngineConfigurator.setHostnameVerifier(new NoCheckHostnameVerifier());
+                        }
+                        client.getProperties().put(ClientProperties.SSL_ENGINE_CONFIGURATOR, sslEngineConfigurator);
+                    }
+                }
+                container.connectToServer(new AgentEndpoint(),
                     ClientEndpointConfig.Builder.create().configurator(headerHandler).build(), URI.create(wsUrl + "wsagents/"));
                 while (ch.get() == null) {
                     Thread.sleep(100);
@@ -887,7 +906,7 @@ public class Engine extends Thread {
         if (directConnection == null) {
             SSLSocketFactory sslSocketFactory = null;
             try {
-                sslSocketFactory = getSSLSocketFactory(candidateCertificates);
+                sslSocketFactory = getSSLSocketFactory(candidateCertificates, disableHttpsCertValidation);
             } catch (Exception e) {
                 events.error(e);
             }
@@ -1037,12 +1056,14 @@ public class Engine extends Thread {
     }
 
     @CheckForNull
-    @Restricted(NoExternalUse.class)
-    static SSLSocketFactory getSSLSocketFactory(List<X509Certificate> x509Certificates)
+    private static SSLContext getSSLContext(List<X509Certificate> x509Certificates, boolean noCertificateCheck)
             throws PrivilegedActionException, KeyStoreException, NoSuchProviderException, CertificateException,
             NoSuchAlgorithmException, IOException, KeyManagementException {
-        SSLSocketFactory sslSocketFactory = null;
-        if (x509Certificates != null && !x509Certificates.isEmpty()) {
+        SSLContext sslContext = null;
+        if (noCertificateCheck) {
+            sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, new TrustManager[]{new NoCheckTrustManager()}, new SecureRandom());
+        } else if (x509Certificates != null && !x509Certificates.isEmpty()) {
             KeyStore keyStore = getCacertsKeyStore();
             // load the keystore
             keyStore.load(null, null);
@@ -1058,11 +1079,19 @@ public class Engine extends Thread {
             SSLContext ctx = SSLContext.getInstance("TLS");
             // now we have our custom socket factory
             ctx.init(null, trustManagerFactory.getTrustManagers(), null);
-            sslSocketFactory = ctx.getSocketFactory();
         }
-        return sslSocketFactory;
+        return sslContext;
     }
     
+    @CheckForNull
+    @Restricted(NoExternalUse.class)
+    static SSLSocketFactory getSSLSocketFactory(List<X509Certificate> x509Certificates, boolean noCertificateCheck)
+            throws PrivilegedActionException, KeyStoreException, NoSuchProviderException, CertificateException,
+            NoSuchAlgorithmException, IOException, KeyManagementException {
+        SSLContext sslContext = getSSLContext(x509Certificates, noCertificateCheck);
+        return sslContext == null ? null : sslContext.getSocketFactory();
+    }
+
     /**
      * Socket read timeout.
      * A {@link SocketInputStream#read()} call associated with underlying Socket will block for only this amount of time

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -297,8 +297,6 @@ public class Launcher {
                 "-tunnel",
                 "-credentials",
                 "-proxyCredentials",
-                "-cert",
-                "-noCertificateCheck",
                 "-noKeepAlive"
             })
     public boolean webSocket;
@@ -409,7 +407,7 @@ public class Launcher {
 
         createX509Certificates();
         try {
-            sslSocketFactory = Engine.getSSLSocketFactory(x509Certificates);
+            sslSocketFactory = Engine.getSSLSocketFactory(x509Certificates, noCertificateCheck);
         } catch (GeneralSecurityException | PrivilegedActionException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
I couldn't see a good reason to support these in one transport but not the other, given that it is just a matter of plumbing through the relevant `SSLContext` to the HTTP layer.

### Testing done

Set up a WebSocket agent against my controller with a self-signed HTTPS certificate. Verified the connection failed before this PR and passed after this PR when adding `-noCertificateCheck`. I also tested that I could connect with HTTPS and `-noCertificateCheck` _without_ WebSocket. I did not test `-cert` because I don't actually have a valid certificate for my local testing environment. But this code is common code, so if it's plumbed through correctly in one case it should be plumbed through correctly in the other as well.