### PR TITLE
Print deprecation warning when deprecated arguments are used

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -98,8 +98,10 @@ import java.util.logging.Logger;
 public class Launcher {
     public Mode mode = Mode.BINARY;
 
-    // no-op, but left for backward compatibility
-    @Option(name="-ping")
+    /**
+     * @deprecated removed without replacement
+     */
+    @Deprecated
     public boolean ping = true;
 
     /**
@@ -117,6 +119,17 @@ public class Launcher {
     public void setTextMode(boolean b) {
         mode = b?Mode.TEXT:Mode.BINARY;
         System.out.println("Running in "+mode.name().toLowerCase(Locale.ENGLISH)+" mode");
+    }
+
+    /**
+     * @deprecated removed without replacement
+     */
+    @Deprecated
+    @Option(name = "-ping", usage = "(deprecated; now always pings)")
+    public void setPing(boolean ping) {
+        this.ping = ping;
+        System.err.println(
+                "WARNING: The \"-ping\" argument is deprecated and will be removed without replacement in a future release.");
     }
 
     /**
@@ -141,17 +154,41 @@ public class Launcher {
     @Option(name="-proxyCredentials",metaVar="USER:PASSWORD",usage="HTTP BASIC AUTH header to pass in for making HTTP authenticated proxy requests.")
     public String proxyCredentials = System.getProperty("proxyCredentials");
 
-    @Option(name="-tcp",usage="instead of talking to the controller via stdin/stdout, " +
+    /**
+     * @deprecated removed without replacement
+     */
+    @Deprecated
+    public File tcpPortFile = null;
+
+    /**
+     * @deprecated removed without replacement
+     */
+    @Deprecated
+    @Option(name="-tcp",usage="(deprecated) instead of talking to the controller via stdin/stdout, " +
             "listens to a random local port, write that port number to the given file, " +
             "then wait for the controller to connect to that port.")
-    public File tcpPortFile=null;
+    public void setTcpPortFile(File tcpPortFile) {
+        this.tcpPortFile = tcpPortFile;
+        System.err.println(
+                "WARNING: The \"-tcp\" argument is deprecated and will be removed without replacement in a future release.");
+    }
 
     /**
      * @deprecated use {@link #agentJnlpCredentials} or {@link #proxyCredentials}
      */
     @Deprecated
-    @Option(name="-auth",metaVar="user:pass",usage="(deprecated) unused; use -credentials or -proxyCredentials")
     public String auth = null;
+
+    /**
+     * @deprecated use {@link #agentJnlpCredentials} or {@link #proxyCredentials}
+     */
+    @Deprecated
+    @Option(name = "-auth", metaVar = "user:pass", usage = "(deprecated) unused; use -credentials or -proxyCredentials")
+    public void setAuth(String auth) {
+        this.auth = auth;
+        System.err.println(
+                "WARNING: The \"-auth\" argument is deprecated and will be removed in a future release; use \"-credentials\" or \"-proxyCredentials\" instead.");
+    }
 
     /**
      * @since 2.24
@@ -187,9 +224,17 @@ public class Launcher {
 
     private HostnameVerifier hostnameVerifier;
 
+    /**
+     * @deprecated removed without replacement
+     */
+    @Deprecated
     public InetSocketAddress connectionTarget = null;
 
-    @Option(name="-connectTo",usage="make a TCP connection to the given host and port, then start communication.",metaVar="HOST:PORT")
+    /**
+     * @deprecated removed without replacement
+     */
+    @Deprecated
+    @Option(name="-connectTo",usage="(deprecated) make a TCP connection to the given host and port, then start communication.",metaVar="HOST:PORT")
     public void setConnectTo(String target) {
         String[] tokens = target.split(":");
         if(tokens.length!=2) {
@@ -197,6 +242,8 @@ public class Launcher {
             System.exit(1);
         }
         connectionTarget = new InetSocketAddress(tokens[0],Integer.parseInt(tokens[1]));
+        System.err.println(
+                "WARNING: The \"-connectTo\" argument is deprecated and will be removed without replacement in a future release.");
     }
 
     @Option(name="-noReconnect",aliases="-noreconnect",usage="Doesn't try to reconnect when a communication fail, and exit instead")
@@ -251,9 +298,22 @@ public class Launcher {
                     + "in which case the missing portion will be auto-configured like the default behavior.")
     public String tunnel;
 
+    /**
+     * @deprecated removed without replacement
+     */
+    @Deprecated
+    public boolean headlessMode;
+
+    /**
+     * @deprecated removed without replacement
+     */
     @Deprecated
     @Option(name = "-headless", usage = "(deprecated; now always headless)")
-    public boolean headlessMode;
+    public void setHeadlessMode(boolean headlessMode) {
+        this.headlessMode = headlessMode;
+        System.err.println(
+                "WARNING: The \"-headless\" argument is deprecated and will be removed without replacement in a future release.");
+    }
 
     @Option(name = "-url", usage = "Specify the Jenkins root URLs to connect to.")
     public List<URL> urls = new ArrayList<>();
@@ -337,6 +397,10 @@ public class Launcher {
         CmdLineParser parser = new CmdLineParser(launcher);
         try {
             parser.parseArgument(args);
+            if (launcher.args.size() == 2) {
+                System.err.println(
+                        "WARNING: Providing the secret and agent name as positional arguments is deprecated; use \"-secret\" and \"-name\" instead.");
+            }
             normalizeArguments(launcher);
             if (launcher.showHelp && !launcher.showVersion) {
                 parser.printUsage(System.out);


### PR DESCRIPTION
Now that I have migrated common usages away from these deprecated arguments, ensure that a warning is printed if a user is still invoking Remoting with a deprecated argument. I haven't yet added a warning for `-jnlpUrl` because I want to wait for https://github.com/jenkinsci/jenkins/pull/8639 to ship in a few weekly releases first. The `-tcp` and `-connectTo` arguments weren't deprecated at the command-line argument level but their implementations were marked with `@Deprecated`, so I am deprecating the command-line arguments too for consistency. I could find no uses besides the WMI Windows Agents plugin tests, and that plugin is itself already deprecated.

### Testing done

Invoked the various arguments at the command-line and verified that a deprecation warning was printed.