### PR TITLE
Use Java 11 methods where possible

### DIFF
--- a/src/main/java/hudson/remoting/Checksum.java
+++ b/src/main/java/hudson/remoting/Checksum.java
@@ -1,6 +1,5 @@
 package hudson.remoting;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.ByteArrayInputStream;
@@ -79,26 +78,12 @@ final class Checksum {
     static Checksum forURL(URL url) throws IOException {
         try {
             MessageDigest md = MessageDigest.getInstance(JarLoaderImpl.DIGEST_ALGORITHM);
-            try(InputStream istream = url.openStream(); OutputStream ostream = new DigestOutputStream(new NullOutputStream(), md)) {
+            try(InputStream istream = url.openStream(); OutputStream ostream = new DigestOutputStream(OutputStream.nullOutputStream(), md)) {
                 Util.copy(istream, ostream);
                 return new Checksum(md.digest(), md.getDigestLength() / 8);
             }
         } catch (NoSuchAlgorithmException e) {
             throw new AssertionError(e);
-        }
-    }
-
-    private static class NullOutputStream extends OutputStream {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void write(@NonNull byte[] b) {
-        }
-
-        @Override
-        public void write(@NonNull byte[] b, int off, int len) {
         }
     }
 }

--- a/src/test/java/hudson/remoting/DiagnosedStreamCorruptionExceptionTest.java
+++ b/src/test/java/hudson/remoting/DiagnosedStreamCorruptionExceptionTest.java
@@ -1,11 +1,11 @@
 package hudson.remoting;
 
 import hudson.remoting.Channel.Mode;
-import org.apache.commons.io.output.NullOutputStream;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.StreamCorruptedException;
 import java.io.StringWriter;
@@ -28,7 +28,7 @@ public class DiagnosedStreamCorruptionExceptionTest {
                 new ChannelBuilder("dummy",null)
                     .withMode(Mode.BINARY)
                     .withBaseLoader(getClass().getClassLoader())
-                    .negotiate(new ByteArrayInputStream(payload), NullOutputStream.INSTANCE);
+                    .negotiate(new ByteArrayInputStream(payload), OutputStream.nullOutputStream());
 
         verify(ct);
     }
@@ -63,7 +63,7 @@ public class DiagnosedStreamCorruptionExceptionTest {
                     new ChannelBuilder("dummy",null)
                         .withMode(Mode.BINARY)
                         .withBaseLoader(getClass().getClassLoader())
-                        .negotiate(in, NullOutputStream.INSTANCE);
+                        .negotiate(in, OutputStream.nullOutputStream());
 
             verify(ct);
         }

--- a/src/test/java/hudson/remoting/PipeTest.java
+++ b/src/test/java/hudson/remoting/PipeTest.java
@@ -39,7 +39,6 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.output.NullOutputStream;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -319,7 +318,7 @@ public class PipeTest implements Serializable {
     private static class DevNullSink extends CallableBase<OutputStream, IOException> {
         @Override
         public OutputStream call() {
-            return new RemoteOutputStream(NullOutputStream.INSTANCE);
+            return new RemoteOutputStream(OutputStream.nullOutputStream());
         }
         private static final long serialVersionUID = 1L;
     }

--- a/src/test/java/hudson/remoting/throughput/DumbReceiver.java
+++ b/src/test/java/hudson/remoting/throughput/DumbReceiver.java
@@ -1,8 +1,8 @@
 package hudson.remoting.throughput;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.output.NullOutputStream;
 
+import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 
@@ -16,7 +16,7 @@ public class DumbReceiver {
             System.out.println("Ready");
             try (Socket s = ss.accept()) {
                 System.out.println("Accepted");
-                IOUtils.copy(s.getInputStream(), NullOutputStream.INSTANCE);
+                IOUtils.copy(s.getInputStream(), OutputStream.nullOutputStream());
             }
         }
     }

--- a/src/test/java/hudson/remoting/throughput/Sender.java
+++ b/src/test/java/hudson/remoting/throughput/Sender.java
@@ -7,13 +7,13 @@ import hudson.remoting.Future;
 import hudson.remoting.Pipe;
 import hudson.remoting.SocketChannelStream;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.output.NullOutputStream;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.Socket;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
@@ -59,7 +59,7 @@ public class Sender {
     }
 
     private static byte[] digest(InputStream in) throws NoSuchAlgorithmException, IOException {
-        DigestOutputStream dos = new DigestOutputStream(NullOutputStream.INSTANCE, MessageDigest.getInstance("MD5"));
+        DigestOutputStream dos = new DigestOutputStream(OutputStream.nullOutputStream(), MessageDigest.getInstance("MD5"));
         IOUtils.copy(in, dos);
         return dos.getMessageDigest().digest();
     }

--- a/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/WorkDirManagerTest.java
@@ -27,14 +27,12 @@
 package org.jenkinsci.remoting.engine;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -44,7 +42,6 @@ import java.nio.file.Path;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.io.IOUtils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -73,20 +70,20 @@ public class WorkDirManagerTest {
         final File dir = tmpDir.newFolder("foo");
 
         // Probe files to confirm the directory does not get wiped
-        final File probeFileInWorkDir = new File(dir, "probe.txt");
-        FileUtils.write(probeFileInWorkDir, "Hello!", StandardCharsets.UTF_8);
-        final File remotingDir = new File(dir, DirType.INTERNAL_DIR.getDefaultLocation());
-        Files.createDirectory(remotingDir.toPath());
-        final File probeFileInInternalDir = new File(remotingDir, "/probe.txt");
-        FileUtils.write(probeFileInInternalDir, "Hello!", StandardCharsets.UTF_8);
+        final Path probeFileInWorkDir = dir.toPath().resolve("probe.txt");
+        Files.writeString(probeFileInWorkDir, "Hello!", StandardCharsets.UTF_8);
+        final Path remotingDir = dir.toPath().resolve(DirType.INTERNAL_DIR.getDefaultLocation());
+        Files.createDirectory(remotingDir);
+        final Path probeFileInInternalDir = remotingDir.resolve("probe.txt");
+        Files.writeString(probeFileInInternalDir, "Hello!", StandardCharsets.UTF_8);
 
         // Initialize and check the results
         final Path createdDir = WorkDirManager.getInstance().initializeWorkDir(dir, DirType.INTERNAL_DIR.getDefaultLocation(), false);
-        assertThat("The initialized " + DirType.INTERNAL_DIR + " differs from the expected one", createdDir.toFile(), equalTo(remotingDir));
+        assertThat("The initialized " + DirType.INTERNAL_DIR + " differs from the expected one", createdDir, equalTo(remotingDir));
 
         // Ensure that the files have not been wiped
-        Assert.assertTrue("Probe file in the " + DirType.WORK_DIR + " has been wiped", probeFileInWorkDir.exists());
-        Assert.assertTrue("Probe file in the " + DirType.INTERNAL_DIR + " has been wiped", probeFileInInternalDir.exists());
+        Assert.assertTrue("Probe file in the " + DirType.WORK_DIR + " has been wiped", Files.exists(probeFileInWorkDir));
+        Assert.assertTrue("Probe file in the " + DirType.INTERNAL_DIR + " has been wiped", Files.exists(probeFileInInternalDir));
 
         // Ensure that sub directories are in place
         assertExists(DirType.JAR_CACHE_DIR);
@@ -230,11 +227,9 @@ public class WorkDirManagerTest {
         assertFileLogsExist(logsDir, "remoting.log", 0);
 
         // Ensure the entry has been written
-        File log0 = new File(logsDir, "remoting.log.0");
-        try (FileInputStream istr = new FileInputStream(log0)) {
-            String contents = IOUtils.toString(istr, StandardCharsets.UTF_8);
-            assertThat("Log file " + log0 + " should contain the probe message", contents, containsString(message));
-        }
+        Path log0 = logsDir.toPath().resolve("remoting.log.0");
+        String contents = Files.readString(log0, StandardCharsets.UTF_8);
+        assertThat("Log file " + log0 + " should contain the probe message", contents, containsString(message));
     }
 
     @Test
@@ -290,11 +285,9 @@ public class WorkDirManagerTest {
 
         // Assert that logs have been written to the specified custom destination
         assertFileLogsExist(customLogDir, "mylog.log", 1);
-        File log0 = new File(customLogDir, "mylog.log.0");
-        try (FileInputStream istr = new FileInputStream(log0)) {
-            String contents = IOUtils.toString(istr, StandardCharsets.UTF_8);
-            assertThat("Log file " + log0 + " should contain the probe message", contents, containsString(message));
-        }
+        Path log0 = customLogDir.toPath().resolve("mylog.log.0");
+        String contents = Files.readString(log0, StandardCharsets.UTF_8);
+        assertThat("Log file " + log0 + " should contain the probe message", contents, containsString(message));
     }
 
     private void assertFileLogsExist(File logsDir, String prefix, int logFilesNumber) {


### PR DESCRIPTION
While reading this code recently, I found a few dozen lines of code that could be deleted by using Java 9+ functionality instead. This PR only touches tests with the exception of the change to `Checksum.java` which can be trivially verified.