### PR TITLE
No need to retry inside `connectTcp`

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -1159,7 +1159,7 @@ public class Engine extends Thread {
     }
 
     /**
-     * Connects to TCP agent host:port, with a few retries.
+     * Connects to TCP agent host:port.
      * @param endpoint Connection endpoint
      * @throws IOException Connection failure or invalid parameter specification
      */

--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -1164,25 +1164,11 @@ public class Engine extends Thread {
      * @throws IOException Connection failure or invalid parameter specification
      */
     private Socket connectTcp(@NonNull JnlpAgentEndpoint endpoint) throws IOException, InterruptedException {
-
         String msg = "Connecting to " + endpoint.getHost() + ':' + endpoint.getPort();
         events.status(msg);
-        int retry = 1;
-        while (true) {
-            try {
-                final Socket s =
-                        endpoint.open(SOCKET_TIMEOUT); // default is 30 mins. See PingThread for the ping interval
-                s.setKeepAlive(keepAlive);
-                return s;
-            } catch (IOException e) {
-                if (retry++ > 10) {
-                    throw e;
-                }
-                // TODO refactor various sleep statements into a common method
-                TimeUnit.SECONDS.sleep(10);
-                events.status(msg + " (retrying:" + retry + ")", e);
-            }
-        }
+        Socket s = endpoint.open(SOCKET_TIMEOUT); // default is 30 mins. See PingThread for the ping interval
+        s.setKeepAlive(keepAlive);
+        return s;
     }
 
     /**


### PR DESCRIPTION
Compare #675. This is called from `innerRun` which already has its own retry logic.

A TCP agent is used in a Pipeline build as part of an integration test in CloudBees CI which restarts the controller and picks a different host:port after the restart. The shutdown of the original controller naturally causes the agent to disconnect. When it tries to connect again, depending on timing conditions, `JnlpAgentEndpointResolver.resolve` might initially have obtained the old host:port, and then `connectTcp` will try repeatedly to contact it, failing each time. Eventually it will give up and fall back into the main retry loop in `innerRun`, but by that time the resumed build might have given up on the agent reconnecting after a 5m timeout and aborted. At least I do see the 5m timeout, though I do not see any messages from `innerRun` after `connectTcp` gives up, so I am not exactly sure what the agent is doing at that point.

https://github.com/jenkinsci/remoting/pull/771#issuecomment-2435096882 remains pending.