### PR TITLE
[JENKINS-45023] Refuse all Request types once a channel close is requested

### DIFF
--- a/src/main/java/hudson/remoting/RemoteInvocationHandler.java
+++ b/src/main/java/hudson/remoting/RemoteInvocationHandler.java
@@ -1066,22 +1066,6 @@ final class RemoteInvocationHandler implements InvocationHandler, Serializable {
         UserRPCRequest(int oid, Method m, Object[] arguments, ClassLoader cl, boolean recordCreatedAt) {
             super(oid, m, arguments, cl, recordCreatedAt);
         }
-
-        // Same implementation as UserRequest
-        @Override
-        public void checkIfCanBeExecutedOnChannel(@NonNull Channel channel) throws IOException {
-            // Default check for all requests
-            super.checkIfCanBeExecutedOnChannel(channel);
-
-            // We also do not want to run UserRequests when the channel is being closed
-            if (channel.isClosingOrClosed()) {
-                throw new ChannelClosedException(
-                        channel,
-                        "The request cannot be executed on channel " + channel + ". "
-                                + "The channel is closing down or has closed down",
-                        channel.getCloseRequestCause());
-            }
-        }
     }
 
     private static final Object[] EMPTY_ARRAY = new Object[0];

--- a/src/main/java/hudson/remoting/Request.java
+++ b/src/main/java/hudson/remoting/Request.java
@@ -130,6 +130,17 @@ public abstract class Request<RSP extends Serializable, EXC extends Throwable> e
             // Sender is closed, we won't be able to send anything
             throw new ChannelClosedException(channel, senderCloseCause);
         }
+
+        // JENKINS-45023: also refuse once a close has been requested but has not completed yet.
+        // Otherwise the request would proceed to acquire the Channel lock, which is held for the
+        // duration of close()/terminate(), and block there instead of failing fast.
+        if (channel.isClosingOrClosed()) {
+            throw new ChannelClosedException(
+                    channel,
+                    "The request cannot be executed on channel " + channel + ". "
+                            + "The channel is closing down or has closed down",
+                    channel.getCloseRequestCause());
+        }
     }
 
     /**

--- a/src/main/java/hudson/remoting/UserRequest.java
+++ b/src/main/java/hudson/remoting/UserRequest.java
@@ -111,21 +111,6 @@ final class UserRequest<RSP, EXC extends Throwable> extends Request<UserRequest.
         this.classLoaderProxy = RemoteClassLoader.export(cl, local);
     }
 
-    @Override
-    public void checkIfCanBeExecutedOnChannel(Channel channel) throws IOException {
-        // Default check for all requests
-        super.checkIfCanBeExecutedOnChannel(channel);
-
-        // We also do not want to run UserRequests when the channel is being closed
-        if (channel.isClosingOrClosed()) {
-            throw new ChannelClosedException(
-                    channel,
-                    "The request cannot be executed on channel " + channel + ". "
-                            + "The channel is closing down or has closed down",
-                    channel.getCloseRequestCause());
-        }
-    }
-
     /**
      * Retrieves classloader for the callable.
      * For {@link DelegatingCallable} the method will try to retrieve a classloader specified there.

--- a/src/test/java/hudson/remoting/ChannelTest.java
+++ b/src/test/java/hudson/remoting/ChannelTest.java
@@ -24,6 +24,7 @@ import java.net.URLClassLoader;
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -31,7 +32,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jenkinsci.remoting.RoleChecker;
 import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -288,7 +288,6 @@ class ChannelTest {
      * Checks if {@link UserRequest}s can be executed during the pending close operation.
      * @throws Exception Test Error
      */
-    @Disabled("TODO flake timed out after 15 seconds")
     @Issue("JENKINS-45023")
     @ParameterizedTest
     @MethodSource(ChannelRunners.PROVIDER_METHOD)
