### PR TITLE
Avoid `System.exit` from `Launcher.run`

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1611,6 +1611,9 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
                 terminate(e);
                 return;
             }
+            if (jarCache instanceof Closeable c) {
+                c.close();
+            }
             outClosed = new IOException(
                     diagnosis); // last command sent. no further command allowed. lock guarantees that no command will
             // slip inbetween

--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -1611,9 +1611,6 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
                 terminate(e);
                 return;
             }
-            if (jarCache instanceof Closeable c) {
-                c.close();
-            }
             outClosed = new IOException(
                     diagnosis); // last command sent. no further command allowed. lock guarantees that no command will
             // slip inbetween

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -34,6 +34,7 @@ import jakarta.websocket.EndpointConfig;
 import jakarta.websocket.HandshakeResponse;
 import jakarta.websocket.Session;
 import jakarta.websocket.WebSocketContainer;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -553,6 +554,13 @@ public class Engine extends Thread {
             }
         } finally {
             executor.shutdown(); // TODO Java 21 maybe .close()
+            if (jarCache instanceof Closeable c) {
+                try {
+                    c.close();
+                } catch (IOException x) {
+                    LOGGER.log(Level.WARNING, null, x);
+                }
+            }
             events.completed();
         }
     }

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -536,12 +536,20 @@ public class Engine extends Thread {
     }
 
     @Override
