### PR TITLE
Proxy support for WebSocket

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -296,7 +296,6 @@ public class Launcher {
                 "-direct",
                 "-tunnel",
                 "-credentials",
-                "-proxyCredentials",
                 "-cert",
                 "-noCertificateCheck",
                 "-noKeepAlive"


### PR DESCRIPTION
This component supports the `http.proxyHost` system property (or `proxy_host` environment variable) for configuring a proxy server, but it is not honored in WebSocket mode. By plumbing this through to Tyrus we can get Tyrus to respect the proxy settings the same way non-WebSocket mode does. Similarly we can plumb through the value of `-proxyCredentials` to Tyrus if the user needs to pass in a `Proxy-Authorization` header (like we do in non-WebSocket mode). We do this only for HTTP to match the non-WebSocket mode.

### Testing done

Set up a Squid proxy that required authentication and verified that I could connect through it using:

```
java -Dhttp.proxyHost=${HOSTNAME} -Dhttp.proxyPort=3128 -jar target/remoting-999999-SNAPSHOT.jar -url ${JENKINS_URL} -secret ${SECRET} -name test -webSocket -proxyCredentials ${USERNAME}:${PASSWORD}
```