### PR TITLE
Fix websocket connection retries logic

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -904,7 +904,7 @@ public class Engine extends Thread {
                 return null;
             } else {
                 events.status("Waiting " + DurationFormatter.format(next.delay) + " before retry");
-                TimeUnit.SECONDS.sleep(next.delay.toSeconds());
+                Thread.sleep(next.delay.toMillis());
             }
             return next;
         }

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -821,11 +821,11 @@ public class Engine extends Thread {
      * @return true if the condition succeeded, false if the condition failed and the timeout was reached
      * @throws InterruptedException if the thread was interrupted while waiting.
      */
-    private boolean succeedsWithRetries(SupplierThrowingException<Boolean> condition) throws InterruptedException {
+    private boolean succeedsWithRetries(java.util.concurrent.Callable<Boolean> condition) throws InterruptedException {
         var exponentialRetry = new ExponentialRetry(noReconnectAfter);
         while (exponentialRetry != null) {
             try {
-                if (condition.get()) {
+                if (condition.call()) {
                     return true;
                 }
             } catch (Exception x) {
@@ -909,11 +909,6 @@ public class Engine extends Thread {
             }
             return next;
         }
-    }
-
-    @FunctionalInterface
-    private interface SupplierThrowingException<T> {
-        T get() throws Exception;
     }
 
     private void reconnect() {

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -903,9 +903,8 @@ public class Engine extends Thread {
                 events.status("Bailing out after " + DurationFormatter.format(next.timeout));
                 return null;
             } else {
-                var delaySeconds = next.delay.toSeconds();
-                events.status("Waiting " + delaySeconds + " seconds before retry");
-                TimeUnit.SECONDS.sleep(delaySeconds);
+                events.status("Waiting " + DurationFormatter.format(next.delay) + " before retry");
+                TimeUnit.SECONDS.sleep(next.delay.toSeconds());
             }
             return next;
         }


### PR DESCRIPTION
We have observed cases where the websocket connection would fail temporarily with a handshake error that was not retried and causing the agent to fail.

Also, in CloudBees CI HA, there are some cases when an agent is disconnected on purpose and we expect a reconnect attempt as soon as possible. The default 10 seconds delay appeared too long in that case.

To reconcile this use case with the typical failure scenario, I have implemented exponential backoff for retries (immediate, 1 sec, 3 seconds, 7 seconds, 10 seconds).

<!-- Please describe your pull request here. -->

### Testing done
* WS: Initial connection
* WS: Applying a rolling restart to the controller. The previous fatal handshake error is now retriable and prints a single log line

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
