### PR TITLE
Require Java 17 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,6 @@ THE SOFTWARE.
     <spotless.check.skip>false</spotless.check.skip>
     <bc-version>1.80</bc-version>
     <argLine>-Xms256M -Xmx256M -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
-    <!-- TODO until we are ready to drop support for Java 11 agents -->
-    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
It's been several LTS releases since controllers required Java 17 or newer, so begin shipping Remoting with Java 17 bytecode.

### Testing done

CI build