### PR TITLE
Move initialization to common method for Swarm

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -365,8 +365,6 @@ public class Launcher {
     @Deprecated
     public List<String> args = new ArrayList<>();
 
-    private boolean initialized = false;
-
     public static void main(String... args) throws IOException, InterruptedException {
         Launcher launcher = new Launcher();
         CmdLineParser parser = new CmdLineParser(launcher);
@@ -413,10 +411,6 @@ public class Launcher {
     }
 
     private synchronized void initialize() throws IOException {
-        if (initialized) {
-            return;
-        }
-
         // Create and verify working directory and logging
         // TODO: The pass-through for the JNLP mode has been added in JENKINS-39817. But we still need to keep this parameter in
         // consideration for other modes (TcpServer, TcpClient, etc.) to retain the legacy behavior.
@@ -441,8 +435,6 @@ public class Launcher {
         if (noCertificateCheck) {
             hostnameVerifier = new NoCheckHostnameVerifier();
         }
-
-        initialized = true;
     }
 
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Parameter supplied by user / administrator.")

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -365,6 +365,8 @@ public class Launcher {
     @Deprecated
     public List<String> args = new ArrayList<>();
 
+    private boolean initialized;
+
     public static void main(String... args) throws IOException, InterruptedException {
         Launcher launcher = new Launcher();
         CmdLineParser parser = new CmdLineParser(launcher);
@@ -413,7 +415,10 @@ public class Launcher {
         }
     }
 
-    private void initialize() throws IOException {
+    private synchronized void initialize() throws IOException {
+        if (initialized) {
+            throw new IllegalStateException("double initialization");
+        }
         // Create and verify working directory and logging
         // TODO: The pass-through for the JNLP mode has been added in JENKINS-39817. But we still need to keep this parameter in
         // consideration for other modes (TcpServer, TcpClient, etc.) to retain the legacy behavior.
@@ -438,6 +443,7 @@ public class Launcher {
         if (noCertificateCheck) {
             hostnameVerifier = new NoCheckHostnameVerifier();
         }
+        initialized = true;
     }
 
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Parameter supplied by user / administrator.")

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -394,23 +394,26 @@ public class Launcher {
             return;
         }
 
-        initialize();
-
         if (connectionTarget != null) {
+            initialize();
             runAsTcpClient();
         } else if (agentJnlpURL != null || !urls.isEmpty() || directConnection != null) {
             if (agentJnlpURL != null) {
-                bootstrapInboundAgent();
+                bootstrapInboundAgent(); // calls initialize() internally
+            } else {
+                initialize();
             }
             runAsInboundAgent();
         } else if (tcpPortFile != null) {
+            initialize();
             runAsTcpServer();
         } else {
+            initialize();
             runWithStdinStdout();
         }
     }
 
-    private synchronized void initialize() throws IOException {
+    private void initialize() throws IOException {
         // Create and verify working directory and logging
         // TODO: The pass-through for the JNLP mode has been added in JENKINS-39817. But we still need to keep this parameter in
         // consideration for other modes (TcpServer, TcpClient, etc.) to retain the legacy behavior.


### PR DESCRIPTION
Found a minor issue when trying to refactor Swarm to take advantage of these recent changes: Swarm directly calls `Launcher#parseJnlpArguments` to get the secret from the server (and can't easily be changed to stop doing this), and that currently means that the initialization logic from `Launcher#run` doesn't get run, so things like `-noCertificateCheck` are working only by accident in that their initialization is done lazily rather than eagerly. This PR fixes that problem and makes the code more easy to understand by putting all initialization logic in one place and ensuring that all public entrypoints invoke it exactly once, and eagerly at the beginning of program launch.

We also took the various initialization paradigms and made them consistent: eager rather than lazy, using the same set of fields everywhere, the same set of arguments everywhere in the same order, etc.

### Testing done

Ran both Remoting and Swarm tests with these changes.