### PR TITLE
Treat `connectTcp` as part of retryable I/O

### DIFF
--- a/src/main/java/hudson/remoting/Engine.java
+++ b/src/main/java/hudson/remoting/Engine.java
@@ -1081,8 +1081,14 @@ public class Engine extends Thread {
                         }
 
                         // On failure form a new connection.
-                        jnlpSocket.close();
-                        jnlpSocket = null;
+                        if (jnlpSocket != null) {
+                            try {
+                                jnlpSocket.close();
+                            } catch (IOException e) {
+                                events.status("Failed to close socket", e);
+                            }
+                            jnlpSocket = null;
+                        }
                     }
 
                     // If no protocol worked.


### PR DESCRIPTION
Following up #827, since I am still seeing the test failures in CloudBees CI quite often:

```
java.lang.IllegalStateException: java.io.IOException: Failed to connect to …
	at hudson.remoting.Launcher.runAsInboundAgent(Launcher.java:734)
	at hudson.remoting.Launcher.run(Launcher.java:498)
	at hudson.remoting.Launcher.main(Launcher.java:469)
Caused by: java.io.IOException: Failed to connect to …
	at org.jenkinsci.remoting.engine.JnlpAgentEndpoint.open(JnlpAgentEndpoint.java:280)
	at hudson.remoting.Engine.connectTcp(Engine.java:1169)
	at hudson.remoting.Engine.innerRun(Engine.java:1054)
	at hudson.remoting.Engine.runTcp(Engine.java:621)
	at hudson.remoting.Engine.run(Engine.java:562)
Caused by: java.net.ConnectException: Connection refused
	at java.base/sun.nio.ch.Net.connect0(Native Method)
	at java.base/sun.nio.ch.Net.connect(Net.java:589)
 	at java.base/sun.nio.ch.Net.connect(Net.java:596)
	at java.base/sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:880)
	at java.base/java.nio.channels.SocketChannel.open(SocketChannel.java:285)
	at org.jenkinsci.remoting.engine.JnlpAgentEndpoint.open(JnlpAgentEndpoint.java:231)
	... 4 more
```

With this fix, the test passes 25× in a row. When the agent tries to reconnect while the controller is restarting, if it hits a `ConnectException` here, the `innerRun` loop retries normally.