### PR TITLE
[DEBUG] TLS Certificate passing debug

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -783,9 +783,9 @@ public class Engine extends Thread {
                         client.getProperties().put(ClientProperties.SSL_ENGINE_CONFIGURATOR, sslEngineConfigurator);
                     }
                 }
-                if (!succeedsWithRetries(this::pingSuccessful)) {
-                    return;
-                }
+//                if (!succeedsWithRetries(this::pingSuccessful)) {
+//                    return;
+//                }
                 if (!succeedsWithRetries(() -> {
                     container.connectToServer(
                             new AgentEndpoint(),
@@ -1270,6 +1270,7 @@ public class Engine extends Thread {
             SSLContext ctx = SSLContext.getInstance("TLS");
             // now we have our custom socket factory
             ctx.init(null, trustManagerFactory.getTrustManagers(), null);
+            sslContext = ctx;
         }
         return sslContext;
     }


### PR DESCRIPTION
**This PR is just for demonstration purposes only**

Self signed TLS certificate passing was not working with WebSocket agents.
* either passing the `-cert` (also affected TCP agent)
  passing the `-cert` is actually a bit tricky need to pass as,
  ```
   # this will put the multi-line root-ca.pem into a single line text into CA_ROOT
   CA_ROOT="$(cat /path/to/root-ca.pem)"
   
   # need ensure double quote enclosing, otherwise parsing fails
   java -jar agent.jar -cert "$CA_ROOT" ...
  ```
* or `-noCertificateCheck` (this worked in TCP agent)

Only passing the trustStore with the locally created CA was working `-Djavax.net.ssl.trustStore=mytruststore.jks`.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
