### PR TITLE
Tolerate IPv6 scoped IPs from `JnlpAgentEndpointResolver.getResolvedHttpProxyAddress`

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -44,6 +44,7 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketTimeoutException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
@@ -486,8 +487,14 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
     @CheckForNull
     static InetSocketAddress getResolvedHttpProxyAddress(@NonNull String host, int port) throws IOException {
         InetSocketAddress targetAddress = null;
+        URI uri;
+        try {
+            uri = new URI("http", null, host, port, null, null, null);
+        } catch (URISyntaxException x) {
+            throw new IOException(x);
+        }
         Iterator<Proxy> proxies = ProxySelector.getDefault()
-                .select(URI.create(String.format("http://%s:%d", host, port)))
+                .select(uri)
                 .iterator();
         while (targetAddress == null && proxies.hasNext()) {
             Proxy proxy = proxies.next();

--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -493,9 +493,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
         } catch (URISyntaxException x) {
             throw new IOException(x);
         }
-        Iterator<Proxy> proxies = ProxySelector.getDefault()
-                .select(uri)
-                .iterator();
+        Iterator<Proxy> proxies = ProxySelector.getDefault().select(uri).iterator();
         while (targetAddress == null && proxies.hasNext()) {
             Proxy proxy = proxies.next();
             if (proxy.type() == Proxy.Type.DIRECT) {

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolverTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolverTest.java
@@ -37,5 +37,4 @@ public final class JnlpAgentEndpointResolverTest {
         // Ignore return value, just assert that it does not throw an exception:
         JnlpAgentEndpointResolver.getResolvedHttpProxyAddress("0:0:0:0:0:0:0:1%lo", 12345);
     }
-
 }

--- a/src/test/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolverTest.java
+++ b/src/test/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolverTest.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.remoting.engine;
+
+import java.net.Inet6Address;
+import org.junit.Test;
+
+public final class JnlpAgentEndpointResolverTest {
+
+    /** @see Inet6Address */
+    @Test
+    public void getResolvedHttpProxyAddressIPv6() throws Exception {
+        JnlpAgentEndpointResolver.getResolvedHttpProxyAddress("localhost", 12345);
+        JnlpAgentEndpointResolver.getResolvedHttpProxyAddress("127.0.0.1", 12345);
+        // Ignore return value, just assert that it does not throw an exception:
+        JnlpAgentEndpointResolver.getResolvedHttpProxyAddress("0:0:0:0:0:0:0:1%lo", 12345);
+    }
+
+}


### PR DESCRIPTION
I noticed some CloudBees CI tests failing in an IPv6 test environment (ref: BEE-52759) where `InboundAgentRule.start` times out because of e.g. `java.lang.IllegalArgumentException: Malformed escape pair at index 22: http://0:0:0:0:0:0:0:1%lo:43723` launching the agent. I think this is because the agent is being asked to connect to a local (loopback) IP address and its proxy detection code is not written to handle general IPv6 `host`s. ~Not tested in context.~ Fixes the test, it seems.