### PR TITLE
Remove unnecessary SpotBugs suppressions

### DIFF
--- a/src/main/java/hudson/remoting/ClassFilter.java
+++ b/src/main/java/hudson/remoting/ClassFilter.java
@@ -128,6 +128,7 @@ public abstract class ClassFilter {
         }
     };
 
+    @SuppressFBWarnings(value = "NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", justification = "TODO needs triage")
     private static @NonNull ClassFilter CURRENT_DEFAULT;
 
     /**

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -236,6 +236,7 @@ public class Engine extends Thread {
      * @since 3.8
      */
     @CheckForNull
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public Path workDir = null;
 
     /**
@@ -246,6 +247,7 @@ public class Engine extends Thread {
      * @since 3.8
      */
     @NonNull
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public String internalDir = WorkDirManager.DirType.INTERNAL_DIR.getDefaultLocation();
 
     /**
@@ -254,6 +256,7 @@ public class Engine extends Thread {
      * (e.g. if a filesystem mount gets disconnected).
      * @since 3.8
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public boolean failIfWorkDirIsMissing = WorkDirManager.DEFAULT_FAIL_IF_WORKDIR_IS_MISSING;
 
     private final DelegatingX509ExtendedTrustManager agentTrustManager =

--- a/src/main/java/hudson/remoting/GCCommand.java
+++ b/src/main/java/hudson/remoting/GCCommand.java
@@ -23,6 +23,8 @@
  */
 package hudson.remoting;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Performs GC.
  *
