### PR TITLE
Downgrade to Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@ THE SOFTWARE.
     <spotbugs.threshold>Low</spotbugs.threshold>
     <bc-version>1.78.1</bc-version>
     <argLine>-Xms256M -Xmx256M -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
+    <!-- TODO until we are ready to drop support for Java 11 agents -->
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Amends #748. I think it is still a little too early to start requiring Java 17 here, as Remoting is still used on agents that might be connecting to a Java 11 LTS release. In the absence of a pressing need to use Java 17, seems simpler to wait until at least the end of October to do this.

### Testing done

`mvn clean verify`