### PR TITLE
[JENKINS-72881] "java -jar agent.jar -url" doesn't use current directory by default anymore

### DIFF
--- a/src/main/java/hudson/remoting/Launcher.java
+++ b/src/main/java/hudson/remoting/Launcher.java
@@ -493,6 +493,11 @@ public class Launcher {
                         "WARNING: The \"-jnlpUrl\" argument is deprecated. Use \"-url\" and \"-name\" instead, potentially also passing in \"-webSocket\", \"-tunnel\", and/or work directory options as needed.");
                 bootstrapInboundAgent(); // calls initialize() internally
             } else {
+                // JENKINS-72881: If workDir is not explicitly set, use current directory by default
+                // This matches the behavior of -jnlpUrl which receives workDir from server (typically ".")
+                if (workDir == null) {
+                    workDir = new File(System.getProperty("user.dir"));
+                }
                 initialize();
             }
             runAsInboundAgent();


### PR DESCRIPTION

<!-- Please describe your pull request here. -->
Fixes #1499 

JENKINS-72881

"java -jar agent.jar -url" doesn't use current directory by default anymore

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
