### PR TITLE
Set `Thread.name` on `Engine`

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -264,6 +264,7 @@ public class Engine extends Thread {
             String directConnection,
             String instanceIdentity,
             Set<String> protocols) {
+        setName("Engine for " + agentName);
         executor = makeExecutor(this, agentName);
         this.listener = listener;
         this.directConnection = directConnection;


### PR DESCRIPTION
Minor diagnosability enhancement tangentially related to #805. Otherwise the thread actually doing the work is just called something like `Thread-8`.