### PR TITLE
Log the fact that a jar is being sent over channel

### DIFF
--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -46,6 +46,7 @@ class JarLoaderImpl implements JarLoader, SerializableOnlyOverRemoting {
         if (channel != null) {
             if (url.getProtocol().equals("file")) {
                 try {
+                    LOGGER.log(Level.FINE, () -> "sending " + url + " to " + channel.getName());
                     channel.notifyJar(new File(url.toURI()));
                 } catch (URISyntaxException | IllegalArgumentException x) {
                     LOGGER.log(Level.WARNING, x, () -> "cannot properly report " + url);


### PR DESCRIPTION
This is already logged through `org.jenkinsci.remoting.util.LoggingChannelListener#onJar`, however since this logger also logs all packets being read or written, this produces too much noise.

With this change, setting a logger on `hudson.remoting.JarLoaderImpl` with level `FINE` will allow to capture all jars being sent over a channel.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
