### PR TITLE
Increase Jenkinsfile timeout from 20 minutes to 30 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
  * easy Linux/Windows testing and produces incrementals. The only feature that relates to plugins is
  * allowing one to test against multiple Jenkins versions.
  */
-buildPlugin(timeout: 20, useContainerAgent: true, configurations: [
+buildPlugin(timeout: 30, useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 21],
   [platform: 'windows', jdk: 17],
 ])


### PR DESCRIPTION
## Increase Jenkinsfile timeout from 20 minutes to 30 minutes

2 of the the last 5 builds on the master branch have timed out after 20 minutes.  The 3 successful builds completed their Windows build stage in 18:58, 19:00, and 19:51 .  Those values are too close to the 20 minute timeout.

3 recent pull request builds all failed due to timeout.  Confirm the failures for the following pull requests:

* https://github.com/jenkinsci/remoting/pull/830
* https://github.com/jenkinsci/remoting/pull/831
* https://github.com/jenkinsci/remoting/pull/832

Let's increase the allowed time for the build from 20 minutes to 30 minutes so that we don't waste effort running builds multiple times.

### Testing done

None.  Rely on ci.jenkins.io to confirm the job runs to completion with a 30 minute timeout

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