@@ -315,7 +314,6 @@ class ChannelTest {
      * Checks if {@link UserRequest}s can be executed during the pending close operation.
      * @throws Exception Test Error
      */
-    @Disabled("TODO flake timed out after 15 seconds")
     @Issue("JENKINS-45294")
     @ParameterizedTest
     @MethodSource(ChannelRunners.PROVIDER_METHOD)
@@ -325,17 +323,24 @@ class ChannelTest {
             src.add("Hello");
             src.add("World");
 
-            // TODO: System request will just hang. Once JENKINS-44785 is implemented, all system requests
-            // in Remoting codebase must have a timeout.
-            final Collection<String> remoteList =
+            // A user-space proxy (RPC goes through Channel.call) and an internal proxy (RPC goes
+            // straight through Request.call). Both must refuse the call once close has been requested.
+            final Collection<String> userProxy =
                     channel.call(new RMIObjectExportedCallable<>(src, Collection.class, true));
+            final Collection<String> internalProxy =
+                    channel.call(new RMIObjectExportedCallable<>(src, Collection.class, false));
 
             try (ChannelCloseLock ignored = new ChannelCloseLock(channel)) {
-                // Call Async
                 assertFailsWithChannelClosedException(channel, new TestRunnable() {
                     @Override
                     public void run(Channel channel) throws AssertionError {
-                        remoteList.size();
+                        userProxy.size();
+                    }
+                });
+                assertFailsWithChannelClosedException(channel, new TestRunnable() {
+                    @Override
+                    public void run(Channel channel) throws AssertionError {
+                        internalProxy.size();
                     }
                 });
             }
@@ -390,37 +395,42 @@ class ChannelTest {
 
         final ExecutorService svc;
         final Channel channel;
+        final CountDownLatch releaseMonitor = new CountDownLatch(1);
 
         public ChannelCloseLock(final @NonNull Channel channel) throws AssertionError, InterruptedException {
             this.svc = Executors.newFixedThreadPool(2);
             this.channel = channel;
 
-            // Lock channel
-            java.util.concurrent.Future<Void> lockChannel = svc.submit(() -> {
+            // Hold the Channel monitor so that close() cannot complete.
+            CountDownLatch monitorHeld = new CountDownLatch(1);
+            svc.submit(() -> {
                 synchronized (channel) {
-                    System.out.println("All your channel belongs to us");
-                    Thread.sleep(Long.MAX_VALUE);
-                    return null;
+                    monitorHeld.countDown();
+                    releaseMonitor.await();
                 }
+                return null;
             });
+            assertTrue(
+                    monitorHeld.await(15, TimeUnit.SECONDS), "background task should have taken the Channel monitor");
 
-            // Try to close the channel in another task
-            java.util.concurrent.Future<Void> closeChannel = svc.submit(() -> {
-                System.out.println("Trying to close the channel");
+            // Start closing the channel on another thread. close() sets closeRequested before it tries
+            // to acquire the monitor, so it will get stuck holding the channel in the pending-close state.
+            svc.submit(() -> {
                 channel.close();
-                System.out.println("Channel is closed");
                 return null;
             });
 
-            // Check the state
-            Thread.sleep(1000);
-            System.out.println("Running the tests");
+            long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+            while (!channel.isClosingOrClosed() && System.nanoTime() < deadlineNanos) {
+                Thread.sleep(10);
+            }
             assertTrue(channel.isClosingOrClosed(), "Channel should be closing");
-            assertFalse(channel.isOutClosed(), "Channel should not be closed due to the lock");
+            assertFalse(channel.isOutClosed(), "Channel should not be closed while the monitor is held");
         }
 
         @Override
         public void close() {
+            releaseMonitor.countDown();
             svc.shutdownNow();
         }
     }


### PR DESCRIPTION
This addresses the two long-disabled pending-close tests in `ChannelTest` (JENKINS-45023 / JENKINS-45294).

### Problem

`Channel.close()` sets `closeRequested` (and `closeRequestCause`) up front, then acquires the `Channel` monitor for the rest of the teardown. During that window the channel is "closing" but `outClosed` is still `null`.

The guard that refuses new requests during this window, `checkIfCanBeExecutedOnChannel()`, was only overridden on `UserRequest` and `RemoteInvocationHandler.UserRPCRequest` (identical copy-pasted bodies). The base `Request.checkIfCanBeExecutedOnChannel()` only checks `getSenderCloseCause()` (i.e. `outClosed`).

So a base `RPCRequest` (RPC on an internal proxy), a `ProxyInputStream.Chunk`, or any other non-user `Request` sent in that window passes the check and then blocks on the `Channel` monitor held by `close()` / `terminate()`, instead of failing fast with `ChannelClosedException`.

### Change

- Move the `isClosingOrClosed()` check into the base `Request.checkIfCanBeExecutedOnChannel()`; remove the two now-redundant overrides.
- Rework the `ChannelCloseLock` test helper to reach the pending-close state deterministically: a latch fires once the background task holds the `Channel` monitor, then it polls for `closeRequested`, instead of `Thread.sleep(1000)` plus thread-pool scheduling. That sleep-based setup is why both tests were `@Disabled("TODO flake timed out after 15 seconds")`.
- Re-enable `testShouldNotAcceptUserRequestsWhenIsBeingClosed` and `testShouldNotAcceptUserRPCRequestsWhenIsBeingClosed`. The latter now also exercises an internal (non user-space) proxy, which is the path this change fixes.

`UserRPCRequest` is kept as a (now trivial) subclass to avoid a wire-compatibility change.

### Testing done

- Both re-enabled tests: green across many consecutive local runs, on all channel runners.
- Revert check: with the `Request.java` change reverted, `testShouldNotAcceptUserRPCRequestsWhenIsBeingClosed` times out after 15s on every channel runner (6/6), which is the original disabled symptom.
- Full suite: `mvn test` green, 2119 run, 0 failures, 0 errors (12 more than before: the re-enabled parameterized tests).
- `mvn spotless:check` clean.

### Submitter checklist

- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [x] For dependency updates: there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points: there is a link to at least one consumer.