### PR TITLE
Deprecate `EngineListenerAdapter`

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -278,7 +278,9 @@ public class Engine extends Thread {
             Set<String> protocols) {
         this.listener = listener;
         this.directConnection = directConnection;
-        this.events.add(listener);
+        if (listener != null) {
+            this.events.add(listener);
+        }
         this.candidateUrls =
                 hudsonUrls.stream().map(Engine::ensureTrailingSlash).collect(Collectors.toList());
         this.secretKey = secretKey;

--- a/src/main/java/hudson/remoting/EngineListener.java
+++ b/src/main/java/hudson/remoting/EngineListener.java
@@ -23,18 +23,8 @@
  */
 package hudson.remoting;
 
-import javax.swing.SwingUtilities;
-
 /**
  * Receives status notification from {@link Engine}.
- *
- * <p>
- * The callback will be invoked on a non-GUI thread, so if the implementation
- * wants to touch Swing, {@link SwingUtilities#invokeLater(Runnable)} would be needed.
- *
- * <p>
- * To implement this interface outside this module, extend from {@link EngineListenerAdapter}
- * instead to protect against method additions in the future.
  *
  * @author Kohsuke Kawaguchi
  */
@@ -42,26 +32,26 @@ public interface EngineListener {
     /**
      * Status message that indicates the progress of the operation.
      */
-    void status(String msg);
+    default void status(String msg) {}
 
     /**
      * Status message, with additional stack trace that indicates an error that was recovered.
      */
-    void status(String msg, Throwable t);
+    default void status(String msg, Throwable t) {}
 
     /**
      * Fatal error that's non recoverable.
      */
-    void error(Throwable t);
+    default void error(Throwable t) {}
 
     /**
      * Called when a connection is terminated.
      */
-    void onDisconnect();
+    default void onDisconnect() {}
 
     /**
      * Called when a re-connection is about to be attempted.
      * @since 2.0
      */
-    void onReconnect();
+    default void onReconnect() {}
 }

--- a/src/main/java/hudson/remoting/EngineListenerAdapter.java
+++ b/src/main/java/hudson/remoting/EngineListenerAdapter.java
@@ -1,24 +1,7 @@
 package hudson.remoting;
 
 /**
- * Adapter class for {@link EngineListener} to shield subtypes from future callback additions.
- *
- * @author Kohsuke Kawaguchi
- * @since 2.36
+ * @deprecated Implement {@link EngineListener} directly.
  */
-public abstract class EngineListenerAdapter implements EngineListener {
-    @Override
-    public void status(String msg) {}
-
-    @Override
-    public void status(String msg, Throwable t) {}
-
-    @Override
-    public void error(Throwable t) {}
-
-    @Override
-    public void onDisconnect() {}
-
-    @Override
-    public void onReconnect() {}
-}
+@Deprecated
+public abstract class EngineListenerAdapter implements EngineListener {}

--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -1182,12 +1182,6 @@ public class Launcher {
             LOGGER.log(Level.SEVERE, t.getMessage(), t);
             System.exit(-1);
         }
-
-        @Override
-        public void onDisconnect() {}
-
-        @Override
-        public void onReconnect() {}
     }
 
     private static String communicationProtocolName;

--- a/src/test/java/hudson/remoting/EngineTest.java
+++ b/src/test/java/hudson/remoting/EngineTest.java
@@ -68,8 +68,7 @@ public class EngineTest {
     @Test
     @Issue("JENKINS-44290")
     public void shouldInitializeCorrectlyWithDefaults() throws Exception {
-        EngineListener l = new TestEngineListener();
-        Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
+        Engine engine = new Engine(null, jenkinsUrls, SECRET_KEY, AGENT_NAME);
         engine.startEngine(true);
 
         // Cache will go to ~/.jenkins , we do not want to worry about this repo
@@ -82,8 +81,7 @@ public class EngineTest {
     public void shouldInitializeCorrectlyWithCustomCache() throws Exception {
         File jarCache = new File(tmpDir.getRoot(), "jarCache");
 
-        EngineListener l = new TestEngineListener();
-        Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
+        Engine engine = new Engine(null, jenkinsUrls, SECRET_KEY, AGENT_NAME);
         engine.setJarCache(new FileSystemJarCache(jarCache, true));
         engine.startEngine(true);
 
@@ -94,8 +92,7 @@ public class EngineTest {
     @Test
     public void shouldInitializeCorrectlyWithWorkDir() throws Exception {
         File workDir = new File(tmpDir.getRoot(), "workDir");
-        EngineListener l = new TestEngineListener();
-        Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
+        Engine engine = new Engine(null, jenkinsUrls, SECRET_KEY, AGENT_NAME);
         engine.setWorkDir(workDir.toPath());
         engine.startEngine(true);
 
@@ -112,8 +109,7 @@ public class EngineTest {
     public void shouldUseCustomCacheDirIfRequired() throws Exception {
         File workDir = new File(tmpDir.getRoot(), "workDir");
         File jarCache = new File(tmpDir.getRoot(), "jarCache");
-        EngineListener l = new TestEngineListener();
-        Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
+        Engine engine = new Engine(null, jenkinsUrls, SECRET_KEY, AGENT_NAME);
         engine.setWorkDir(workDir.toPath());
         engine.setJarCache(new FileSystemJarCache(jarCache, true));
         engine.startEngine(true);
@@ -126,14 +122,13 @@ public class EngineTest {
     @Test
     @Issue("JENKINS-60926")
     public void getAgentName() {
-        EngineListener l = new TestEngineListener();
-        Engine engine = new Engine(l, jenkinsUrls, SECRET_KEY, AGENT_NAME);
+        Engine engine = new Engine(null, jenkinsUrls, SECRET_KEY, AGENT_NAME);
         assertThat(engine.getAgentName(), is(AGENT_NAME));
     }
 
     @Test(timeout = 5_000)
     public void shouldNotReconnect() {
-        EngineListener l = new TestEngineListener() {
+        EngineListener l = new EngineListener() {
             @Override
             public void error(Throwable t) {
                 throw new NoReconnectException();
@@ -148,8 +143,13 @@ public class EngineTest {
 
     @Test(timeout = 30_000)
     public void shouldReconnectOnJnlpAgentEndpointResolutionExceptions() {
-        EngineListener l = new TestEngineListener() {
+        EngineListener l = new EngineListener() {
             private int count;
+
+            @Override
+            public void status(String msg) {
+                status(msg, null);
+            }
 
             @Override
             public void status(String msg, Throwable t) {
@@ -174,32 +174,4 @@ public class EngineTest {
     }
 
     private static class ExpectedException extends RuntimeException {}
-
-    private static class TestEngineListener implements EngineListener {
-
-        @Override
-        public void status(String msg) {
-            status(msg, null);
-        }
-
-        @Override
-        public void status(String msg, Throwable t) {
-            // Do nothing
-        }
-
-        @Override
-        public void error(Throwable t) {
-            // Do nothing
-        }
-
-        @Override
-        public void onDisconnect() {
-            // Do nothing
-        }
-
-        @Override
-        public void onReconnect() {
-            // Do nothing
-        }
-    }
 }


### PR DESCRIPTION
No longer necessary with Java 8 `default` methods in `interface`s. Used only by `JnlpSlaveRestarterInstaller`.