-    @SuppressFBWarnings(value = "HARD_CODE_PASSWORD", justification = "Password doesn't need to be protected.")
     public void run() {
-        if (webSocket) {
-            runWebSocket();
-            return;
+        try {
+            if (webSocket) {
+                runWebSocket();
+            } else {
+                runTcp();
+            }
+        } finally {
+            events.completed();
         }
+    }
+
+    @SuppressFBWarnings(value = "HARD_CODE_PASSWORD", justification = "Password doesn't need to be protected.")
+    private void runTcp() {
         // Create the engine
         try {
             try (IOHub hub = IOHub.create(executor)) {

--- a/src/main/java/hudson/remoting/EngineListener.java
+++ b/src/main/java/hudson/remoting/EngineListener.java
@@ -64,4 +64,9 @@ public interface EngineListener {
      * @since 2.0
      */
     void onReconnect();
+
+    /**
+     * Called when {@link Engine#run} exits, whether due to {@link #error} or normally.
+     */
+    default void completed() {}
 }

--- a/src/main/java/hudson/remoting/EngineListenerSplitter.java
+++ b/src/main/java/hudson/remoting/EngineListenerSplitter.java
@@ -54,4 +54,11 @@ public class EngineListenerSplitter implements EngineListener {
             l.onReconnect();
         }
     }
+
+    @Override
+    public void completed() {
+        for (EngineListener l : listeners) {
+            l.completed();
+        }
+    }
 }

--- a/src/main/java/hudson/remoting/JarCacheSupport.java
+++ b/src/main/java/hudson/remoting/JarCacheSupport.java
@@ -2,6 +2,7 @@ package hudson.remoting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
@@ -21,7 +22,7 @@ import java.util.logging.Logger;
  * @author Kohsuke Kawaguchi
  * @since 2.24
  */
-public abstract class JarCacheSupport extends JarCache {
+public abstract class JarCacheSupport extends JarCache implements Closeable {
     /**
      * Remember in-progress jar file resolution to avoid retrieving the same jar file twice.
      */
@@ -73,6 +74,12 @@ public abstract class JarCacheSupport extends JarCache {
         final CompletableFuture<URL> promise = new CompletableFuture<>();
         downloader.submit(new DownloadRunnable(channel, sum1, sum2, key, promise));
         return promise;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // TODO Java 21 maybe just use ExecutorService.close()
+        downloader.shutdown();
     }
 
     private class DownloadRunnable implements Runnable {

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -730,8 +730,6 @@ public class Launcher {
         try {
             completion.get();
             LOGGER.fine("Engine has died");
-        } catch (InterruptedException x) {
-            throw x;
         } catch (ExecutionException x) {
             throw new IllegalStateException(x.getCause());
         } finally {

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -58,6 +58,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -77,6 +78,7 @@ import org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver;
 import org.jenkinsci.remoting.engine.WorkDirManager;
 import org.jenkinsci.remoting.util.DurationFormatter;
 import org.jenkinsci.remoting.util.PathUtils;
+import org.jenkinsci.remoting.util.SettableFuture;
 import org.jenkinsci.remoting.util.https.NoCheckHostnameVerifier;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
@@ -275,8 +277,7 @@ public class Launcher {
     public void setConnectTo(String target) {
         String[] tokens = target.split(":");
         if (tokens.length != 2) {
-            System.err.println("Illegal parameter: " + target);
-            System.exit(1);
+            throw new IllegalArgumentException(target);
         }
         connectionTarget = new InetSocketAddress(tokens[0], Integer.parseInt(tokens[1]));
         System.err.println(
@@ -723,11 +724,16 @@ public class Launcher {
 
     private void runAsInboundAgent() throws CmdLineException, IOException, InterruptedException {
         validateInboundAgentArgs(this);
-        Engine engine = createEngine();
+        SettableFuture<Void> completion = SettableFuture.create();
+        Engine engine = createEngine(completion);
         engine.startEngine();
         try {
-            engine.join();
+            completion.get();
             LOGGER.fine("Engine has died");
+        } catch (InterruptedException x) {
+            throw x;
+        } catch (ExecutionException x) {
+            throw new IllegalStateException(x.getCause());
         } finally {
             // if we are programmatically driven by other code, allow them to interrupt our blocking main thread to kill
             // the on-going connection to Jenkins
@@ -1109,10 +1115,10 @@ public class Launcher {
         }
     }
 
-    private Engine createEngine() throws IOException {
+    private Engine createEngine(SettableFuture<Void> completion) throws IOException {
         LOGGER.log(Level.INFO, "Setting up agent: {0}", name);
         Engine engine = new Engine(
-                new CuiListener(), urls, secret, name, directConnection, instanceIdentity, new HashSet<>(protocols));
+                new CuiListener(completion), urls, secret, name, directConnection, instanceIdentity, new HashSet<>(protocols));
         engine.setWebSocket(webSocket);
         if (webSocketHeaders != null) {
             engine.setWebSocketHeaders(webSocketHeaders);
@@ -1164,6 +1170,13 @@ public class Launcher {
      * {@link EngineListener} implementation that sends output to {@link Logger}.
      */
     private static final class CuiListener implements EngineListener {
+
+        private final SettableFuture<Void> completion;
+
+        CuiListener(SettableFuture<Void> completion) {
+            this.completion = completion;
+        }
+
         @Override
         public void status(String msg, Throwable t) {
             LOGGER.log(Level.INFO, msg, t);
@@ -1175,12 +1188,14 @@ public class Launcher {
         }
 
         @Override
-        @SuppressFBWarnings(
-                value = "DM_EXIT",
-                justification = "Yes, we really want to exit in the case of severe error")
         public void error(Throwable t) {
-            LOGGER.log(Level.SEVERE, t.getMessage(), t);
-            System.exit(-1);
+            LOGGER.log(Level.FINE, null, t); // thrown out of runAsInboundAgent so printed by caller
+            completion.setException(t);
+        }
+
+        @Override
+        public void completed() {
+            completion.set(null);
         }
 
         @Override

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -1118,7 +1118,13 @@ public class Launcher {
     private Engine createEngine(SettableFuture<Void> completion) throws IOException {
         LOGGER.log(Level.INFO, "Setting up agent: {0}", name);
         Engine engine = new Engine(
-                new CuiListener(completion), urls, secret, name, directConnection, instanceIdentity, new HashSet<>(protocols));
+                new CuiListener(completion),
+                urls,
+                secret,
+                name,
+                directConnection,
+                instanceIdentity,
+                new HashSet<>(protocols));
         engine.setWebSocket(webSocket);
         if (webSocketHeaders != null) {
             engine.setWebSocketHeaders(webSocketHeaders);


### PR DESCRIPTION
Avoiding `System.exit` when used as an inbound agent (`main(String[])`). The `main` overloads called by `runWithStdinStdout` (or deprecated `runAsTcpServer`) used for outbound agents https://github.com/jenkinsci/remoting/blob/1d80543ebaf27c64e3641d6a67993a13ca9cd7f6/src/main/java/hudson/remoting/Launcher.java#L991-L1065 still `exit`.

Also ensuring that some resources are closed when exiting the (again, inbound) agent loop which were previously leaking threads.

In combination, these fixes make it possible to run multiple (inbound) agents (`Engine`s & `Channel`s) from one JVM, with independent configurations and even class loading after `remoting.jar` itself. Tested in the context of CloudBees CI in high availability mode, where it is unsafe to offer multiple executors from a single agent. Without the fixes, running multiple (inbound) agents from one JVM mostly works but there are some poor effects from disconnecting some agents while others are still trying to run.