### PR TITLE
Make Channel.closeRequested and closeRequestCause volatile

### DIFF
--- a/src/main/java/hudson/remoting/Channel.java
+++ b/src/main/java/hudson/remoting/Channel.java
@@ -348,17 +348,24 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
     /**
      * Indicates that close of the channel has been requested.
      * When the value is {@code true}, it does not make sense to execute new user-space commands like {@link UserRequest}.
+     *
+     * <p>Set by {@link #close(Throwable)} and {@link #terminate(IOException)} outside of the {@code this} monitor, and
+     * read from arbitrary caller threads via {@link #isClosingOrClosed()}, so it is {@code volatile} like
+     * {@link #inClosed}/{@link #outClosed}. Both methods assign {@link #closeRequestCause} before this flag, so a
+     * thread that observes the flag also observes the cause.
      */
-    private boolean closeRequested = false;
+    private volatile boolean closeRequested = false;
 
     /**
      * Stores cause of the close Request.
      *
      * In the case of race condition between multiple close operations,
      * this field stores just one of them.
+     *
+     * <p>{@code volatile} and assigned before {@link #closeRequested}; see that field.
      */
     @CheckForNull
-    private Throwable closeRequestCause = null;
+    private volatile Throwable closeRequestCause = null;
 
     /**
      * Communication mode used in conjunction with {@link ClassicCommandTransport}.
@@ -1166,11 +1173,12 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         if (e == null) {
             throw new IllegalArgumentException("Cause is null. Channel cannot be closed properly in such case");
         }
-        closeRequested = true;
         if (closeRequestCause == null) {
             // Cache the cause value just in case it takes long to acquire the lock
             closeRequestCause = e;
         }
+        // Set last: this volatile write publishes closeRequestCause to threads that observe the flag.
+        closeRequested = true;
 
         try {
             synchronized (this) {
@@ -1591,13 +1599,14 @@ public class Channel implements VirtualChannel, IChannel, Closeable {
         if (outClosed != null) {
             return; // already closed
         }
-        closeRequested = true;
         if (closeRequestCause == null) {
             // Cache the cause value just in case it takes long to acquire the lock
             // TODO: This IOException wrapper is copy-pasted from the original logic, but do we actually need it when
             // diagnosis is non-null?
             closeRequestCause = new IOException(diagnosis);
         }
+        // Set last: this volatile write publishes closeRequestCause to threads that observe the flag.
+        closeRequested = true;
 
         synchronized (this) {
             if (outClosed != null) {


### PR DESCRIPTION
Follow-up to #1544 

`Channel.close(Throwable)` and `Channel.terminate(IOException)` assign `closeRequested` and `closeRequestCause` before entering the `synchronized (this)` block. Those fields are then read from arbitrary caller threads without the monitor, via `isClosingOrClosed()` and `getCloseRequestCause()` (for example from `Request.checkIfCanBeExecutedOnChannel()`, and from `Channel.call()` / `callAsync()`).

With plain fields there is no happens-before edge between the write and those reads, so a reader can keep observing the pre-close values. `inClosed` and `outClosed`, read the same way in the same methods, are already `volatile`; this makes `closeRequested` and `closeRequestCause` match.

### Testing done

- `mvn test`: green, 2149 run, 0 failures, 0 errors.
- `mvn spotless:check`: clean.

### Submitter checklist

- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [x] For dependency updates: there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points: there is a link to at least one consumer.
