### PR TITLE
Fix FifoBuffer.writable() returning a value beyond the limit when closed

### DIFF
--- a/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
+++ b/src/main/java/org/jenkinsci/remoting/nio/FifoBuffer.java
@@ -238,15 +238,20 @@ public class FifoBuffer implements Closeable {
         }
     }
 
-    // TODO: Value beyond the limit is actually a bug (JENKINS-37514)
     /**
      * Number of bytes writable.
      * @return Number of bytes we can write to the buffer.
-     *         If the buffer is closed, may return the value beyond the limit (JENKINS-37514)
+     *         0 if the buffer is closed and there's no more data to read, since no further writes
+     *         are accepted at that point. {@link #readable()}'s {@code -1} EOF sentinel must not be
+     *         subtracted from {@code limit} directly, or this returns a bogus value beyond the limit.
      */
     public int writable() {
         synchronized (lock) {
-            return Math.max(0, limit - readable());
+            int r = readable();
+            if (r < 0) {
+                return 0;
+            }
+            return Math.max(0, limit - r);
         }
     }
 

--- a/src/test/java/org/jenkinsci/remoting/nio/FifoBufferTest.java
+++ b/src/test/java/org/jenkinsci/remoting/nio/FifoBufferTest.java
@@ -56,6 +56,30 @@ class FifoBufferTest {
     }
 
     @Test
+    void writableIsZeroAfterCloseWithNoDataLeft() throws Exception {
+        buf.write(b(TEN));
+        buf.read(new byte[10]);
+        buf.close();
+
+        // readable() returns -1 here (closed, nothing left), and writable() must not derive from that
+        // sentinel via `limit - readable()`, which would wrongly return a value beyond the limit
+        // (JENKINS-37514).
+        assertEquals(-1, buf.readable());
+        assertEquals(0, buf.writable());
+    }
+
+    @Test
+    void writableReflectsRemainingRoomWhenClosedWithDataStillBuffered() throws Exception {
+        buf.write(b(TEN));
+        buf.close();
+
+        // there is still data to read, so this is not the -1 sentinel case: writable() should keep
+        // reporting the actual remaining room, unchanged from the behavior before this fix.
+        assertEquals(10, buf.readable());
+        assertEquals(256 - 10, buf.writable());
+    }
+
+    @Test
     void nonBlockingWrite() throws Exception {
         buf.setLimit(185);
 


### PR DESCRIPTION
Fixes #1176

`writable()` computed `Math.max(0, limit - readable())`, but `readable()` uses `-1` as a sentinel meaning closed and empty, not an actual byte count. Subtracting that sentinel produced `limit + 1` instead of `0` exactly when the buffer was closed with nothing left to read. The code already carried a `// TODO: Value beyond the limit is actually a bug (JENKINS-37514)` comment acknowledging this.

This is more than a cosmetic accounting bug. `releaseRing()` nulls the write pointer `w` under the same `readable() < 0` condition. A `write()` call racing right as the buffer closes could see a positive `writable()` value, skip the `closeRequested` check in its retry loop, and call `w.write(...)` on a pointer that is already null.

The fix only changes the `readable() < 0` case. When the buffer is closed but still has buffered data left to read, `readable()` returns a real positive count and `writable()` keeps its prior behavior unchanged. I checked both call sites of `writable()` in `NioChannelHub.java` before deciding this, and didn't want to change behavior there beyond the specific bug being reported.

### Testing done

Added two tests to `FifoBufferTest`: one for the reported case (closed with nothing left to read, `writable()` must be `0`), one confirming the closed-with-buffered-data case is unchanged (`writable()` still reflects real remaining room).

Verified the fix actually matters by reverting only the source change and rerunning: the new test fails with the exact reported symptom, `writable()` returns `257` instead of `0` for a buffer with `limit=256`, matching `limit + 1`.

Ran the full existing test suite on JDK 21 (matching this repo's linux CI leg): 2108 tests run, 0 failures, 0 errors, 28 skipped (pre-existing, unrelated). Also verified `./mvnw spotless:check` passes clean.

### Submitter checklist
- [x] Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed