### PR TITLE
Increase ci.jenkins.io timeout from 15 to 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
  * easy Linux/Windows testing and produces incrementals. The only feature that relates to plugins is
  * allowing one to test against multiple Jenkins versions.
  */
-buildPlugin(timeout: 15, useContainerAgent: true, configurations: [
+buildPlugin(timeout: 25, useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 21],
   [platform: 'windows', jdk: 17],
 ])


### PR DESCRIPTION
## Increase ci.jenkins.io timeout from 15 to 25

The Windows build time has increased from 7 minutes to 17 minutes.  While we're working to reduce the Windows build time, let's unblock this build by allowing it to run longer.

The Jenkins infra help desk that records the issue with ci.jenkins.io Windows build performance.

* https://github.com/jenkins-infra/helpdesk/issues/4557 

### Testing done

Confirmed that jobs passed in 20 minutes or less, but more than 15 minutes: 

* https://ci.jenkins.io/job/Core/job/remoting/job/master/796/
* https://ci.jenkins.io/job/Core/job/remoting/view/change-requests/job/PR-781/
* https://ci.jenkins.io/job/Core/job/remoting/view/change-requests/job/PR-782/

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
