### PR TITLE
introduce memory limits (in tests)

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Xmx256m -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@ THE SOFTWARE.
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <bc-version>1.78.1</bc-version>
+    <argLine>-Xms256M -Xmx256M -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
   </properties>
 
   <dependencies>

--- a/src/test/java/hudson/remoting/ForkRunner.java
+++ b/src/test/java/hudson/remoting/ForkRunner.java
@@ -22,6 +22,7 @@ public class ForkRunner implements ChannelRunner {
         String cp = getClasspath();
 
         List<String> r = new ArrayList<>();
+        r.add("-Xmx128M");
         r.add("-cp");
         r.add(cp);
         r.add(Launcher.class.getName());


### PR DESCRIPTION
whilst running tests I experienced some random memory issues.

As there was no attempt at running maven / surefire or even the JVM spawned inside a test with amy memory limits I added some.

The memory chosen may or may not be optimal, no attempt has been made to optimize the values.  they have mostly be taken from other places that are known to be reasonable.

<!-- Please describe your pull request here. -->

### Testing done

`mvn deploy`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
