### PR TITLE
Remove deprecated `-cp` argument

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -59,13 +59,11 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -144,23 +142,6 @@ public class Launcher {
 
     @Option(name="-proxyCredentials",metaVar="USER:PASSWORD",usage="HTTP BASIC AUTH header to pass in for making HTTP authenticated proxy requests.")
     public String proxyCredentials = System.getProperty("proxyCredentials");
-
-    @Option(name="-cp",aliases="-classpath",metaVar="PATH",
-            usage="add the given classpath elements to the system classloader. (DEPRECATED)")
-    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Parameter supplied by user / administrator.")
-    public void addClasspath(String pathList) throws Exception {
-        LOGGER.warning("[JENKINS-64831] Passing -cp to hudson.remoting.Launcher is deprecated and may not work at all on Java 9+");
-        Method $addURL = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
-        $addURL.setAccessible(true);
-
-        for(String token : pathList.split(File.pathSeparator))
-            $addURL.invoke(ClassLoader.getSystemClassLoader(),new File(token).toURI().toURL());
-
-        // fix up the system.class.path to pretend that those jar files
-        // are given through CLASSPATH or something.
-        // some tools like JAX-WS RI and Hadoop relies on this.
-        System.setProperty("java.class.path",System.getProperty("java.class.path")+File.pathSeparatorChar+pathList);
-    }
 
     @Option(name="-tcp",usage="instead of talking to the controller via stdin/stdout, " +
             "listens to a random local port, write that port number to the given file, " +


### PR DESCRIPTION
As of jenkinsci/jenkins#6723 this is no longer used and would not work on Java 9+ anyway, which we have been requiring for quite some time now.

### Testing done

CI build