### PR TITLE
Upgrade Remoting test client from 1.0 to 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,14 +306,14 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci</groupId>
                   <artifactId>remoting-test-client</artifactId>
-                  <version>1.0</version>
+                  <version>1.3</version>
                   <outputDirectory>target/test-classes</outputDirectory>
                   <destFileName>remoting-test-client.jar</destFileName>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.jenkins-ci</groupId>
                   <artifactId>remoting-test-client</artifactId>
-                  <version>1.0</version>
+                  <version>1.3</version>
                   <classifier>tests</classifier>
                   <outputDirectory>target/test-classes</outputDirectory>
                   <destFileName>remoting-test-client-tests.jar</destFileName>

--- a/src/test/java/hudson/remoting/PrefetchingTest.java
+++ b/src/test/java/hudson/remoting/PrefetchingTest.java
@@ -1,8 +1,5 @@
 package hudson.remoting;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -13,6 +10,8 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -239,7 +238,7 @@ public class PrefetchingTest implements Serializable {
             e.value = cl.loadClass("test.Foo").getDeclaredConstructor().newInstance();
             Object r = channel.call(e);
 
-            ((Predicate<Void>) r).apply(null); // this verifies that the object is still in a good state
+            ((Predicate<Void>) r).test(null); // this verifies that the object is still in a good state
         });
     }
 


### PR DESCRIPTION
Component now lives at https://github.com/jenkinsci/remoting-test-client.

### Testing done

`mvn clean verify`