### PR TITLE
Increase visibility of field

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -202,7 +202,7 @@ public class Launcher {
      * This option is managed by the {@code -noCertificateCheck} option.
      */
     @Option(name="-noCertificateCheck", aliases = "-disableHttpsCertValidation", forbids = "-cert", usage="Ignore SSL validation errors - use as a last resort only.")
-    private boolean noCertificateCheck = false;
+    public boolean noCertificateCheck = false;
 
     public InetSocketAddress connectionTarget = null;
 


### PR DESCRIPTION
When migrating `@Option` from the setter to the field (and deprecating the setter) I neglected to also make the field `public` (like all other `@Option` fields) as I discovered when trying to migrate Swarm away from the deprecated usage.