### PR TITLE
Reduce calls to deprecated Java Platform methods

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -46,14 +46,11 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.security.AccessController;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
@@ -1165,20 +1162,14 @@ public class Engine extends Thread {
 
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "File path is loaded from system properties.")
     static KeyStore getCacertsKeyStore()
-            throws PrivilegedActionException, KeyStoreException, NoSuchProviderException, CertificateException,
-                    NoSuchAlgorithmException, IOException {
-        Map<String, String> properties =
-                AccessController.doPrivileged((PrivilegedExceptionAction<Map<String, String>>) () -> {
-                    Map<String, String> result = new HashMap<>();
-                    result.put("trustStore", System.getProperty("javax.net.ssl.trustStore"));
-                    result.put("javaHome", System.getProperty("java.home"));
-                    result.put(
-                            "trustStoreType",
-                            System.getProperty("javax.net.ssl.trustStoreType", KeyStore.getDefaultType()));
-                    result.put("trustStoreProvider", System.getProperty("javax.net.ssl.trustStoreProvider", ""));
-                    result.put("trustStorePasswd", System.getProperty("javax.net.ssl.trustStorePassword", ""));
-                    return result;
-                });
+            throws KeyStoreException, NoSuchProviderException, CertificateException, NoSuchAlgorithmException,
+                    IOException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("trustStore", System.getProperty("javax.net.ssl.trustStore"));
+        properties.put("javaHome", System.getProperty("java.home"));
+        properties.put("trustStoreType", System.getProperty("javax.net.ssl.trustStoreType", KeyStore.getDefaultType()));
+        properties.put("trustStoreProvider", System.getProperty("javax.net.ssl.trustStoreProvider", ""));
+        properties.put("trustStorePasswd", System.getProperty("javax.net.ssl.trustStorePassword", ""));
         KeyStore keystore = null;
 
         FileInputStream trustStoreStream = null;
@@ -1243,20 +1234,18 @@ public class Engine extends Thread {
     }
 
     @CheckForNull
-    private static FileInputStream getFileInputStream(final File file) throws PrivilegedActionException {
-        return AccessController.doPrivileged((PrivilegedExceptionAction<FileInputStream>) () -> {
-            try {
-                return file.exists() ? new FileInputStream(file) : null;
-            } catch (FileNotFoundException e) {
-                return null;
-            }
-        });
+    private static FileInputStream getFileInputStream(final File file) {
+        try {
+            return file.exists() ? new FileInputStream(file) : null;
+        } catch (FileNotFoundException e) {
+            return null;
+        }
     }
 
     @CheckForNull
     private static SSLContext getSSLContext(List<X509Certificate> x509Certificates, boolean noCertificateCheck)
-            throws PrivilegedActionException, KeyStoreException, NoSuchProviderException, CertificateException,
-                    NoSuchAlgorithmException, IOException, KeyManagementException {
+            throws KeyStoreException, NoSuchProviderException, CertificateException, NoSuchAlgorithmException,
+                    IOException, KeyManagementException {
         SSLContext sslContext = null;
         if (noCertificateCheck) {
             sslContext = SSLContext.getInstance("TLS");
@@ -1285,8 +1274,8 @@ public class Engine extends Thread {
     @CheckForNull
     @Restricted(NoExternalUse.class)
     static SSLSocketFactory getSSLSocketFactory(List<X509Certificate> x509Certificates, boolean noCertificateCheck)
-            throws PrivilegedActionException, KeyStoreException, NoSuchProviderException, CertificateException,
-                    NoSuchAlgorithmException, IOException, KeyManagementException {
+            throws KeyStoreException, NoSuchProviderException, CertificateException, NoSuchAlgorithmException,
+                    IOException, KeyManagementException {
         SSLContext sslContext = getSSLContext(x509Certificates, noCertificateCheck);
         return sslContext != null ? sslContext.getSocketFactory() : null;
     }

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -46,7 +46,6 @@ import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
-import java.security.PrivilegedActionException;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -529,7 +528,7 @@ public class Launcher {
         createX509Certificates();
         try {
             sslSocketFactory = Engine.getSSLSocketFactory(x509Certificates, noCertificateCheck);
-        } catch (GeneralSecurityException | PrivilegedActionException e) {
+        } catch (GeneralSecurityException e) {
             throw new RuntimeException(e);
         }
         if (noCertificateCheck) {

--- a/src/main/java/hudson/remoting/RemoteClassLoader.java
+++ b/src/main/java/hudson/remoting/RemoteClassLoader.java
@@ -490,7 +490,7 @@ final class RemoteClassLoader extends URLClassLoader {
         }
 
         String packageName = name.substring(0, idx);
-        if (getPackage(packageName) != null) { // already defined
+        if (getDefinedPackage(packageName) != null) { // already defined
             return;
         }
 

--- a/src/main/java/org/jenkinsci/remoting/protocol/cert/PublicKeyMatchingX509ExtendedTrustManager.java
+++ b/src/main/java/org/jenkinsci/remoting/protocol/cert/PublicKeyMatchingX509ExtendedTrustManager.java
@@ -205,7 +205,7 @@ public class PublicKeyMatchingX509ExtendedTrustManager extends X509ExtendedTrust
             throw new CertificateException(String.format(
                     "Public key of the first certificate in chain (subject: '%s') "
                             + "(algorithm: '%s'; format: '%s') does not support binary encoding",
-                    chain[0].getSubjectDN(), chainKey.getAlgorithm(), chainKey.getFormat()));
+                    chain[0].getSubjectX500Principal(), chainKey.getAlgorithm(), chainKey.getFormat()));
         }
         synchronized (publicKeys) {
             if (publicKeys.isEmpty() ? (client ? !strictClient : !strictServer) : isTrusted(chainKey)) {
@@ -214,7 +214,7 @@ public class PublicKeyMatchingX509ExtendedTrustManager extends X509ExtendedTrust
         }
         throw new CertificateException(String.format(
                 "Public key of the first certificate in chain (subject: %s) " + "is not in the list of trusted keys",
-                chain[0].getSubjectDN()));
+                chain[0].getSubjectX500Principal()));
     }
 
     /**


### PR DESCRIPTION
These methods are deprecated in the Java Platform, so move to the recommended non-deprecated equivalents.

### Testing done

`mvn clean verify`