### PR TITLE
Migrate from deprecated finalization API to Java 9+ API

### DIFF
--- a/src/main/java/hudson/remoting/FastPipedInputStream.java
+++ b/src/main/java/hudson/remoting/FastPipedInputStream.java
@@ -121,7 +121,9 @@ public class FastPipedInputStream extends InputStream {
             // Release any pending writers.
             buffer.notifyAll();
         }
-        cleanable.clean();
+        if (cleanable != null) {
+            cleanable.clean();
+        }
     }
 
     /**

--- a/src/main/java/hudson/remoting/FastPipedOutputStream.java
+++ b/src/main/java/hudson/remoting/FastPipedOutputStream.java
@@ -90,7 +90,9 @@ public class FastPipedOutputStream extends OutputStream implements ErrorPropagat
     @Override
     public void close() throws IOException {
         error(null);
-        cleanable.clean();
+        if (cleanable != null) {
+            cleanable.clean();
+        }
     }
 
     @Override

--- a/src/main/java/hudson/remoting/ProxyOutputStream.java
+++ b/src/main/java/hudson/remoting/ProxyOutputStream.java
@@ -169,7 +169,9 @@ final class ProxyOutputStream extends OutputStream implements ErrorPropagatingOu
     @Override
     public synchronized void close() throws IOException {
         error(null);
-        cleanable.clean();
+        if (cleanable != null) {
+            cleanable.clean();
+        }
     }
 
     @Override

--- a/src/main/java/hudson/remoting/ProxyWriter.java
+++ b/src/main/java/hudson/remoting/ProxyWriter.java
@@ -188,7 +188,9 @@ final class ProxyWriter extends Writer {
     @Override
     public synchronized void close() throws IOException {
         error(null);
-        cleanable.clean();
+        if (cleanable != null) {
+            cleanable.clean();
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The `Object#finalize` method has been deprecated since the release of Java 9. In this PR we migrate away from the deprecated API by introducing recent `Cleaner` API.

( See : [Issue](https://issues.jenkins.io/browse/JENKINS-75443) )
### Testing done
`mvn clean verify`
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
