### PR TITLE
Use `CompletableFuture` in `JarCache`

### DIFF
--- a/src/main/java/hudson/remoting/JarCache.java
+++ b/src/main/java/hudson/remoting/JarCache.java
@@ -5,6 +5,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Jar file cache.
@@ -55,5 +56,5 @@ public abstract class JarCache {
      *      URL of the jar file.
      */
     @NonNull
-    public abstract Future<URL> resolve(@NonNull Channel channel, long sum1, long sum2) throws IOException, InterruptedException;
+    public abstract CompletableFuture<URL> resolve(@NonNull Channel channel, long sum1, long sum2) throws IOException, InterruptedException;
 }

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
+import java.util.concurrent.Future;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/src/main/java/hudson/remoting/ResourceImageBoth.java
+++ b/src/main/java/hudson/remoting/ResourceImageBoth.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/src/main/java/hudson/remoting/ResourceImageDirect.java
+++ b/src/main/java/hudson/remoting/ResourceImageDirect.java
@@ -4,6 +4,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -35,12 +37,12 @@ class ResourceImageDirect extends ResourceImageRef {
     @Override
     Future<byte[]> resolve(Channel channel, String resourcePath) throws IOException, InterruptedException {
         LOGGER.log(Level.FINE, resourcePath+" image is direct");
-        return new AsyncFutureImpl<>(payload);
+        return CompletableFuture.completedFuture(payload);
     }
 
     @Override
     Future<URLish> resolveURL(Channel channel, String resourcePath) throws IOException, InterruptedException {
-        return new AsyncFutureImpl<>(URLish.from(makeResource(resourcePath, payload)));
+        return CompletableFuture.completedFuture(URLish.from(makeResource(resourcePath, payload)));
     }
 
     private static final Logger LOGGER = Logger.getLogger(ResourceImageDirect.class.getName());

--- a/src/main/java/hudson/remoting/ResourceImageInJar.java
+++ b/src/main/java/hudson/remoting/ResourceImageInJar.java
@@ -4,9 +4,12 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 /**
  * {@link ResourceImageRef} that points to a resource inside a jar file.
@@ -42,31 +45,29 @@ class ResourceImageInJar extends ResourceImageRef {
 
     @Override
     Future<byte[]> resolve(Channel channel, final String resourcePath) throws IOException, InterruptedException {
-        return new FutureAdapter<>(_resolveJarURL(channel)) {
-            @Override
-            @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "This is only used for managing the jar cache as files.")
-            protected byte[] adapt(URL jar) throws ExecutionException {
-                try {
-                    return Util.readFully(toResourceURL(jar, resourcePath).openStream());
-                } catch (IOException e) {
-                    throw new ExecutionException(e);
-                }
-            }
-        };
+        return _resolveJarURL(channel).thenApply(jar -> readContents(jar, resourcePath));
+    }
+
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "This is only used for managing the jar cache as files.")
+    private byte[] readContents(URL jar, String resourcePath) {
+        try (InputStream in = toResourceURL(jar, resourcePath).openStream()) {
+            return Util.readFully(in);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override
     Future<URLish> resolveURL(Channel channel, final String resourcePath) throws IOException, InterruptedException {
-        return new FutureAdapter<>(_resolveJarURL(channel)) {
-            @Override
-            protected URLish adapt(URL jar) throws ExecutionException {
-                try {
-                    return URLish.from(toResourceURL(jar, resourcePath));
-                } catch (IOException e) {
-                    throw new ExecutionException(e);
-                }
-            }
-        };
+        return _resolveJarURL(channel).thenApply(jar -> getUrlish(jar, resourcePath));
+    }
+
+    private URLish getUrlish(URL jar, String resourcePath) {
+        try {
+            return URLish.from(toResourceURL(jar, resourcePath));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @NonNull
@@ -83,7 +84,7 @@ class ResourceImageInJar extends ResourceImageRef {
         return new URL("jar:"+ jar +"!/"+resourcePath);
     }
 
-    Future<URL> _resolveJarURL(Channel channel) throws IOException, InterruptedException {
+    CompletableFuture<URL> _resolveJarURL(Channel channel) throws IOException, InterruptedException {
         JarCache c = channel.getJarCache();
         if (c == null) {
             throw new IOException(String.format("Failed to resolve a jar %016x%016x. JAR Cache is disabled for the channel %s",

--- a/src/main/java/hudson/remoting/ResourceImageRef.java
+++ b/src/main/java/hudson/remoting/ResourceImageRef.java
@@ -4,6 +4,7 @@ import hudson.remoting.RemoteClassLoader.ClassReference;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.concurrent.Future;
 
 /**
  * Wire protocol data representation that encapsulates the access to a resource inside a {@link ClassLoader}.


### PR DESCRIPTION
When reading this code recently, I noticed we were using some custom classes like `AsyncFutureImpl` and `FutureAdapter` which now have equivalents in the Java Platform. I thought the code was easier to read when using the standard classes rather than our custom ones.

This is a tiny public API change for `hudson.remoting.JarCache` and a handful of package-private internal classes, but I searched in `jenkinsci` and `cloudbees` and found no consumers outside of Remoting itself, so this change seems safe from an API compatibility point of view.

I stepped through the code in the debugger before and after and found one minor change: when downloading a JAR for the first time, the chained future to read the file into memory from `ResourceImageInJar` runs immediately as part of the `promise.complete(url)` call in `JarCacheSupport` on the `AtmostOneThreadExecutor` thread rather than before where it was run lazily a little bit later when calling `.get()` from `RemoteClassLoader#loadRemoteClass` as part of the request handling thread. This doesn't seem like it should make any difference to me, and I think the readability benefits of using `CompletableFuture` everywhere are worth the minor change in behavior. But if people feel this is too risky, I can always roll back the call to `CompletableFuture#thenApply` in `ResourceImageInJar` and go back to using Kohsuke's `FutureAdapter` which would restore the old behavior. In any case, this only matters when the cache is cold; when the cache is warm, the behavior is identical to the old behavior (including the horrific existing behavior of reading the entire JAR file from disk for each `.class` file load operation, a great stress test of the OS page cache!).

All in all this change shuffles a few things around internally within the implementation but shouldn't result in any change in user-visible behavior, and in my opinion modernizes the codebase a little and improves readability, but if people feel the risk is too high, I could make this change somewhat more conservative as described above, or even close this PR entirely if people would rather not touch this messy code at all.

### Testing done

Ran `mvn clean verify`, and ran a Pipeline job with the Git plugin and JGit with both warm and cold JAR caches, stepping through the relevant functionality in both cases in the debugger to verify correct operation before and after this change.