### PR TITLE
Rely on parent pom spotbugs configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,10 +62,6 @@ THE SOFTWARE.
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
     <build.type>private</build.type>
-    <!-- TODO: Remove when parent pom is using this version or newer -->
-    <!-- https://github.com/jenkinsci/pom/pull/510 -->
-    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
-    <spotbugs.omitVisitors>FindReturnRef,ConstructorThrow</spotbugs.omitVisitors>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <bc-version>1.77</bc-version>


### PR DESCRIPTION
## Rely on spotbugs configuration from parent pom

Removes cd91eea5dc25cee827a502d0b40423312f5bb11 workaround that was added in https://github.com/jenkinsci/remoting/pull/708

https://github.com/jenkinsci/pom/pull/510 is the pull request to the parent pom.  It was released in parent pom 1.109.

### Testing done

Confirmed that spotbugs output is still silent after the change.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
