### PR TITLE
Flip temp buffer in HoldFilterLayer flush loops and re-enable ack tests

### DIFF
--- a/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackImplTest.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/ProtocolStackImplTest.java
@@ -57,7 +57,6 @@ import org.jenkinsci.remoting.protocol.impl.ConnectionRefusalException;
 import org.jenkinsci.remoting.protocol.impl.HoldFilterLayer;
 import org.jenkinsci.remoting.protocol.impl.NIONetworkLayer;
 import org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -731,8 +730,6 @@ class ProtocolStackImplTest {
         assertThat(se.getCause(), instanceOf(ConnectionRefusalException.class));
     }
 
-    @Disabled(
-            "TODO flake: ConnectionRefusal Incorrect acknowledgement received, expected 0x000341436b got 0x0000000000")
     @RepeatedTest(16)
     void pipeChannelFullProtocolNIO_invalidAck() throws Exception {
         Pipe clientToServer = Pipe.open();
@@ -780,8 +777,6 @@ class ProtocolStackImplTest {
                 anyOf(instanceOf(ConnectionRefusalException.class), instanceOf(ClosedChannelException.class)));
     }
 
-    @Disabled(
-            "TODO flake: ConnectionRefusalException: Incorrect acknowledgement received, expected 0x000341436b got 0x0000000000")
     @RepeatedTest(16)
     void socketChannelFullProtocolNIO_invalidAck() throws Exception {
         ServerSocketChannel serverServerSocketChannel = ServerSocketChannel.open();

--- a/src/test/java/org/jenkinsci/remoting/protocol/impl/HoldFilterLayer.java
+++ b/src/test/java/org/jenkinsci/remoting/protocol/impl/HoldFilterLayer.java
@@ -25,6 +25,7 @@ package org.jenkinsci.remoting.protocol.impl;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import org.jenkinsci.remoting.protocol.FilterLayer;
 import org.jenkinsci.remoting.util.ByteBufferQueue;
@@ -62,8 +63,9 @@ public class HoldFilterLayer extends FilterLayer {
                 recvQueue.put(data);
                 ByteBuffer tempBuffer = recvQueue.newByteBuffer();
                 while (recvQueue.hasRemaining()) {
-                    tempBuffer.clear();
+                    ((Buffer) tempBuffer).clear();
                     recvQueue.get(tempBuffer);
+                    ((Buffer) tempBuffer).flip();
                     next().onRecv(tempBuffer);
                 }
             } else if (data.hasRemaining()) {
@@ -87,8 +89,9 @@ public class HoldFilterLayer extends FilterLayer {
                 sendQueue.put(data);
                 ByteBuffer tempBuffer = sendQueue.newByteBuffer();
                 while (sendQueue.hasRemaining()) {
-                    tempBuffer.clear();
+                    ((Buffer) tempBuffer).clear();
                     sendQueue.get(tempBuffer);
+                    ((Buffer) tempBuffer).flip();
                     next().doSend(tempBuffer);
                 }
             } else if (data.hasRemaining()) {


### PR DESCRIPTION
### Problem

`HoldFilterLayer` (test helper used by `ProtocolStackImplTest`) drains its queues in `onRecv()` / `doSend()` like this:

```java
while (recvQueue.hasRemaining()) {
    tempBuffer.clear();
    recvQueue.get(tempBuffer);
    next().onRecv(tempBuffer);   // tempBuffer still in write mode
}
```

`ByteBufferQueue.get(ByteBuffer)` fills the buffer and advances its position; it does not flip it. Every other caller of that method flips before handing the buffer on (`FilterLayer.flushRecv` / `flushSend`, `NetworkLayer.flushRecvQueue` / `flushSendQueue`), because the receiving layer reads from `position` to `limit`.

Left unflipped, the next layer sees `position` pointing past the real data and `limit` at capacity, so it reads uninitialised zero bytes. In `ProtocolStackImplTest` this made `AckFilterLayer` read five zero bytes for the peer acknowledgement, which is exactly why the two disabled invalid-ack tests had recorded `expected 0x000341436b got 0x0000000000` rather than the real mismatching bytes.

### Fix

Flip the temp buffer after filling it, in both loops. With correct buffers:

- the diagnostic now reports the real bytes, e.g. `expected 0x000341434b got 0x000341436b`
- `pipeChannelFullProtocolNIO_invalidAck` and `socketChannelFullProtocolNIO_invalidAck` pass reliably, so the `@Disabled` annotations are removed

### Testing done

- `pipeChannelFullProtocolNIO_invalidAck` and `socketChannelFullProtocolNIO_invalidAck` (`@RepeatedTest(16)` each): green across many consecutive runs; previously they carried `@Disabled("TODO flake ...")`.
- `ProtocolStackImplTest` whole class: 113 tests green, repeated.
- Full test suite: `mvn test` green, 2139 run, 0 failures, 0 errors (32 more than before: the two re-enabled repeated tests).
- `mvn spotless:check` clean.

### Submitter checklist

- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [x] For dependency updates: there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points: there is a link to at least one consumer.