@@ -30,6 +32,7 @@ package hudson.remoting;
  */
 class GCCommand extends Command {
     @Override
+    @SuppressFBWarnings(value = "DM_GC", justification = "TODO needs triage")
     protected void execute(Channel channel) {
         System.gc();
     }

--- a/src/main/java/hudson/remoting/JarLoaderImpl.java
+++ b/src/main/java/hudson/remoting/JarLoaderImpl.java
@@ -25,10 +25,15 @@ class JarLoaderImpl implements JarLoader, SerializableOnlyOverRemoting {
 
     private static final Logger LOGGER = Logger.getLogger(JarLoaderImpl.class.getName());
 
+    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "TODO needs triage")
     private final ConcurrentMap<Checksum, URL> knownJars = new ConcurrentHashMap<>();
 
+    @SuppressFBWarnings(
+            value = {"DMI_COLLECTION_OF_URLS", "SE_BAD_FIELD"},
+            justification = "TODO needs triage")
     private final ConcurrentMap<URL, Checksum> checksums = new ConcurrentHashMap<>();
 
+    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "TODO needs triage")
     private final Set<Checksum> presentOnRemote = Collections.synchronizedSet(new HashSet<>());
 
     @Override

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -100,12 +100,14 @@ import org.xml.sax.SAXException;
         value = "DM_EXIT",
         justification = "This class is runnable. It is eligible to exit in the case of wrong params")
 public class Launcher {
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public Channel.Mode mode = Channel.Mode.BINARY;
 
     /**
      * @deprecated removed without replacement
      */
     @Deprecated
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public boolean ping = true;
 
     /**
@@ -149,6 +151,7 @@ public class Launcher {
                     + "Connection parameters are obtained by parsing the JNLP file.",
             forbids = {"-direct", "-name", "-tunnel", "-url", "-webSocket"})
     @Deprecated
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public URL agentJnlpURL = null;
 
     @Option(
@@ -159,9 +162,11 @@ public class Launcher {
     public String agentJnlpCredentials = null;
 
     @Option(name = "-secret", metaVar = "HEX_SECRET", usage = "Agent connection secret.")
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public String secret;
 
     @Option(name = "-name", usage = "Name of the agent.")
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public String name;
 
     @Option(
@@ -174,6 +179,7 @@ public class Launcher {
      * @deprecated removed without replacement
      */
     @Deprecated
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public File tcpPortFile = null;
 
     /**
@@ -195,6 +201,7 @@ public class Launcher {
      * @deprecated use {@link #agentJnlpCredentials} or {@link #proxyCredentials}
      */
     @Deprecated
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public String auth = null;
 
     /**
@@ -255,6 +262,7 @@ public class Launcher {
      * @deprecated removed without replacement
      */
     @Deprecated
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public InetSocketAddress connectionTarget = null;
 
     /**
@@ -305,6 +313,7 @@ public class Launcher {
             name = "-workDir",
             usage = "Declares the working directory of the remoting instance (stores cache and logs by default)")
     @CheckForNull
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public File workDir = null;
 
     /**
@@ -319,6 +328,7 @@ public class Launcher {
             usage = "Specifies a name of the internal files within a working directory ('remoting' by default)",
             depends = "-workDir")
     @NonNull
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public String internalDir = WorkDirManager.DirType.INTERNAL_DIR.getDefaultLocation();
 
     /**
@@ -331,6 +341,7 @@ public class Launcher {
             name = "-failIfWorkDirIsMissing",
             usage = "Fails the initialization if the requested workDir or internalDir are missing ('false' by default)",
             depends = "-workDir")
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public boolean failIfWorkDirIsMissing = WorkDirManager.DEFAULT_FAIL_IF_WORKDIR_IS_MISSING;
 
     @Option(
@@ -339,12 +350,14 @@ public class Launcher {
             usage = "Connect to the specified host and port, instead of connecting directly to Jenkins. "
                     + "Useful when connection to Jenkins needs to be tunneled. Can be also HOST: or :PORT, "
                     + "in which case the missing portion will be auto-configured like the default behavior.")
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public String tunnel;
 
     /**
      * @deprecated removed without replacement
      */
     @Deprecated
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public boolean headlessMode;
 
     /**
@@ -366,6 +379,7 @@ public class Launcher {
             usage = "Make a WebSocket connection to Jenkins rather than using the TCP port.",
             depends = "-url",
             forbids = {"-direct", "-tunnel", "-credentials", "-noKeepAlive"})
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO needs triage")
     public boolean webSocket;
 
     @Option(

--- a/src/main/java/org/jenkinsci/remoting/protocol/ProtocolStack.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/ProtocolStack.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.OverrideMustInvoke;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.remoting.Future;
 import java.io.Closeable;
 import java.io.IOException;
@@ -144,6 +145,7 @@ public class ProtocolStack<T> implements Closeable, ByteBufferPool {
     @GuardedBy("stackLock")
     private final List<Listener> listeners = new ArrayList<>();
 
+    @SuppressFBWarnings(value = "SS_SHOULD_BE_STATIC", justification = "TODO needs triage")
     private final long handshakingTimeout = 10L;
 
     private final TimeUnit handshakingUnits = TimeUnit.SECONDS;

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,111 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
   <!--
-    Exclusions in this section have been triaged and determined to be false positives.
+    Suppress low-priority non-serialization violations below to avoid cluttering the codebase with annotations for
+    low-priority warnings. High-priority warnings, medium-priority warnings, and low-priority serialization warnings
+    should be fixed or suppressed with annotations instead.
   -->
-  <Match>
-    <Or>
-      <!-- We don't care about this behavior -->
-      <Bug pattern="CRLF_INJECTION_LOGS"/>
-      <!-- Pending https://github.com/spotbugs/spotbugs/issues/1515 -->
-      <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
-      <Bug pattern="DP_DO_INSIDE_DO_PRIVILEGED"/>
-    </Or>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_MUTABLE_OBJECT_ATTRIBUTE"/>
-    <Class name="hudson.remoting.Channel"/>
-    <Or>
-      <Field name="classLoadingCount"/>
-      <Field name="classLoadingPrefetchCacheCount"/>
-      <Field name="classLoadingTime"/>
-      <Field name="resourceLoadingCount"/>
-      <Field name="resourceLoadingTime"/>
-    </Or>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.remoting.Engine"/>
-    <Or>
-      <Field name="failIfWorkDirIsMissing"/>
-      <Field name="internalDir"/>
-      <Field name="workDir"/>
-    </Or>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_MUTABLE_OBJECT_ATTRIBUTE"/>
-    <Class name="hudson.remoting.Launcher"/>
-    <Or>
-      <Field name="args"/>
-      <Field name="urls"/>
-    </Or>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.remoting.Launcher"/>
-    <Or>
-      <Field name="agentJnlpURL"/>
-      <Field name="auth"/>
-      <Field name="connectionTarget"/>
-      <Field name="failIfWorkDirIsMissing"/>
-      <Field name="headlessMode"/>
-      <Field name="internalDir"/>
-      <Field name="mode"/>
-      <Field name="name"/>
-      <Field name="ping"/>
-      <Field name="secret"/>
-      <Field name="tcpPortFile"/>
-      <Field name="tunnel"/>
-      <Field name="webSocket"/>
-      <Field name="workDir"/>
-    </Or>
-  </Match>
-  <!--
-    Here lies technical debt. Exclusions in this section have not yet been triaged. When working on
-    on this section, pick an exclusion to triage, then:
-    - If it is a false positive, add a @SuppressFBWarnings(value = "[…]", justification = "[…]")
-      annotation indicating the reason why it is a false positive, then remove the exclusion from
-      this section.
-    - If it is not a false positive, fix the bug, then remove the exclusion from this section.
-   -->
-  <Match>
-    <Confidence value="1"/>
-    <Or>
-      <And>
-        <Bug pattern="DM_GC"/>
-        <Class name="hudson.remoting.GCCommand"/>
-      </And>
-      <And>
-        <Bug pattern="DMI_COLLECTION_OF_URLS"/>
-        <Class name="hudson.remoting.JarLoaderImpl"/>
-      </And>
-    </Or>
-  </Match>
-  <Match>
-    <Confidence value="2"/>
-    <Or>
-      <And>
-        <Bug pattern="NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
-        <Class name="hudson.remoting.ClassFilter"/>
-      </And>
-      <And>
-        <Bug pattern="SE_BAD_FIELD"/>
-        <Class name="hudson.remoting.JarLoaderImpl"/>
-      </And>
-    </Or>
-  </Match>
   <Match>
     <Confidence value="3"/>
     <Or>
+      <And>
+        <Bug pattern="AA_ASSERTION_OF_ARGUMENTS"/>
+        <Or>
+          <And>
+            <Class name="org.jenkinsci.remoting.nio.NioChannelHub"/>
+            <Method name="setFrameSize"/>
+          </And>
+          <And>
+            <Class name="org.jenkinsci.remoting.protocol.ProtocolStack"/>
+            <Method name="toString"/>
+          </And>
+        </Or>
+      </And>
+      <Bug pattern="CRLF_INJECTION_LOGS"/>
       <And>
         <Bug pattern="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR"/>
         <Or>
           <Class name="hudson.remoting.Channel"/>
           <Class name="hudson.remoting.Engine"/>
-          <Class name="hudson.remoting.forward.PortForwarder"/>
-          <Class name="hudson.remoting.forward.PortForwarder$1"/>
-          <Class name="hudson.remoting.RemoteInputStream$1"/>
           <Class name="org.jenkinsci.remoting.protocol.impl.NIONetworkLayer"/>
+        </Or>
+      </And>
+      <And>
+        <Bug pattern="PA_PUBLIC_MUTABLE_OBJECT_ATTRIBUTE"/>
+        <Or>
+          <And>
+            <Class name="hudson.remoting.Channel"/>
+            <Or>
+              <Field name="classLoadingCount"/>
+              <Field name="classLoadingPrefetchCacheCount"/>
+              <Field name="classLoadingTime"/>
+              <Field name="resourceLoadingCount"/>
+              <Field name="resourceLoadingTime"/>
+            </Or>
+          </And>
+          <And>
+            <Class name="hudson.remoting.Launcher"/>
+            <Or>
+              <Field name="args"/>
+              <Field name="urls"/>
+            </Or>
+          </And>
         </Or>
       </And>
       <And>
@@ -122,38 +66,23 @@
           <Class name="hudson.remoting.RemoteInputStream"/>
         </Or>
       </And>
+      <And>
+        <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
+        <Class name="hudson.remoting.Launcher"/>
+        <Or>
+          <Field name="auth"/>
+          <Field name="headlessMode"/>
+        </Or>
+      </And>
+      <And>
+        <Bug pattern="UWF_UNWRITTEN_FIELD"/>
+        <Class name="hudson.remoting.RemoteClassLoader"/>
+        <Or>
+          <Field name="TESTING_CLASS_LOAD"/>
+          <Field name="TESTING_CLASS_REFERENCE_LOAD"/>
+          <Field name="TESTING_RESOURCE_LOAD"/>
+        </Or>
+      </And>
     </Or>
-  </Match>
-  <Match>
-    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
-    <Class name="hudson.remoting.Launcher"/>
-    <Or>
-      <Field name="auth"/>
-      <Field name="headlessMode"/>
-    </Or>
-  </Match>
-  <Match>
-    <Bug pattern="UWF_UNWRITTEN_FIELD"/>
-    <Class name="hudson.remoting.RemoteClassLoader"/>
-    <Or>
-      <Field name="TESTING_CLASS_LOAD"/>
-      <Field name="TESTING_CLASS_REFERENCE_LOAD"/>
-      <Field name="TESTING_RESOURCE_LOAD"/>
-    </Or>
-  </Match>
-  <Match>
-    <Bug pattern="AA_ASSERTION_OF_ARGUMENTS"/>
-    <Class name="org.jenkinsci.remoting.nio.NioChannelHub"/>
-    <Method name="setFrameSize"/>
-  </Match>
-  <Match>
-    <Bug pattern="AA_ASSERTION_OF_ARGUMENTS"/>
-    <Class name="org.jenkinsci.remoting.protocol.ProtocolStack"/>
-    <Method name="toString"/>
-  </Match>
-  <Match>
-    <Bug pattern="SS_SHOULD_BE_STATIC"/>
-    <Class name="org.jenkinsci.remoting.protocol.ProtocolStack"/>
-    <Field name="handshakingTimeout"/>
   </Match>
 </FindBugsFilter>


### PR DESCRIPTION
- Migrates all High and Medium SpotBugs suppressions from XML to Java annotations, where they are easier to manage
- Leaves all Low suppressions in XML
- Removes all unnecessary suppressions

The use of Low rather than Medium dates back to commit 39bc5430d7966e7ab184cb99044ed7510a2adb6b by Kohsuke:

> Couldn't figure out how to add specific checker to the default setting, so I'm activating a whole bunch by setting `threshold=low`, then excluding most of them except the serialization problem

Since these Low threshold violations are frequent and annoying, leaving their suppressions in XML so as not to litter the codebase with unnecessary annotations. Perhaps in the future some better solution can be found to Kohsuke's original problem.

### Testing done

`mvn clean verify`

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
