### PR TITLE
Remove HTTPS restriction on using a proxy

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/JnlpAgentEndpointResolver.java
@@ -602,7 +602,7 @@ public class JnlpAgentEndpointResolver extends JnlpEndpointResolver {
             httpProxy = System.getenv("http_proxy");
         }
         URLConnection con;
-        if (httpProxy != null && "http".equals(url.getProtocol()) && NoProxyEvaluator.shouldProxy(url.getHost())) {
+        if (httpProxy != null && NoProxyEvaluator.shouldProxy(url.getHost())) {
             try {
                 URL proxyUrl = new URL(httpProxy);
                 SocketAddress addr = new InetSocketAddress(proxyUrl.getHost(), proxyUrl.getPort());


### PR DESCRIPTION
Currently using a proxy is restricted to Jenkins' instances hosted on HTTP sites. Sites that are hosted using SSL / HTTPS are conditionally filtered out even if the proxy params are provided.

This change removes the `"http".equals(url.getProtocol())` requirement from `JnlpAgentEndpointResolver.openURLConnection(...)#605`  to allow HTTPS hosted sites to use proxies.

### Testing done
When trying to connect via the standard `agent.jar` file using the following command:
`java -jar agent.jar -url https://<host> -secret <secret> -name "<name>" -workDir "<workdir>" -tunnel <host>:<port>`

You are presented with the following log:
```
INFO: Locating server among [https://<host>]
... after 30 second timeout ...
INFO: Could not locate server among [https://<host>]; waiting 10 seconds before retry
java.io.IOException: Failed to connect to https://<host>/tcpSlaveAgentListener/: Connect timed out
	at org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.resolve(JnlpAgentEndpointResolver.java:217)
	at hudson.remoting.Engine.innerRun(Engine.java:809)
	at hudson.remoting.Engine.run(Engine.java:563)
Caused by: java.net.SocketTimeoutException: Connect timed out
	at java.base/sun.nio.ch.NioSocketImpl.timedFinishConnect(NioSocketImpl.java:546)
	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:592)
	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
	at java.base/java.net.Socket.connect(Socket.java:751)
	at java.base/sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:304)
	at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:178)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:531)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:636)
	at java.base/sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:264)
	at java.base/sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:377)
	at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:193)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1252)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1138)
	at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:179)
	at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.connect(HttpsURLConnectionImpl.java:141)
	at org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.resolve(JnlpAgentEndpointResolver.java:214)
	... 2 more
```

After removing the HTTP requirement recompiling and re-running the same command, you are presented with a successful connection
```
INFO: Locating server among [https://<host>/]
INFO: Remoting server accepts the following protocols: [JNLP4-connect, Ping]
INFO: Remoting TCP connection tunneling is enabled. Skipping the TCP Agent Listener Port availability check
INFO: Agent discovery successful
  Agent address: <host>
  Agent port:    <port>
  Identity:      <ident>
INFO: Handshaking
INFO: Connecting to <host>:<port>
INFO: Server reports protocol JNLP4-connect-proxy not supported, skipping
INFO: Trying protocol: JNLP4-connect
INFO: Waiting for ProtocolStack to start.
INFO: Remote identity confirmed: <ident>
INFO: Connected
```

This change may not be possible to write a test for as it requires an active proxy on your network.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
