### PR TITLE
Reduce visibility of `parseJnlpArguments`

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -674,8 +674,8 @@ public class Launcher {
      * Parses the connection arguments from JNLP file given in the URL.
      */
     @SuppressFBWarnings(value = {"CIPHER_INTEGRITY", "STATIC_IV"}, justification = "Integrity not needed here. IV used for decryption only, loaded from encryptor.")
-    public List<String> parseJnlpArguments() throws ParserConfigurationException, SAXException, IOException, InterruptedException {
-        initialize();  // For Swarm, or anyone else who invokes this public method directly rather than going through main() or run()
+    private List<String> parseJnlpArguments() throws ParserConfigurationException, SAXException, IOException, InterruptedException {
+        initialize();
         if (secret != null) {
             agentJnlpURL = new URL(agentJnlpURL + "?encrypt=true");
             if (agentJnlpCredentials != null) {

--- a/src/main/java/hudson/remoting/jnlp/Main.java
+++ b/src/main/java/hudson/remoting/jnlp/Main.java
@@ -25,10 +25,7 @@ package hudson.remoting.jnlp;
 
 import hudson.remoting.Launcher;
 import java.io.IOException;
-import java.util.List;
-import javax.xml.parsers.ParserConfigurationException;
 import org.kohsuke.args4j.CmdLineException;
-import org.xml.sax.SAXException;
 
 /**
  * Previous entry point to pseudo-JNLP agent.
@@ -52,13 +49,6 @@ public class Main extends Launcher {
     public void run() throws CmdLineException, IOException, InterruptedException {
         logDeprecation();
         super.run();
-    }
-
-    @Override
-    public List<String> parseJnlpArguments()
-            throws ParserConfigurationException, SAXException, IOException, InterruptedException {
-        logDeprecation();
-        return super.parseJnlpArguments();
     }
 
     private static void logDeprecation() {


### PR DESCRIPTION
This method was only ever public for use by Swarm, and as of https://github.com/jenkinsci/swarm-plugin/pull/606 Swarm is not calling it anymore.

### Testing done

Verified in a code search in `jenkinsci` and `cloudbees` that nothing is invoking `parseJnlpArguments` directly.