### PR TITLE
`Engine.getWebSocketHeaders`

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -415,7 +415,7 @@ public class Engine extends Thread {
         this.webSocket = webSocket;
     }
 
-    @CheckForNull
+    @NonNull
     public Map<String, String> getWebSocketHeaders() {
         return webSocketHeaders != null ? Collections.unmodifiableMap(new LinkedHashMap<>(webSocketHeaders)) : Map.of();
     }
@@ -635,11 +635,6 @@ public class Engine extends Thread {
             addedHeaders.put(JnlpConnectionState.CLIENT_NAME_KEY, List.of(agentName));
             addedHeaders.put(JnlpConnectionState.SECRET_KEY, List.of(secretKey));
             addedHeaders.put(Capability.KEY, List.of(localCap));
-            if (webSocketHeaders != null) {
-                for (Map.Entry<String, String> entry : webSocketHeaders.entrySet()) {
-                    addedHeaders.put(entry.getKey(), List.of(entry.getValue()));
-                }
-            }
             while (true) {
                 AtomicReference<Channel> ch = new AtomicReference<>();
                 class HeaderHandler extends ClientEndpointConfig.Configurator {
@@ -648,6 +643,11 @@ public class Engine extends Thread {
                     @Override
                     public void beforeRequest(Map<String, List<String>> headers) {
                         headers.putAll(addedHeaders);
+                        if (webSocketHeaders != null) {
+                            for (var entry : webSocketHeaders.entrySet()) {
+                                headers.put(entry.getKey(), List.of(entry.getValue()));
+                            }
+                        }
                         LOGGER.fine(() -> "Sending: " + headers);
                     }
 


### PR DESCRIPTION
While working on a CloudBees CI plugin I found it useful to be able to call `setWebSocketHeaders` on an existing agent to adjust the behavior of subsequent reconnection attempts, but it was tricky to find the initial headers (for example by looking for `$REMOTING_OPTS`, honored by the standard inbound agent image, and breaking on spaces).