### PR TITLE
Reduce default size of diagnostic buffer for `FlightRecorderInputStream` from 1MiB to 1KiB

### DIFF
--- a/src/main/java/hudson/remoting/FlightRecorderInputStream.java
+++ b/src/main/java/hudson/remoting/FlightRecorderInputStream.java
@@ -22,8 +22,8 @@ class FlightRecorderInputStream extends InputStream {
      * Size (in bytes) of the flight recorder ring buffer used for debugging remoting issues.
      * @since 2.41
      */
-    static final int BUFFER_SIZE =
-            Integer.getInteger("hudson.remoting.FlightRecorderInputStream.BUFFER_SIZE", 1024 * 1024);
+    static int BUFFER_SIZE =
+            Integer.getInteger("hudson.remoting.FlightRecorderInputStream.BUFFER_SIZE", 1024);
 
     private final InputStream source;
     private ByteArrayRingBuffer recorder = new ByteArrayRingBuffer(BUFFER_SIZE);


### PR DESCRIPTION
One of the main side effects of the bug fixed by https://github.com/jenkinsci/google-compute-engine-plugin/pull/478 was that each failed connection caused a 1MiB buffer to be retained by a `FlightRecorderInputStream`, leading to high memory usage. This buffer is only used to print a hex dump of the stream contents in case of a stream corruption error, and so having it be a full 1MiB by default seems unnecessary, and if there is something interesting in the dump, it is probably right at the end.

I considered disabling the buffer completely by making the default value 0, but that requires a few changes to avoid `ArrayIndexOutOfBoundsException` and improve the error messages, so it seemed more expedient to just reduce the default buffer size.

In the real-world case we observed, there were around 600 instances of this class in memory, so this patch would have cut ~600MB of memory used by these buffers down to around ~600KB.

I'll file a matching core PR in a few minutes.

### Testing done

Only tested using the existing automated tests in `FlightRecorderInputStreamTest` and `DiagnosedStreamCorruptionExceptionTest`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
