### PR TITLE
Test with guava 33.3.1-jre, same as Jenkins core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.0.1-jre</version>
+      <version>33.3.1-jre</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Test with guava 33.3.1-jre, same as Jenkins core

Guava versions prior to 32.0.0 have two issues reported:

* [Guava vulnerable to insecure use of temporary directory](https://github.com/jenkinsci/remoting/security/dependabot/4)
* [Information Disclosure in Guava](https://github.com/jenkinsci/remoting/security/dependabot/3)

Neither of those issues is any risk to production because this is a test dependency.  However, since Jenkins core is using Guava 33.3.1-jre, let's upgrade this test dependency to use the same Guava version and resolve the dependabot alerts at the same time.

### Testing done

Confirmed that `mvn clean verify` passes with Java 11 and Java 21 on my Linux computer.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
