### PR TITLE
Print deprecation warning when using `-jnlpUrl`

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -430,6 +430,8 @@ public class Launcher {
             runAsTcpClient();
         } else if (agentJnlpURL != null || !urls.isEmpty() || directConnection != null) {
             if (agentJnlpURL != null) {
+                System.err.println(
+                        "WARNING: The \"-jnlpUrl\" argument is deprecated. Use \"-url\" and \"-name\" instead, potentially also passing in \"-webSocket\", \"-tunnel\", and/or work directory options as needed.");
                 bootstrapInboundAgent(); // calls initialize() internally
             } else {
                 initialize();


### PR DESCRIPTION
Now that https://github.com/jenkinsci/jenkins/pull/8639 and https://github.com/jenkinsci/jenkins-test-harness/pull/670 have been shipping for a bit, time to deprecate this legacy usage mode.

### Testing done

Verified that I could connect to the controller with the new calling convention without any warnings and that the warning was printed when using the old calling convention.