### PR TITLE
Avoid capturing `Request` in `LogRecord` parameters

### DIFF
--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -393,7 +393,7 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
                     // this means the caller will block forever
                     if (e instanceof ChannelClosedException && !logger.isLoggable(Level.FINE)) {
                         // TODO if this is from CloseCommand reduce level to FINE
-                        logger.info("Failed to send back a reply to the request " + Request.this + ": " + e);
+                        logger.info(() -> "Failed to send back a reply to the request " + Request.this + ": " + e);
                     } else {
                         logger.log(Level.WARNING, e, () -> "Failed to send back a reply to the request " + Request.this);
                     }

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -393,7 +393,7 @@ public abstract class Request<RSP extends Serializable,EXC extends Throwable> ex
                     // this means the caller will block forever
                     if (e instanceof ChannelClosedException && !logger.isLoggable(Level.FINE)) {
                         // TODO if this is from CloseCommand reduce level to FINE
-                        logger.log(Level.INFO, "Failed to send back a reply to the request {0}: {1}", new Object[] {Request.this, e});
+                        logger.info("Failed to send back a reply to the request " + Request.this + ": " + e);
                     } else {
                         logger.log(Level.WARNING, e, () -> "Failed to send back a reply to the request " + Request.this);
                     }


### PR DESCRIPTION
Noticed in a heap dump that there were several `Channel`s sticking around after the associated builds had completed, and found that they were referenced in a log ring buffer

```
this     - value: hudson.remoting.Channel #1
 <- channel     - class: hudson.remoting.RemoteClassLoader$ClassLoaderProxy, value: hudson.remoting.Channel #1
  <- classLoaderProxy     - class: hudson.remoting.UserRequest, value: hudson.remoting.RemoteClassLoader$ClassLoaderProxy #1
   <- [0]     - class: java.lang.Object[], value: hudson.remoting.UserRequest #1
    <- parameters     - class: java.util.logging.LogRecord, value: java.lang.Object[] #97789
     <- [177]     - class: java.util.logging.LogRecord[], value: java.util.logging.LogRecord #32
      <- records     - class: hudson.WebAppMain$1, value: java.util.logging.LogRecord[] #1
       <- handler     - class: hudson.WebAppMain, value: hudson.WebAppMain$1 #1
        <- [4]     - class: java.lang.Object[], value: hudson.WebAppMain #1
         <- elementData     - class: java.util.ArrayList, value: java.lang.Object[] #1868
          <- _destroyServletContextListeners     - class: winstone.HostConfiguration$1, value: java.util.ArrayList #91
           <- _context (Java frame)     - class: org.eclipse.jetty.webapp.WebAppClassLoader, value: winstone.HostConfiguration$1 #1
```

whose message I traced to this line.

See https://github.com/jenkinsci/jenkins/pull/6643 for background.
